### PR TITLE
Add date filtering with calendar picker

### DIFF
--- a/src/application/web/routes/trends._index/components/DateNavigator.test.tsx
+++ b/src/application/web/routes/trends._index/components/DateNavigator.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DateNavigator from './DateNavigator'
+
+describe('DateNavigator', () => {
+  const mockOnDateChange = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('日付が表示される', () => {
+    const testDate = new Date('2024-01-15')
+    render(<DateNavigator date={testDate} onDateChange={mockOnDateChange} />)
+
+    expect(screen.getByText(/2024\/1\/15/)).toBeInTheDocument()
+  })
+
+  it('前日ボタンをクリックすると、前日の日付でonDateChangeが呼ばれる', async () => {
+    const user = userEvent.setup()
+    const testDate = new Date('2024-01-15')
+    render(<DateNavigator date={testDate} onDateChange={mockOnDateChange} />)
+
+    const prevButton = screen.getByRole('button', { name: '前日' })
+    await user.click(prevButton)
+
+    expect(mockOnDateChange).toHaveBeenCalledTimes(1)
+    const calledDate = mockOnDateChange.mock.calls[0][0] as Date
+    expect(calledDate.getFullYear()).toBe(2024)
+    expect(calledDate.getMonth()).toBe(0)
+    expect(calledDate.getDate()).toBe(14)
+  })
+
+  it('翌日ボタンをクリックすると、翌日の日付でonDateChangeが呼ばれる', async () => {
+    const user = userEvent.setup()
+    const testDate = new Date('2024-01-15')
+    render(<DateNavigator date={testDate} onDateChange={mockOnDateChange} />)
+
+    const nextButton = screen.getByRole('button', { name: '翌日' })
+    await user.click(nextButton)
+
+    expect(mockOnDateChange).toHaveBeenCalledTimes(1)
+    const calledDate = mockOnDateChange.mock.calls[0][0] as Date
+    expect(calledDate.getFullYear()).toBe(2024)
+    expect(calledDate.getMonth()).toBe(0)
+    expect(calledDate.getDate()).toBe(16)
+  })
+
+  it('日付部分をクリックすると、DatePickerダイアログが開く', async () => {
+    const user = userEvent.setup()
+    const testDate = new Date('2024-01-15')
+    render(<DateNavigator date={testDate} onDateChange={mockOnDateChange} />)
+
+    const dateButton = screen.getByText(/2024\/1\/15/)
+    await user.click(dateButton)
+
+    expect(screen.getByText('日付を選択')).toBeInTheDocument()
+  })
+})

--- a/src/application/web/routes/trends._index/components/DateNavigator.tsx
+++ b/src/application/web/routes/trends._index/components/DateNavigator.tsx
@@ -1,0 +1,70 @@
+import { ArrowBigLeft, ArrowBigRight } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import { Button } from '@/application/web/components/ui/button'
+import { toJaDateString } from '@/common/locale'
+import DatePickerDialog from './DatePickerDialog'
+
+type Props = {
+  date: Date
+  onDateChange: (date: Date) => void
+}
+
+export default function DateNavigator({ date, onDateChange }: Props) {
+  const [isPickerOpen, setIsPickerOpen] = useState(false)
+
+  const handlePrevDay = useCallback(() => {
+    const prevDay = new Date(date)
+    prevDay.setDate(prevDay.getDate() - 1)
+    onDateChange(prevDay)
+  }, [date, onDateChange])
+
+  const handleNextDay = useCallback(() => {
+    const nextDay = new Date(date)
+    nextDay.setDate(nextDay.getDate() + 1)
+    onDateChange(nextDay)
+  }, [date, onDateChange])
+
+  const handleDateSelect = useCallback(
+    (selectedDate: Date) => {
+      onDateChange(selectedDate)
+      setIsPickerOpen(false)
+    },
+    [onDateChange],
+  )
+
+  return (
+    <div className='flex items-center gap-2'>
+      <Button
+        variant='ghost'
+        size='icon'
+        onClick={handlePrevDay}
+        aria-label='前日'
+        className='h-8 w-8'
+      >
+        <ArrowBigLeft className='h-5 w-5' />
+      </Button>
+      <button
+        type='button'
+        onClick={() => setIsPickerOpen(true)}
+        className='cursor-pointer text-xl italic hover:underline'
+      >
+        - {toJaDateString(date)} -
+      </button>
+      <Button
+        variant='ghost'
+        size='icon'
+        onClick={handleNextDay}
+        aria-label='翌日'
+        className='h-8 w-8'
+      >
+        <ArrowBigRight className='h-5 w-5' />
+      </Button>
+      <DatePickerDialog
+        isOpen={isPickerOpen}
+        onClose={() => setIsPickerOpen(false)}
+        selectedDate={date}
+        onDateSelect={handleDateSelect}
+      />
+    </div>
+  )
+}

