### PR TITLE
fix: CDワークフローの.node-versionパスを修正

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:
-          node-version-file: .node-version
+          node-version-file: ./application/.node-version
 
       - name: ビルド
         run: npm run build
@@ -62,7 +62,7 @@ jobs:
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:
-          node-version-file: .node-version
+          node-version-file: ./application/.node-version
 
       - name: Prismaのマイグレーション
         run: npm run db:deploy


### PR DESCRIPTION

# 概要
## 問題のあった領域
<!-- どの領域に問題があったかチェックを入れてください -->

- [ ] フロントエンド
  - [ ] UIの描画(レンダリング)
  - [ ] ビジネスロジック（状態管理、非同期処理、エラーハンドリングなど）
  - [ ] バックエンドとの整合ミス
- [ ] バックエンド
  - [ ] API（プレゼン層）
  - [ ] ビジネスロジック
  - [ ] データアクセス（DB・SQL）
  - [ ] 脆弱性
- [ ] その他
    - [x] CI/CD（GitHub Actionsやクラウド上のCI/CD関連）
    - [ ] インフラ（パブリッククラウドの設定・技術詳細）

### 要因の詳細
<!-- 詳しく事象を記載してください -->
node-version-fileのパスを.node-versionから./application/.node-versionに変更。 実際のファイルはapplication/ディレクトリに存在するため、正しいパスを指定。



### 再現手順

## 修正方針
<!-- 方針を網羅的に記載し、修正判断を下した理由を記載してください -->

### その方針を選んだ理由

## その他、参考情報
