### PR TITLE
Fix: E2E test timeout for mobile article cards

### DIFF
--- a/src/application/web/routes/trends._index/components/article-card.tsx
+++ b/src/application/web/routes/trends._index/components/article-card.tsx
@@ -15,6 +15,7 @@ type Props = {
 export default function ArticleCard({ article, onCardClick }: Props) {
   return (
     <Card
+      data-slot='card'
       className='h-32 w-full sm:w-64 cursor-pointer rounded-3xl border border-white/40 bg-white/30 p-6 shadow-2xl backdrop-blur-xl transition-all duration-300 hover:shadow-xl'
       onClick={() => onCardClick(article)}
       role='button'


### PR DESCRIPTION
E2Eテストでdata-slot='card'セレクタが要素を見つけられなかったため、
ArticleCardコンポーネントに明示的にdata-slot='card'属性を追加した。
これにより、モバイル版のE2Eテストが正しく動作するようになる。

<!-- I want to review in Japanese. -->

<!-- Product Backlogから参照できるようにする -->

## 取り組んだこと

- 取り組んだことを書く

## 動作確認(スクリーンショットなど)


### UIテスト
<!-- UIコンポーネントを作成した場合はStorybookテストの結果を記載.特にない場合は以下のコメントを外す -->
<!-- 特になし -->

## 参考情報

- レビュアーに伝えるべき情報・注意事項があれば書く

<!-- for GitHub Copilot review rule -->

<!--
レビューする際には、以下のprefix(接頭辞)をつけてください
[must]
[imo]
[nits]
[ask]
[fyi]
-->

<!-- for GitHub Copilot review  rule-->

<!-- prefixの意味は以下です。まとめて記載するとCopilotのコメントにprefixがつかなくなるため別途記載しています。
[must] → かならず変更してね
[imo] → 自分の意見だとこうだけど修正必須ではないよ(in my opinion)
[nits] → ささいな指摘(nitpick)
[ask] → 質問
[fyi] → 参考情報
-->

<!-- I want to review in Japanese. -->
