### PR TITLE
CIのテスト部分で差分フィルタリングを導入

### DIFF
--- a/.github/actions/diff/action.yaml
+++ b/.github/actions/diff/action.yaml
@@ -7,7 +7,7 @@ inputs:
     description: チェックするディレクトリ
     required: true
   exclude_pattern:
-    description: 除外するパターン（グロブパターン）
+    description: 除外するパターン(スペース区切り)
     required: false
     default: ''
 outputs:
@@ -21,22 +21,8 @@ runs:
     - id: diff
       env:
         TARGET_BRANCH: ${{ github.base_ref || 'main' }}
-        EXCLUDE_PATTERN: ${{ inputs.exclude_pattern }}
       run: |
         git fetch origin ${TARGET_BRANCH}
-
-        # 基本的な差分取得
-        all_files=$(git diff origin/${TARGET_BRANCH} HEAD --name-only --relative=${{ inputs.subdir }})
-
-        # 除外パターンが指定されていない場合
-        if [ -z "${EXCLUDE_PATTERN}" ]; then
-          count=$(echo "$all_files" | wc -l)
-        else
-          # 除外パターンを使ってフィルタ
-          filtered_files=$(echo "$all_files" | grep -v -E "${EXCLUDE_PATTERN}" || true)
-          count=$(echo "$filtered_files" | grep -v "^$" | wc -l)
-        fi
-
-        echo "Matched files count: $count"
+        count=$(git diff origin/${TARGET_BRANCH} HEAD --name-only -- ${{ inputs.subdir }} ":(exclude)${{ inputs.exclude_pattern }}" | wc -l)
         echo "diff-count=$count" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,22 +90,19 @@ jobs:
         with:
           node-version-file: ${{ env.NODE_VERSION_FILE }}
 
-      # フロントエンド関連ファイルの差分チェック
       - name: フロントエンドの差分チェック
         id: check-frontend
         uses: ./.github/actions/diff
         with:
           subdir: src/app
 
-      # バックエンド関連ファイルの差分チェック（除外ディレクトリあり）
       - name: バックエンドの差分チェック
         id: check-backend
         uses: ./.github/actions/diff
         with:
           subdir: src
-          exclude_pattern: '^src/app/|^src/middleware/|^src/logger/'
+          exclude_pattern: 'src/app/ src/middleware/ src/logger/'
 
-      # 差分の要約を出力
       - name: 差分結果の表示
         run: |
           echo "フロントエンド差分: ${{ steps.check-frontend.outputs.diff-count }} ファイル"


### PR DESCRIPTION
<!-- Product Backlogから参照できるようにする -->

## 取り組んだこと

- CIのテスト部分で差分がある時だけテストを実行するように修正

## 参考情報

- git diffを活用
  - 除外時はコマンドのオプション活用（https://qiita.com/talesleaves/items/1a2c781ff16ac2762371）
