### PR TITLE
fix(deps): override transitive deps to patch security alerts

### DIFF
--- a/application/package-lock.json
+++ b/application/package-lock.json
@@ -1518,9 +1518,9 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -5250,9 +5250,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5797,9 +5797,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -5873,9 +5873,9 @@
       "license": "MIT"
     },
     "node_modules/effect": {
-      "version": "3.16.12",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.16.12.tgz",
-      "integrity": "sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==",
+      "version": "3.21.2",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.2.tgz",
+      "integrity": "sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -6975,9 +6975,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -7442,9 +7442,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/application/package.json
+++ b/application/package.json
@@ -108,10 +108,10 @@
   },
   "overrides": {
     "@hono/node-server": "^1.19.13",
-    "defu": "^6.1.5",
-    "lodash": "^4.18.1",
     "brace-expansion": "^2.0.3",
-    "picomatch": "^4.0.4",
-    "effect": "^3.20.0"
+    "defu": "^6.1.5",
+    "effect": "^3.20.0",
+    "lodash": "^4.18.1",
+    "picomatch": "^4.0.4"
   }
 }

--- a/application/package.json
+++ b/application/package.json
@@ -105,5 +105,13 @@
     "vitest": "^3.2.4",
     "vitest-mock-extended": "^3.1.1",
     "wrangler": "^4.80.0"
+  },
+  "overrides": {
+    "@hono/node-server": "^1.19.13",
+    "defu": "^6.1.5",
+    "lodash": "^4.18.1",
+    "brace-expansion": "^2.0.3",
+    "picomatch": "^4.0.4",
+    "effect": "^3.20.0"
   }
 }


### PR DESCRIPTION
## Summary

Dependabotで検出されたセキュリティアラートのうち、**推移依存パッケージ**6件を `package.json` の `overrides` フィールドで脆弱性パッチ済みバージョンに固定する。

```json
"overrides": {
  "@hono/node-server": "^1.19.13",
  "defu": "^6.1.5",
  "lodash": "^4.18.1",
  "brace-expansion": "^2.0.3",
  "picomatch": "^4.0.4",
  "effect": "^3.20.0"
}
```

## 解消されるアラート (8件)

| # | パッケージ | severity | 経路 |
|---|---|---|---|
| #85 | @hono/node-server | medium | @hono/vite-dev-server |
| #81 | defu | high | c12 / giget / rc9 |
| #80 | lodash | high | @react-router/dev, recharts |
| #79 | lodash | medium | 同上 |
| #78 | brace-expansion | medium | (node_modules共通) |
| #77 | picomatch | high | vite, vitest, fdir, tinyglobby |
| #76 | picomatch | medium | 同上 |
| #75 | effect | high | @prisma/config |

## 注意

- 直接依存（hono / vite）は別PR #585 で対応。**こちらが先にマージされた場合は本PRをリベースする必要あり**。
- `lodash` は最新の 4.18.1 を採用（メジャー番号 4 のままで重大な互換破壊は無い見込み）。
- `effect` は `@prisma/config` の peer 要件 `^3.20.0` を満たす最低バージョン。

## Test plan

- [x] `npm install` 成功（overrides 適用済み）
- [x] `npm run lint` (biome ci + tsgo typecheck) パス
- [x] `npm audit` で対象6パッケージのアラート消滅確認
- [ ] CI (lint.yaml / test.yaml / e2e.yaml) パス