### PR TITLE
test: fix e2e tests to wait for MediaFilter buttons visibility

### DIFF
--- a/src/test/e2e/page/trends._index.mobile.test.ts
+++ b/src/test/e2e/page/trends._index.mobile.test.ts
@@ -184,6 +184,11 @@ test.describe('記事一覧ページ(モバイル)', () => {
       const qiitaButton = page.getByRole('button', { name: 'Qiita' })
       const zennButton = page.getByRole('button', { name: 'Zenn' })
 
+      // ボタンが表示されるまで待機
+      await allButton.waitFor({ state: 'visible', timeout: TIMEOUT })
+      await qiitaButton.waitFor({ state: 'visible', timeout: TIMEOUT })
+      await zennButton.waitFor({ state: 'visible', timeout: TIMEOUT })
+
       await expect(allButton).toBeVisible()
       await expect(qiitaButton).toBeVisible()
       await expect(zennButton).toBeVisible()
@@ -191,6 +196,7 @@ test.describe('記事一覧ページ(モバイル)', () => {
 
     test('Qiitaボタンをクリックすると、Qiita記事のみが表示される', async ({ page }) => {
       const qiitaButton = page.getByRole('button', { name: 'Qiita' })
+      await qiitaButton.waitFor({ state: 'visible', timeout: TIMEOUT })
       await qiitaButton.click()
 
       // URLパラメータが変更されるのを待機
@@ -207,6 +213,7 @@ test.describe('記事一覧ページ(モバイル)', () => {
 
     test('Zennボタンをクリックすると、Zenn記事のみが表示される', async ({ page }) => {
       const zennButton = page.getByRole('button', { name: 'Zenn' })
+      await zennButton.waitFor({ state: 'visible', timeout: TIMEOUT })
       await zennButton.click()
 
       // URLパラメータが変更されるのを待機

--- a/src/test/e2e/page/trends._index.test.ts
+++ b/src/test/e2e/page/trends._index.test.ts
@@ -134,6 +134,11 @@ test.describe('記事一覧ページ', () => {
       const qiitaButton = page.getByRole('button', { name: 'Qiita' })
       const zennButton = page.getByRole('button', { name: 'Zenn' })
 
+      // ボタンが表示されるまで待機
+      await allButton.waitFor({ state: 'visible', timeout: TIMEOUT })
+      await qiitaButton.waitFor({ state: 'visible', timeout: TIMEOUT })
+      await zennButton.waitFor({ state: 'visible', timeout: TIMEOUT })
+
       await expect(allButton).toBeVisible()
       await expect(qiitaButton).toBeVisible()
       await expect(zennButton).toBeVisible()
@@ -147,6 +152,7 @@ test.describe('記事一覧ページ', () => {
 
     test('Qiitaボタンをクリックすると、Qiita記事のみが表示される', async ({ page }) => {
       const qiitaButton = page.getByRole('button', { name: 'Qiita' })
+      await qiitaButton.waitFor({ state: 'visible', timeout: TIMEOUT })
       await qiitaButton.click()
 
       // URLパラメータが変更されるのを待機
@@ -163,6 +169,7 @@ test.describe('記事一覧ページ', () => {
 
     test('Zennボタンをクリックすると、Zenn記事のみが表示される', async ({ page }) => {
       const zennButton = page.getByRole('button', { name: 'Zenn' })
+      await zennButton.waitFor({ state: 'visible', timeout: TIMEOUT })
       await zennButton.click()
 
       // URLパラメータが変更されるのを待機
@@ -182,6 +189,7 @@ test.describe('記事一覧ページ', () => {
     }) => {
       // まずQiitaフィルターを選択
       const qiitaButton = page.getByRole('button', { name: 'Qiita' })
+      await qiitaButton.waitFor({ state: 'visible', timeout: TIMEOUT })
       await qiitaButton.click()
       await page.waitForURL('**/trends?media=qiita', { timeout: TIMEOUT })
 
@@ -191,6 +199,7 @@ test.describe('記事一覧ページ', () => {
 
       // 全てボタンをクリック
       const allButton = page.getByRole('button', { name: '全て' })
+      await allButton.waitFor({ state: 'visible', timeout: TIMEOUT })
       await allButton.click()
 
       // URLパラメータからmediaが削除されるのを待機
@@ -208,6 +217,7 @@ test.describe('記事一覧ページ', () => {
 
       // Qiitaフィルターをクリック
       const qiitaButton = page.getByRole('button', { name: 'Qiita' })
+      await qiitaButton.waitFor({ state: 'visible', timeout: TIMEOUT })
       await qiitaButton.click()
 
       // ページ番号がリセットされることを確認


### PR DESCRIPTION
MediaFilterボタンが表示されるまで明示的に待機するようにE2Eテストを修正。
これにより、ボタンの読み込みタイミングによるテスト失敗を防ぐ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- I want to review in Japanese. -->

<!-- Product Backlogから参照できるようにする -->

## 取り組んだこと

- 取り組んだことを書く

## 動作確認(スクリーンショットなど)


### UIテスト
<!-- UIコンポーネントを作成した場合はStorybookテストの結果を記載.特にない場合は以下のコメントを外す -->
<!-- 特になし -->

## 参考情報

- レビュアーに伝えるべき情報・注意事項があれば書く

<!-- for GitHub Copilot review rule -->

<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]
[imo]
[nits]
[ask]
[fyi]
-->

<!-- for GitHub Copilot review  rule-->

<!-- prefixの意味は以下です。まとめて記載するとCopilotのコメントにprefixがつかなくなるため別途記載しています。
[must] → かならず変更してね
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)
[nits] → ささいな指摘(nitpick)
[ask] → 質問
[fyi] → 参考情報
-->

<!-- I want to review in Japanese. -->