--- a/src/application/web/routes/trends._index/components/DatePickerDialog.test.tsx
+++ b/src/application/web/routes/trends._index/components/DatePickerDialog.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DatePickerDialog from './DatePickerDialog'
+
+describe('DatePickerDialog', () => {
+  const mockOnClose = vi.fn()
+  const mockOnDateSelect = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('isOpen=trueの場合、ダイアログが表示される', () => {
+    const testDate = new Date('2024-01-15')
+    render(
+      <DatePickerDialog
+        isOpen={true}
+        onClose={mockOnClose}
+        selectedDate={testDate}
+        onDateSelect={mockOnDateSelect}
+      />,
+    )
+
+    expect(screen.getByText('日付を選択')).toBeInTheDocument()
+    expect(screen.getByText('2024年1月')).toBeInTheDocument()
+  })
+
+  it('isOpen=falseの場合、ダイアログが表示されない', () => {
+    const testDate = new Date('2024-01-15')
+    render(
+      <DatePickerDialog
+        isOpen={false}
+        onClose={mockOnClose}
+        selectedDate={testDate}
+        onDateSelect={mockOnDateSelect}
+      />,
+    )
+
+    expect(screen.queryByText('日付を選択')).not.toBeInTheDocument()
+  })
+
+  it('前月ボタンをクリックすると、前月のカレンダーが表示される', async () => {
+    const user = userEvent.setup()
+    const testDate = new Date('2024-01-15')
+    render(
+      <DatePickerDialog
+        isOpen={true}
+        onClose={mockOnClose}
+        selectedDate={testDate}
+        onDateSelect={mockOnDateSelect}
+      />,
+    )
+
+    expect(screen.getByText('2024年1月')).toBeInTheDocument()
+
+    const prevButton = screen.getByRole('button', { name: '前月' })
+    await user.click(prevButton)
+
+    expect(screen.getByText('2023年12月')).toBeInTheDocument()
+  })
+
+  it('翌月ボタンをクリックすると、翌月のカレンダーが表示される', async () => {
+    const user = userEvent.setup()
+    const testDate = new Date('2024-01-15')
+    render(
+      <DatePickerDialog
+        isOpen={true}
+        onClose={mockOnClose}
+        selectedDate={testDate}
+        onDateSelect={mockOnDateSelect}
+      />,
+    )
+
+    expect(screen.getByText('2024年1月')).toBeInTheDocument()
+
+    const nextButton = screen.getByRole('button', { name: '翌月' })
+    await user.click(nextButton)
+
+    expect(screen.getByText('2024年2月')).toBeInTheDocument()
+  })
+
+  it('日付をクリックすると、onDateSelectが呼ばれる', async () => {
+    const user = userEvent.setup()
+    const testDate = new Date('2024-01-15')
+    render(
+      <DatePickerDialog
+        isOpen={true}
+        onClose={mockOnClose}
+        selectedDate={testDate}
+        onDateSelect={mockOnDateSelect}
+      />,
+    )
+
+    const dayButton = screen.getByRole('button', { name: '20' })
+    await user.click(dayButton)
+
+    expect(mockOnDateSelect).toHaveBeenCalledTimes(1)
+    const calledDate = mockOnDateSelect.mock.calls[0][0] as Date
+    expect(calledDate.getFullYear()).toBe(2024)
+    expect(calledDate.getMonth()).toBe(0)
+    expect(calledDate.getDate()).toBe(20)
+  })
+
+  it('閉じるボタンをクリックすると、onCloseが呼ばれる', async () => {
+    const user = userEvent.setup()
+    const testDate = new Date('2024-01-15')
+    render(
+      <DatePickerDialog
+        isOpen={true}
+        onClose={mockOnClose}
+        selectedDate={testDate}
+        onDateSelect={mockOnDateSelect}
+      />,
+    )
+
+    const closeButton = screen.getByRole('button', { name: '閉じる' })
+    await user.click(closeButton)
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('曜日が日本語で表示される', () => {
+    const testDate = new Date('2024-01-15')
+    render(
+      <DatePickerDialog
+        isOpen={true}
+        onClose={mockOnClose}
+        selectedDate={testDate}
+        onDateSelect={mockOnDateSelect}
+      />,
+    )
+
+    expect(screen.getByText('日')).toBeInTheDocument()
+    expect(screen.getByText('月')).toBeInTheDocument()
+    expect(screen.getByText('火')).toBeInTheDocument()
+    expect(screen.getByText('水')).toBeInTheDocument()
+    expect(screen.getByText('木')).toBeInTheDocument()
+    expect(screen.getByText('金')).toBeInTheDocument()
+    expect(screen.getByText('土')).toBeInTheDocument()
+  })
+})

--- a/src/application/web/routes/trends._index/components/DatePickerDialog.tsx
+++ b/src/application/web/routes/trends._index/components/DatePickerDialog.tsx
@@ -1,0 +1,156 @@
+import { useCallback, useMemo, useState } from 'react'
+import { Button } from '@/application/web/components/ui/button'
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/application/web/components/ui/drawer'
+
+type Props = {
+  isOpen: boolean
+  onClose: () => void
+  selectedDate: Date
+  onDateSelect: (date: Date) => void
+}
+
+const WEEKDAYS_JP = ['日', '月', '火', '水', '木', '金', '土']
+
+export default function DatePickerDialog({ isOpen, onClose, selectedDate, onDateSelect }: Props) {
+  const [currentMonth, setCurrentMonth] = useState(() => {
+    const date = new Date(selectedDate)
+    date.setDate(1)
+    return date
+  })
+
+  // 月のカレンダーデータを生成
+  const calendarDays = useMemo(() => {
+    const year = currentMonth.getFullYear()
+    const month = currentMonth.getMonth()
+    const firstDay = new Date(year, month, 1)
+    const lastDay = new Date(year, month + 1, 0)
+    const daysInMonth = lastDay.getDate()
+    const startDayOfWeek = firstDay.getDay()
+
+    const days: (Date | null)[] = []
+
+    // 前月の空白
+    for (let i = 0; i < startDayOfWeek; i++) {
+      days.push(null)
+    }
+
+    // 当月の日付
+    for (let day = 1; day <= daysInMonth; day++) {
+      days.push(new Date(year, month, day))
+    }
+
+    return days
+  }, [currentMonth])
+
+  const handlePrevMonth = useCallback(() => {
+    setCurrentMonth((prev) => {
+      const newMonth = new Date(prev)
+      newMonth.setMonth(newMonth.getMonth() - 1)
+      return newMonth
+    })
+  }, [])
+
+  const handleNextMonth = useCallback(() => {
+    setCurrentMonth((prev) => {
+      const newMonth = new Date(prev)
+      newMonth.setMonth(newMonth.getMonth() + 1)
+      return newMonth
+    })
+  }, [])
+
+  const handleDayClick = useCallback(
+    (day: Date) => {
+      onDateSelect(day)
+    },
+    [onDateSelect],
+  )
+
+  const isSelectedDate = useCallback(
+    (day: Date) => {
+      return (
+        day.getFullYear() === selectedDate.getFullYear() &&
+        day.getMonth() === selectedDate.getMonth() &&
+        day.getDate() === selectedDate.getDate()
+      )
+    },
+    [selectedDate],
+  )
+
+  return (
+    <Drawer open={isOpen} onOpenChange={onClose}>
+      <DrawerContent>
+        <DrawerHeader>
+          <DrawerTitle>日付を選択</DrawerTitle>
+          <DrawerDescription>トレンド記事を表示する日付を選択してください</DrawerDescription>
+        </DrawerHeader>
+        <div className='px-4 pb-4'>
+          {/* 月ナビゲーション */}
+          <div className='mb-4 flex items-center justify-between'>
+            <Button variant='outline' size='sm' onClick={handlePrevMonth}>
+              前月
+            </Button>
+            <span className='text-lg font-semibold'>
+              {currentMonth.getFullYear()}年{currentMonth.getMonth() + 1}月
+            </span>
+            <Button variant='outline' size='sm' onClick={handleNextMonth}>
+              翌月
+            </Button>
+          </div>
+
+          {/* カレンダーグリッド */}
+          <div className='grid grid-cols-7 gap-2'>
+            {/* 曜日ヘッダー */}
+            {WEEKDAYS_JP.map((day) => (
+              <div key={day} className='text-center text-sm font-medium text-gray-600'>
+                {day}
+              </div>
+            ))}
+
+            {/* 日付セル */}
+            {calendarDays.map((day, index) => {
+              if (day === null) {
+                return <div key={`empty-${index}`} />
+              }
+
+              const isSelected = isSelectedDate(day)
+              const isToday =
+                day.getFullYear() === new Date().getFullYear() &&
+                day.getMonth() === new Date().getMonth() &&
+                day.getDate() === new Date().getDate()
+
+              return (
+                <button
+                  type='button'
+                  key={`day-${day.getTime()}`}
+                  onClick={() => handleDayClick(day)}
+                  className={`rounded-md p-2 text-center text-sm transition-colors ${
+                    isSelected
+                      ? 'bg-blue-500 text-white hover:bg-blue-600'
+                      : isToday
+                        ? 'border-2 border-blue-500 hover:bg-gray-100'
+                        : 'hover:bg-gray-100'
+                  }`}
+                >
+                  {day.getDate()}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+        <DrawerFooter>
+          <DrawerClose asChild>
+            <Button variant='outline'>閉じる</Button>
+          </DrawerClose>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  )
+}

--- a/src/application/web/routes/trends._index/page.tsx
+++ b/src/application/web/routes/trends._index/page.tsx
@@ -8,10 +8,10 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from '@/application/web/components/ui/pagination'
-import { toJaDateString } from '@/common/locale'
 import type { ArticleOutput as Article } from '@/domain/article/schema/articleSchema'
 import LoadingSpinner from '../../components/LoadingSpinner'
 import ArticleCard from './components/ArticleCard'
+import DateNavigator from './components/DateNavigator'
 import MediaFilter from './components/MediaFilter'
 import type { MediaType } from './useTrends'
 
@@ -26,6 +26,7 @@ type Props = {
   totalPages: number
   selectedMedia: MediaType
   onMediaChange: (media: MediaType) => void
+  onDateChange: (date: Date) => void
 }
 
 export default function TrendsPage({
@@ -39,6 +40,7 @@ export default function TrendsPage({
   totalPages,
   selectedMedia,
   onMediaChange,
+  onDateChange,
 }: Props) {
   const [searchParams] = useSearchParams()
 
@@ -89,7 +91,9 @@ export default function TrendsPage({
 
   return (
     <div className='relative min-h-screen bg-gradient-to-br from-gray-100 to-gray-200 p-6'>
-      <h1 className='pb-4 text-xl italic'>- {toJaDateString(date)} -</h1>
+      <div className='pb-4'>
+        <DateNavigator date={date} onDateChange={onDateChange} />
+      </div>
       <div className='mb-4'>
         <MediaFilter selectedMedia={selectedMedia} onMediaChange={onMediaChange} />
       </div>

--- a/src/application/web/routes/trends._index/route.tsx
+++ b/src/application/web/routes/trends._index/route.tsx
@@ -16,6 +16,7 @@ export default function Trends() {
     date,
     setSearchParams,
     handleMediaChange,
+    handleDateChange,
     selectedMedia,
   } = useTrends()
   const {
@@ -38,6 +39,7 @@ export default function Trends() {
         totalPages={totalPages}
         selectedMedia={selectedMedia}
         onMediaChange={handleMediaChange}
+        onDateChange={handleDateChange}
       />
       {selectedArticle && (
         <ArticleDrawer article={selectedArticle} isOpen={isDrawerOpen} onClose={closeDrawer} />

--- a/src/application/web/routes/trends._index/useTrends.ts
+++ b/src/application/web/routes/trends._index/useTrends.ts
@@ -31,7 +31,17 @@ export default function useTrends() {
   const isLoadingRef = useRef(false)
   const isMobile = useIsMobile()
 
-  const date = useMemo(() => new Date(), [])
+  const date = useMemo(() => {
+    const dateParam = searchParams.get('date')
+    if (dateParam) {
+      const parsedDate = new Date(dateParam)
+      // 有効な日付かチェック
+      if (!Number.isNaN(parsedDate.getTime())) {
+        return parsedDate
+      }
+    }
+    return new Date()
+  }, [searchParams])
 
   const fetchArticles: FetchArticles = useCallback(
     async ({ date, page = 1, limit = 20, media = null }) => {
@@ -134,6 +144,18 @@ export default function useTrends() {
     [searchParams, setSearchParams],
   )
 
+  const handleDateChange = useCallback(
+    (newDate: Date) => {
+      const newParams = new URLSearchParams(searchParams)
+      const formattedDate = formatDate(newDate)
+      newParams.set('date', formattedDate)
+      // 日付を変更したらページを1にリセット
+      newParams.delete('page')
+      setSearchParams(newParams)
+    },
+    [searchParams, setSearchParams],
+  )
+
   return {
     date,
     articles,
@@ -144,6 +166,7 @@ export default function useTrends() {
     isLoading,
     setSearchParams,
     handleMediaChange,
+    handleDateChange,
     selectedMedia,
   }
 }


### PR DESCRIPTION
- URLパラメータで日付を管理できるように変更
- 矢印ボタンで日付を前後に移動可能
- 日付クリックでカレンダーUIを表示
- カレンダーから任意の日付を選択可能
- 曜日は日本語表記に対応
- 日付変更時はページ番号をリセット

Changes:
- useTrends: URL paramsから日付を取得、handleDateChangeを追加
- DateNavigator: 矢印ボタンと日付表示を統合したコンポーネント
- DatePickerDialog: Drawerベースのカレンダー選択UI
- Tests: 新機能のテストケースを追加

<!-- I want to review in Japanese. -->

<!-- Product Backlogから参照できるようにする -->

## 取り組んだこと

- 取り組んだことを書く

## 動作確認(スクリーンショットなど)


### UIテスト
<!-- UIコンポーネントを作成した場合はStorybookテストの結果を記載.特にない場合は以下のコメントを外す -->
<!-- 特になし -->

## 参考情報

- レビュアーに伝えるべき情報・注意事項があれば書く

<!-- for GitHub Copilot review rule -->

<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]
[imo]
[nits]
[ask]
[fyi]
-->

<!-- for GitHub Copilot review  rule-->

<!-- prefixの意味は以下です。まとめて記載するとCopilotのコメントにprefixがつかなくなるため別途記載しています。
[must] → かならず変更してね
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)
[nits] → ささいな指摘(nitpick)
[ask] → 質問
[fyi] → 参考情報
-->

<!-- I want to review in Japanese. -->
