### PR TITLE
ci: DependabotでCF previewを無効化し、ビルドチェックを追加

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -39,3 +39,18 @@ jobs:
 
       - name: TypeScript型チェック
         run: npm run typecheck
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Node.jsの構築
+        uses: ./.github/actions/setup_node
+        with:
+          node-version-file: ${{ env.NODE_VERSION_FILE }}
+
+      - name: Prismaクライアント生成
+        run: npx prisma generate
+
+      - name: ビルド
+        run: npm run build

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,75 @@
+name: Cloudflare Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup-preview:
+    if: github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      deployments: write
+
+    steps:
+      - name: Delete Preview Alias Deployment
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          PREVIEW_ALIAS="pr-${PR_NUMBER}"
+          SCRIPT_NAME="trend-diary"
+
+          # プレビューエイリアスに関連するデプロイメントを一覧取得
+          DEPLOYMENTS=$(curl -s "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}/deployments" \
+            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            -H "Content-Type: application/json")
+
+          # プレビューエイリアスに一致するデプロイメントIDを抽出
+          DEPLOYMENT_ID=$(echo "$DEPLOYMENTS" | jq -r ".result[] | select(.annotations.\"workers/triggered_by\" == \"upload\" and .annotations.\"workers/preview-alias\" == \"${PREVIEW_ALIAS}\") | .id" | head -1)
+
+          if [ -n "$DEPLOYMENT_ID" ] && [ "$DEPLOYMENT_ID" != "null" ]; then
+            echo "Deleting deployment: ${DEPLOYMENT_ID} for alias: ${PREVIEW_ALIAS}"
+
+            # デプロイメントを削除
+            curl -X DELETE "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}/deployments/${DEPLOYMENT_ID}" \
+              -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+              -H "Content-Type: application/json"
+
+            echo "Preview deployment deleted successfully"
+          else
+            echo "No deployment found for preview alias: ${PREVIEW_ALIAS}"
+          fi
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Mark GitHub Deployment as Inactive
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = ${{ github.event.pull_request.number }};
+
+            // preview環境のデプロイメントを取得
+            const { data: deployments } = await github.rest.repos.listDeployments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              environment: 'preview'
+            });
+
+            // このPRに関連するデプロイメントを探す
+            const prDeployments = deployments.filter(d =>
+              d.description && d.description.includes(`PR #${prNumber}`)
+            );
+
+            // 各デプロイメントをinactiveにする
+            for (const deployment of prDeployments) {
+              await github.rest.repos.createDeploymentStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                deployment_id: deployment.id,
+                state: 'inactive',
+                description: 'Preview environment cleaned up'
+              });
+              console.log(`Marked deployment ${deployment.id} as inactive`);
+            }

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -2,35 +2,20 @@ name: Cloudflare Preview Deploy
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'src/**'
+      - 'prisma/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'wrangler.toml'
+      - 'tsconfig.json'
+      - 'vite.config.ts'
+      - '.github/workflows/preview-deploy.yml'
 
 jobs:
-  check-changes:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-    outputs:
-      should_deploy: ${{ steps.filter.outputs.should_deploy }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            should_deploy:
-              - 'src/**'
-              - 'prisma/**'
-              - 'package.json'
-              - 'package-lock.json'
-              - 'wrangler.toml'
-              - 'tsconfig.json'
-              - 'vite.config.ts'
-              - '.github/workflows/preview-deploy.yml'
-
   deploy-preview:
-    needs: check-changes
-    if: github.event.action != 'closed' && needs.check-changes.outputs.should_deploy == 'true'
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -162,73 +147,4 @@ jobs:
                 issue_number: prNumber,
                 body: commentBody
               });
-            }
-
-  cleanup-preview:
-    if: github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      deployments: write
-
-    steps:
-      - name: Delete Preview Alias Deployment
-        run: |
-          PR_NUMBER=${{ github.event.pull_request.number }}
-          PREVIEW_ALIAS="pr-${PR_NUMBER}"
-          SCRIPT_NAME="trend-diary"
-
-          # プレビューエイリアスに関連するデプロイメントを一覧取得
-          DEPLOYMENTS=$(curl -s "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}/deployments" \
-            -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-            -H "Content-Type: application/json")
-
-          # プレビューエイリアスに一致するデプロイメントIDを抽出
-          DEPLOYMENT_ID=$(echo "$DEPLOYMENTS" | jq -r ".result[] | select(.annotations.\"workers/triggered_by\" == \"upload\" and .annotations.\"workers/preview-alias\" == \"${PREVIEW_ALIAS}\") | .id" | head -1)
-
-          if [ -n "$DEPLOYMENT_ID" ] && [ "$DEPLOYMENT_ID" != "null" ]; then
-            echo "Deleting deployment: ${DEPLOYMENT_ID} for alias: ${PREVIEW_ALIAS}"
-
-            # デプロイメントを削除
-            curl -X DELETE "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}/deployments/${DEPLOYMENT_ID}" \
-              -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
-              -H "Content-Type: application/json"
-
-            echo "Preview deployment deleted successfully"
-          else
-            echo "No deployment found for preview alias: ${PREVIEW_ALIAS}"
-          fi
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-      - name: Mark GitHub Deployment as Inactive
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const prNumber = ${{ github.event.pull_request.number }};
-
-            // preview環境のデプロイメントを取得
-            const { data: deployments } = await github.rest.repos.listDeployments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              environment: 'preview'
-            });
-
-            // このPRに関連するデプロイメントを探す
-            const prDeployments = deployments.filter(d =>
-              d.description && d.description.includes(`PR #${prNumber}`)
-            );
-
-            // 各デプロイメントをinactiveにする
-            for (const deployment of prDeployments) {
-              await github.rest.repos.createDeploymentStatus({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                deployment_id: deployment.id,
-                state: 'inactive',
-                description: 'Preview environment cleaned up'
-              });
-              console.log(`Marked deployment ${deployment.id} as inactive`);
             }


### PR DESCRIPTION
- preview-deploy.ymlをデプロイ専用に変更（pathsフィルター追加）
- preview-cleanup.ymlを新規作成（クリーンアップ専用）
- 両ワークフローでDependabotを除外
- lint.yamlにbuildジョブを追加（全pushでビルド検証）
