### PR TITLE
chore: remove unnecessary .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,0 @@
-node_modules/
-postgresql/
-docs/
-.wrangler/
-.vscode/
-./github


### PR DESCRIPTION
This project uses Cloudflare Workers and does not use Docker.
The .dockerignore file is not needed.