### PR TITLE
test(domain): 不足テストを追加して branches 閾値を 80% に戻す

### DIFF
--- a/application/src/domain/article/media.test.ts
+++ b/application/src/domain/article/media.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { ARTICLE_MEDIA, ARTICLE_MEDIA_LABELS, isArticleMedia } from './media'
+
+describe('media', () => {
+  describe('ARTICLE_MEDIA', () => {
+    it('全てのサポート対象メディアを含むこと', () => {
+      expect(ARTICLE_MEDIA).toEqual(['qiita', 'zenn', 'hatena'])
+    })
+  })
+
+  describe('ARTICLE_MEDIA_LABELS', () => {
+    it('各メディアに対応する表示用ラベルを保持すること', () => {
+      expect(ARTICLE_MEDIA_LABELS.qiita).toBe('Qiita')
+      expect(ARTICLE_MEDIA_LABELS.zenn).toBe('Zenn')
+      expect(ARTICLE_MEDIA_LABELS.hatena).toBe('はてブ')
+    })
+
+    it('全てのARTICLE_MEDIA要素に対応するラベルが定義されていること', () => {
+      for (const media of ARTICLE_MEDIA) {
+        expect(ARTICLE_MEDIA_LABELS[media]).toBeDefined()
+        expect(typeof ARTICLE_MEDIA_LABELS[media]).toBe('string')
+      }
+    })
+  })
+
+  describe('isArticleMedia', () => {
+    describe('正常系', () => {
+      it.each(['qiita', 'zenn', 'hatena'])(
+        'サポート対象のメディア(%s)に対してtrueを返すこと',
+        (media) => {
+          expect(isArticleMedia(media)).toBe(true)
+        },
+      )
+    })
+
+    describe('異常系', () => {
+      it.each(['note', 'medium', 'invalid', 'Qiita', 'ZENN', '', ' qiita', 'qiita '])(
+        'サポート対象外の文字列(%s)に対してfalseを返すこと',
+        (value) => {
+          expect(isArticleMedia(value)).toBe(false)
+        },
+      )
+    })
+  })
+})

--- a/application/src/domain/article/schema/diary-schema.test.ts
+++ b/application/src/domain/article/schema/diary-schema.test.ts
@@ -3,45 +3,29 @@ import { diaryReadItemSchema, diarySourceSchema, diarySummarySchema } from './di
 
 describe('diarySummarySchema', () => {
   describe('正常系', () => {
-    it('読了数とスキップ数が0の場合に検証成功すること', () => {
-      const result = diarySummarySchema.safeParse({ read: 0, skip: 0 })
-      expect(result.success).toBe(true)
-    })
+    const validTestCases = [
+      { name: '読了数とスキップ数が0の場合に検証成功すること', data: { read: 0, skip: 0 } },
+      { name: '正の整数値を受け入れること', data: { read: 10, skip: 5 } },
+    ]
 
-    it('正の整数値を受け入れること', () => {
-      const result = diarySummarySchema.safeParse({ read: 10, skip: 5 })
+    it.each(validTestCases)('$name', ({ data }) => {
+      const result = diarySummarySchema.safeParse(data)
       expect(result.success).toBe(true)
     })
   })
 
   describe('異常系', () => {
-    it('readが負の整数の場合に検証失敗すること', () => {
-      const result = diarySummarySchema.safeParse({ read: -1, skip: 0 })
-      expect(result.success).toBe(false)
-    })
+    const invalidTestCases = [
+      { name: 'readが負の整数の場合に検証失敗すること', data: { read: -1, skip: 0 } },
+      { name: 'skipが負の整数の場合に検証失敗すること', data: { read: 0, skip: -1 } },
+      { name: 'readが小数の場合に検証失敗すること', data: { read: 1.5, skip: 0 } },
+      { name: 'readが文字列の場合に検証失敗すること', data: { read: '1', skip: 0 } },
+      { name: 'readフィールドが欠けている場合に検証失敗すること', data: { skip: 0 } },
+      { name: 'skipフィールドが欠けている場合に検証失敗すること', data: { read: 0 } },
+    ]
 
-    it('skipが負の整数の場合に検証失敗すること', () => {
-      const result = diarySummarySchema.safeParse({ read: 0, skip: -1 })
-      expect(result.success).toBe(false)
-    })
-
-    it('readが小数の場合に検証失敗すること', () => {
-      const result = diarySummarySchema.safeParse({ read: 1.5, skip: 0 })
-      expect(result.success).toBe(false)
-    })
-
-    it('readが文字列の場合に検証失敗すること', () => {
-      const result = diarySummarySchema.safeParse({ read: '1', skip: 0 })
-      expect(result.success).toBe(false)
-    })
-
-    it('readフィールドが欠けている場合に検証失敗すること', () => {
-      const result = diarySummarySchema.safeParse({ skip: 0 })
-      expect(result.success).toBe(false)
-    })
-
-    it('skipフィールドが欠けている場合に検証失敗すること', () => {
-      const result = diarySummarySchema.safeParse({ read: 0 })
+    it.each(invalidTestCases)('$name', ({ data }) => {
+      const result = diarySummarySchema.safeParse(data)
       expect(result.success).toBe(false)
     })
   })
@@ -56,18 +40,23 @@ describe('diarySourceSchema', () => {
   })
 
   describe('異常系', () => {
-    it('mediaが許可リストにない場合に検証失敗すること', () => {
-      const result = diarySourceSchema.safeParse({ media: 'note', read: 1, skip: 1 })
-      expect(result.success).toBe(false)
-    })
+    const invalidTestCases = [
+      {
+        name: 'mediaが許可リストにない場合に検証失敗すること',
+        data: { media: 'note', read: 1, skip: 1 },
+      },
+      {
+        name: 'readが負の整数の場合に検証失敗すること',
+        data: { media: 'qiita', read: -1, skip: 0 },
+      },
+      {
+        name: 'skipが負の整数の場合に検証失敗すること',
+        data: { media: 'qiita', read: 0, skip: -1 },
+      },
+    ]
 
-    it('readが負の整数の場合に検証失敗すること', () => {
-      const result = diarySourceSchema.safeParse({ media: 'qiita', read: -1, skip: 0 })
-      expect(result.success).toBe(false)
-    })
-
-    it('skipが負の整数の場合に検証失敗すること', () => {
-      const result = diarySourceSchema.safeParse({ media: 'qiita', read: 0, skip: -1 })
+    it.each(invalidTestCases)('$name', ({ data }) => {
+      const result = diarySourceSchema.safeParse(data)
       expect(result.success).toBe(false)
     })
   })
@@ -91,43 +80,31 @@ describe('diaryReadItemSchema', () => {
   })
 
   describe('異常系', () => {
-    it('readHistoryIdがbigintでない場合に検証失敗すること', () => {
-      const result = diaryReadItemSchema.safeParse({
-        ...validReadItem,
-        readHistoryId: 1,
-      })
-      expect(result.success).toBe(false)
-    })
+    const invalidTestCases = [
+      {
+        name: 'readHistoryIdがbigintでない場合に検証失敗すること',
+        overrides: { readHistoryId: 1 },
+      },
+      {
+        name: 'articleIdがbigintでない場合に検証失敗すること',
+        overrides: { articleId: '10' },
+      },
+      {
+        name: 'mediaが許可リストにない場合に検証失敗すること',
+        overrides: { media: 'note' },
+      },
+      {
+        name: 'urlが無効な形式の場合に検証失敗すること',
+        overrides: { url: 'not-a-url' },
+      },
+      {
+        name: 'readAtがDate型でない場合に検証失敗すること',
+        overrides: { readAt: '2026-03-07' },
+      },
+    ]
 
-    it('articleIdがbigintでない場合に検証失敗すること', () => {
-      const result = diaryReadItemSchema.safeParse({
-        ...validReadItem,
-        articleId: '10',
-      })
-      expect(result.success).toBe(false)
-    })
-
-    it('mediaが許可リストにない場合に検証失敗すること', () => {
-      const result = diaryReadItemSchema.safeParse({
-        ...validReadItem,
-        media: 'note',
-      })
-      expect(result.success).toBe(false)
-    })
-
-    it('urlが無効な形式の場合に検証失敗すること', () => {
-      const result = diaryReadItemSchema.safeParse({
-        ...validReadItem,
-        url: 'not-a-url',
-      })
-      expect(result.success).toBe(false)
-    })
-
-    it('readAtがDate型でない場合に検証失敗すること', () => {
-      const result = diaryReadItemSchema.safeParse({
-        ...validReadItem,
-        readAt: '2026-03-07',
-      })
+    it.each(invalidTestCases)('$name', ({ overrides }) => {
+      const result = diaryReadItemSchema.safeParse({ ...validReadItem, ...overrides })
       expect(result.success).toBe(false)
     })
   })

--- a/application/src/domain/article/schema/diary-schema.test.ts
+++ b/application/src/domain/article/schema/diary-schema.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+import { diaryReadItemSchema, diarySourceSchema, diarySummarySchema } from './diary-schema'
+
+describe('diarySummarySchema', () => {
+  describe('正常系', () => {
+    it('読了数とスキップ数が0の場合に検証成功すること', () => {
+      const result = diarySummarySchema.safeParse({ read: 0, skip: 0 })
+      expect(result.success).toBe(true)
+    })
+
+    it('正の整数値を受け入れること', () => {
+      const result = diarySummarySchema.safeParse({ read: 10, skip: 5 })
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('異常系', () => {
+    it('readが負の整数の場合に検証失敗すること', () => {
+      const result = diarySummarySchema.safeParse({ read: -1, skip: 0 })
+      expect(result.success).toBe(false)
+    })
+
+    it('skipが負の整数の場合に検証失敗すること', () => {
+      const result = diarySummarySchema.safeParse({ read: 0, skip: -1 })
+      expect(result.success).toBe(false)
+    })
+
+    it('readが小数の場合に検証失敗すること', () => {
+      const result = diarySummarySchema.safeParse({ read: 1.5, skip: 0 })
+      expect(result.success).toBe(false)
+    })
+
+    it('readが文字列の場合に検証失敗すること', () => {
+      const result = diarySummarySchema.safeParse({ read: '1', skip: 0 })
+      expect(result.success).toBe(false)
+    })
+
+    it('readフィールドが欠けている場合に検証失敗すること', () => {
+      const result = diarySummarySchema.safeParse({ skip: 0 })
+      expect(result.success).toBe(false)
+    })
+
+    it('skipフィールドが欠けている場合に検証失敗すること', () => {
+      const result = diarySummarySchema.safeParse({ read: 0 })
+      expect(result.success).toBe(false)
+    })
+  })
+})
+
+describe('diarySourceSchema', () => {
+  describe('正常系', () => {
+    it.each(['qiita', 'zenn', 'hatena'])(
+      'media=%s で有効な集計データを受け入れること',
+      (media) => {
+        const result = diarySourceSchema.safeParse({ media, read: 1, skip: 1 })
+        expect(result.success).toBe(true)
+      },
+    )
+  })
+
+  describe('異常系', () => {
+    it('mediaが許可リストにない場合に検証失敗すること', () => {
+      const result = diarySourceSchema.safeParse({ media: 'note', read: 1, skip: 1 })
+      expect(result.success).toBe(false)
+    })
+
+    it('readが負の整数の場合に検証失敗すること', () => {
+      const result = diarySourceSchema.safeParse({ media: 'qiita', read: -1, skip: 0 })
+      expect(result.success).toBe(false)
+    })
+
+    it('skipが負の整数の場合に検証失敗すること', () => {
+      const result = diarySourceSchema.safeParse({ media: 'qiita', read: 0, skip: -1 })
+      expect(result.success).toBe(false)
+    })
+  })
+})
+
+describe('diaryReadItemSchema', () => {
+  const validReadItem = {
+    readHistoryId: 1n,
+    articleId: 10n,
+    media: 'qiita' as const,
+    title: 'Sample title',
+    url: 'https://example.com/sample',
+    readAt: new Date('2026-03-07T08:00:00.000Z'),
+  }
+
+  describe('正常系', () => {
+    it('有効な読了履歴アイテムを受け入れること', () => {
+      const result = diaryReadItemSchema.safeParse(validReadItem)
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('異常系', () => {
+    it('readHistoryIdがbigintでない場合に検証失敗すること', () => {
+      const result = diaryReadItemSchema.safeParse({
+        ...validReadItem,
+        readHistoryId: 1,
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('articleIdがbigintでない場合に検証失敗すること', () => {
+      const result = diaryReadItemSchema.safeParse({
+        ...validReadItem,
+        articleId: '10',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('mediaが許可リストにない場合に検証失敗すること', () => {
+      const result = diaryReadItemSchema.safeParse({
+        ...validReadItem,
+        media: 'note',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('urlが無効な形式の場合に検証失敗すること', () => {
+      const result = diaryReadItemSchema.safeParse({
+        ...validReadItem,
+        url: 'not-a-url',
+      })
+      expect(result.success).toBe(false)
+    })
+
+    it('readAtがDate型でない場合に検証失敗すること', () => {
+      const result = diaryReadItemSchema.safeParse({
+        ...validReadItem,
+        readAt: '2026-03-07',
+      })
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/application/src/domain/article/schema/diary-schema.test.ts
+++ b/application/src/domain/article/schema/diary-schema.test.ts
@@ -49,13 +49,10 @@ describe('diarySummarySchema', () => {
 
 describe('diarySourceSchema', () => {
   describe('正常系', () => {
-    it.each(['qiita', 'zenn', 'hatena'])(
-      'media=%s で有効な集計データを受け入れること',
-      (media) => {
-        const result = diarySourceSchema.safeParse({ media, read: 1, skip: 1 })
-        expect(result.success).toBe(true)
-      },
-    )
+    it.each(['qiita', 'zenn', 'hatena'])('media=%s で有効な集計データを受け入れること', (media) => {
+      const result = diarySourceSchema.safeParse({ media, read: 1, skip: 1 })
+      expect(result.success).toBe(true)
+    })
   })
 
   describe('異常系', () => {

--- a/application/src/domain/article/schema/read-history-schema.test.ts
+++ b/application/src/domain/article/schema/read-history-schema.test.ts
@@ -18,34 +18,36 @@ describe('readHistorySchema', () => {
   })
 
   describe('異常系', () => {
-    it('readHistoryIdがbigintでない場合に検証失敗すること', () => {
-      const result = readHistorySchema.safeParse({ ...validData, readHistoryId: 1 })
-      expect(result.success).toBe(false)
-    })
+    const { readHistoryId: _readHistoryId, ...withoutRequiredField } = validData
+    const invalidTestCases = [
+      {
+        name: 'readHistoryIdがbigintでない場合に検証失敗すること',
+        data: { ...validData, readHistoryId: 1 },
+      },
+      {
+        name: 'activeUserIdがbigintでない場合に検証失敗すること',
+        data: { ...validData, activeUserId: '10' },
+      },
+      {
+        name: 'articleIdがbigintでない場合に検証失敗すること',
+        data: { ...validData, articleId: 100 },
+      },
+      {
+        name: 'readAtがDate型でない場合に検証失敗すること',
+        data: { ...validData, readAt: '2026-03-07' },
+      },
+      {
+        name: 'createdAtがDate型でない場合に検証失敗すること',
+        data: { ...validData, createdAt: '2026-03-07' },
+      },
+      {
+        name: '必須フィールドが欠落している場合に検証失敗すること',
+        data: withoutRequiredField,
+      },
+    ]
 
-    it('activeUserIdがbigintでない場合に検証失敗すること', () => {
-      const result = readHistorySchema.safeParse({ ...validData, activeUserId: '10' })
-      expect(result.success).toBe(false)
-    })
-
-    it('articleIdがbigintでない場合に検証失敗すること', () => {
-      const result = readHistorySchema.safeParse({ ...validData, articleId: 100 })
-      expect(result.success).toBe(false)
-    })
-
-    it('readAtがDate型でない場合に検証失敗すること', () => {
-      const result = readHistorySchema.safeParse({ ...validData, readAt: '2026-03-07' })
-      expect(result.success).toBe(false)
-    })
-
-    it('createdAtがDate型でない場合に検証失敗すること', () => {
-      const result = readHistorySchema.safeParse({ ...validData, createdAt: '2026-03-07' })
-      expect(result.success).toBe(false)
-    })
-
-    it('必須フィールドが欠落している場合に検証失敗すること', () => {
-      const { readHistoryId: _readHistoryId, ...withoutId } = validData
-      const result = readHistorySchema.safeParse(withoutId)
+    it.each(invalidTestCases)('$name', ({ data }) => {
+      const result = readHistorySchema.safeParse(data)
       expect(result.success).toBe(false)
     })
   })

--- a/application/src/domain/article/schema/read-history-schema.test.ts
+++ b/application/src/domain/article/schema/read-history-schema.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { readHistorySchema } from './read-history-schema'
+
+describe('readHistorySchema', () => {
+  const validData = {
+    readHistoryId: 1n,
+    activeUserId: 10n,
+    articleId: 100n,
+    readAt: new Date('2026-03-07T08:00:00.000Z'),
+    createdAt: new Date('2026-03-07T08:00:00.000Z'),
+  }
+
+  describe('正常系', () => {
+    it('有効な読了履歴データを受け入れること', () => {
+      const result = readHistorySchema.safeParse(validData)
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('異常系', () => {
+    it('readHistoryIdがbigintでない場合に検証失敗すること', () => {
+      const result = readHistorySchema.safeParse({ ...validData, readHistoryId: 1 })
+      expect(result.success).toBe(false)
+    })
+
+    it('activeUserIdがbigintでない場合に検証失敗すること', () => {
+      const result = readHistorySchema.safeParse({ ...validData, activeUserId: '10' })
+      expect(result.success).toBe(false)
+    })
+
+    it('articleIdがbigintでない場合に検証失敗すること', () => {
+      const result = readHistorySchema.safeParse({ ...validData, articleId: 100 })
+      expect(result.success).toBe(false)
+    })
+
+    it('readAtがDate型でない場合に検証失敗すること', () => {
+      const result = readHistorySchema.safeParse({ ...validData, readAt: '2026-03-07' })
+      expect(result.success).toBe(false)
+    })
+
+    it('createdAtがDate型でない場合に検証失敗すること', () => {
+      const result = readHistorySchema.safeParse({ ...validData, createdAt: '2026-03-07' })
+      expect(result.success).toBe(false)
+    })
+
+    it('必須フィールドが欠落している場合に検証失敗すること', () => {
+      const { readHistoryId: _readHistoryId, ...withoutId } = validData
+      const result = readHistorySchema.safeParse(withoutId)
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/application/src/domain/article/schema/skipped-article-schema.test.ts
+++ b/application/src/domain/article/schema/skipped-article-schema.test.ts
@@ -17,29 +17,32 @@ describe('skippedArticleSchema', () => {
   })
 
   describe('異常系', () => {
-    it('skippedArticleIdがbigintでない場合に検証失敗すること', () => {
-      const result = skippedArticleSchema.safeParse({ ...validData, skippedArticleId: 1 })
-      expect(result.success).toBe(false)
-    })
+    const { skippedArticleId: _skippedArticleId, ...withoutRequiredField } = validData
+    const invalidTestCases = [
+      {
+        name: 'skippedArticleIdがbigintでない場合に検証失敗すること',
+        data: { ...validData, skippedArticleId: 1 },
+      },
+      {
+        name: 'activeUserIdがbigintでない場合に検証失敗すること',
+        data: { ...validData, activeUserId: '10' },
+      },
+      {
+        name: 'articleIdがbigintでない場合に検証失敗すること',
+        data: { ...validData, articleId: 100 },
+      },
+      {
+        name: 'createdAtがDate型でない場合に検証失敗すること',
+        data: { ...validData, createdAt: '2026-03-07' },
+      },
+      {
+        name: '必須フィールドが欠落している場合に検証失敗すること',
+        data: withoutRequiredField,
+      },
+    ]
 
-    it('activeUserIdがbigintでない場合に検証失敗すること', () => {
-      const result = skippedArticleSchema.safeParse({ ...validData, activeUserId: '10' })
-      expect(result.success).toBe(false)
-    })
-
-    it('articleIdがbigintでない場合に検証失敗すること', () => {
-      const result = skippedArticleSchema.safeParse({ ...validData, articleId: 100 })
-      expect(result.success).toBe(false)
-    })
-
-    it('createdAtがDate型でない場合に検証失敗すること', () => {
-      const result = skippedArticleSchema.safeParse({ ...validData, createdAt: '2026-03-07' })
-      expect(result.success).toBe(false)
-    })
-
-    it('必須フィールドが欠落している場合に検証失敗すること', () => {
-      const { skippedArticleId: _skippedArticleId, ...withoutId } = validData
-      const result = skippedArticleSchema.safeParse(withoutId)
+    it.each(invalidTestCases)('$name', ({ data }) => {
+      const result = skippedArticleSchema.safeParse(data)
       expect(result.success).toBe(false)
     })
   })

--- a/application/src/domain/article/schema/skipped-article-schema.test.ts
+++ b/application/src/domain/article/schema/skipped-article-schema.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { skippedArticleSchema } from './skipped-article-schema'
+
+describe('skippedArticleSchema', () => {
+  const validData = {
+    skippedArticleId: 1n,
+    activeUserId: 10n,
+    articleId: 100n,
+    createdAt: new Date('2026-03-07T08:00:00.000Z'),
+  }
+
+  describe('正常系', () => {
+    it('有効なスキップ済み記事データを受け入れること', () => {
+      const result = skippedArticleSchema.safeParse(validData)
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('異常系', () => {
+    it('skippedArticleIdがbigintでない場合に検証失敗すること', () => {
+      const result = skippedArticleSchema.safeParse({ ...validData, skippedArticleId: 1 })
+      expect(result.success).toBe(false)
+    })
+
+    it('activeUserIdがbigintでない場合に検証失敗すること', () => {
+      const result = skippedArticleSchema.safeParse({ ...validData, activeUserId: '10' })
+      expect(result.success).toBe(false)
+    })
+
+    it('articleIdがbigintでない場合に検証失敗すること', () => {
+      const result = skippedArticleSchema.safeParse({ ...validData, articleId: 100 })
+      expect(result.success).toBe(false)
+    })
+
+    it('createdAtがDate型でない場合に検証失敗すること', () => {
+      const result = skippedArticleSchema.safeParse({ ...validData, createdAt: '2026-03-07' })
+      expect(result.success).toBe(false)
+    })
+
+    it('必須フィールドが欠落している場合に検証失敗すること', () => {
+      const { skippedArticleId: _skippedArticleId, ...withoutId } = validData
+      const result = skippedArticleSchema.safeParse(withoutId)
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/application/src/domain/user/factory.test.ts
+++ b/application/src/domain/user/factory.test.ts
@@ -1,0 +1,17 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { describe, expect, it } from 'vitest'
+import { mockDeep } from 'vitest-mock-extended'
+import type { RdbClient } from '@/infrastructure/rdb'
+import { createAuthUseCase } from './factory'
+import { AuthUseCase } from './use-case'
+
+describe('createAuthUseCase', () => {
+  it('SupabaseClientとRdbClientから AuthUseCase インスタンスを生成すること', () => {
+    const supabaseClient = mockDeep<SupabaseClient>()
+    const rdbClient = mockDeep<RdbClient>()
+
+    const useCase = createAuthUseCase(supabaseClient, rdbClient)
+
+    expect(useCase).toBeInstanceOf(AuthUseCase)
+  })
+})

--- a/application/src/domain/user/infrastructure/supabase-auth-repository.test.ts
+++ b/application/src/domain/user/infrastructure/supabase-auth-repository.test.ts
@@ -1,0 +1,556 @@
+import {
+  AuthInvalidCredentialsError,
+  AuthSessionMissingError,
+  type SupabaseClient,
+} from '@supabase/supabase-js'
+import { isFailure, isSuccess } from '@yuukihayashi0510/core'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mockDeep } from 'vitest-mock-extended'
+import { AlreadyExistsError, ClientError, ServerError } from '@/common/errors'
+import UnauthorizedError from '@/common/errors/client-error/unauthorized-error'
+import { SupabaseAuthRepository } from './supabase-auth-repository'
+
+const buildSupabaseUser = (overrides: Record<string, unknown> = {}) => ({
+  id: 'auth-user-id-123',
+  app_metadata: {},
+  user_metadata: {},
+  aud: 'authenticated',
+  email: 'test@example.com',
+  email_confirmed_at: '2026-03-07T08:00:00.000Z',
+  created_at: '2026-03-07T08:00:00.000Z',
+  ...overrides,
+})
+
+const buildSupabaseSession = (overrides: Record<string, unknown> = {}) => ({
+  access_token: 'access-token',
+  refresh_token: 'refresh-token',
+  expires_in: 3600,
+  expires_at: 1234567890,
+  token_type: 'bearer',
+  user: buildSupabaseUser(),
+  ...overrides,
+})
+
+describe('SupabaseAuthRepository', () => {
+  const client = mockDeep<SupabaseClient>()
+  const repository = new SupabaseAuthRepository(client)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('signup', () => {
+    describe('正常系', () => {
+      it('セッションを含むサインアップ結果を返すこと', async () => {
+        const supabaseUser = buildSupabaseUser()
+        const supabaseSession = buildSupabaseSession({ user: supabaseUser })
+        client.auth.signUp.mockResolvedValue({
+          data: { user: supabaseUser, session: supabaseSession },
+          error: null,
+        } as never)
+
+        const result = await repository.signup('test@example.com', 'Password1!')
+
+        expect(isSuccess(result)).toBe(true)
+        if (isSuccess(result)) {
+          expect(result.data.user.id).toBe(supabaseUser.id)
+          expect(result.data.user.email).toBe('test@example.com')
+          expect(result.data.user.createdAt).toBeInstanceOf(Date)
+          expect(result.data.user.emailConfirmedAt).toBeInstanceOf(Date)
+          expect(result.data.session?.accessToken).toBe('access-token')
+          expect(result.data.session?.refreshToken).toBe('refresh-token')
+          expect(result.data.session?.expiresIn).toBe(3600)
+        }
+      })
+
+      it('セッションがnullの場合もサインアップ結果を返すこと', async () => {
+        const supabaseUser = buildSupabaseUser()
+        client.auth.signUp.mockResolvedValue({
+          data: { user: supabaseUser, session: null },
+          error: null,
+        } as never)
+
+        const result = await repository.signup('test@example.com', 'Password1!')
+
+        expect(isSuccess(result)).toBe(true)
+        if (isSuccess(result)) {
+          expect(result.data.session).toBeNull()
+        }
+      })
+
+      it('emailConfirmedAtが未設定の場合はnullになること', async () => {
+        const supabaseUser = buildSupabaseUser({ email_confirmed_at: undefined })
+        client.auth.signUp.mockResolvedValue({
+          data: { user: supabaseUser, session: null },
+          error: null,
+        } as never)
+
+        const result = await repository.signup('test@example.com', 'Password1!')
+
+        expect(isSuccess(result)).toBe(true)
+        if (isSuccess(result)) {
+          expect(result.data.user.emailConfirmedAt).toBeNull()
+        }
+      })
+
+      it('Supabaseのemailが空でもfallbackEmailを使用すること', async () => {
+        const supabaseUser = buildSupabaseUser({ email: undefined })
+        const supabaseSession = buildSupabaseSession({ user: supabaseUser, expires_in: undefined })
+        client.auth.signUp.mockResolvedValue({
+          data: { user: supabaseUser, session: supabaseSession },
+          error: null,
+        } as never)
+
+        const result = await repository.signup('fallback@example.com', 'Password1!')
+
+        expect(isSuccess(result)).toBe(true)
+        if (isSuccess(result)) {
+          expect(result.data.user.email).toBe('fallback@example.com')
+          expect(result.data.session?.expiresIn).toBe(3600)
+        }
+      })
+    })
+
+    describe('異常系', () => {
+      it('Supabase呼び出しが例外を投げる場合ServerErrorを返すこと', async () => {
+        client.auth.signUp.mockRejectedValue(new Error('network down'))
+
+        const result = await repository.signup('test@example.com', 'Password1!')
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ServerError)
+        }
+      })
+
+      it('既に登録済みのユーザーの場合AlreadyExistsErrorを返すこと', async () => {
+        client.auth.signUp.mockResolvedValue({
+          data: { user: null, session: null },
+          error: { message: 'User already registered', name: 'AuthError', status: 400 },
+        } as never)
+
+        const result = await repository.signup('test@example.com', 'Password1!')
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(AlreadyExistsError)
+          expect(result.error.message).toBe('User already exists')
+        }
+      })
+
+      it('それ以外のエラーはServerErrorで包んで返すこと', async () => {
+        client.auth.signUp.mockResolvedValue({
+          data: { user: null, session: null },
+          error: { message: 'unexpected', name: 'AuthError', status: 500 },
+        } as never)
+
+        const result = await repository.signup('test@example.com', 'Password1!')
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ServerError)
+          expect(result.error.message).toContain('unexpected')
+        }
+      })
+
+      it('ユーザーが返却されない場合ServerErrorを返すこと', async () => {
+        client.auth.signUp.mockResolvedValue({
+          data: { user: null, session: null },
+          error: null,
+        } as never)
+
+        const result = await repository.signup('test@example.com', 'Password1!')
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ServerError)
+          expect(result.error.message).toBe('User registration failed')
+        }
+      })
+
+      it('emailもfallbackEmailも無い場合ServerErrorを返すこと', async () => {
+        const supabaseUser = buildSupabaseUser({ email: undefined })
+        client.auth.signUp.mockResolvedValue({
+          data: { user: supabaseUser, session: null },
+          error: null,
+        } as never)
+
+        const result = await repository.signup('', 'Password1!')
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ServerError)
+          expect(result.error.message).toContain('User email is missing')
+        }
+      })
+    })
+  })
+
+  describe('login', () => {
+    describe('正常系', () => {
+      it('ログイン結果を返すこと', async () => {
+        const supabaseUser = buildSupabaseUser()
+        const supabaseSession = buildSupabaseSession({ user: supabaseUser })
+        client.auth.signInWithPassword.mockResolvedValue({
+          data: { user: supabaseUser, session: supabaseSession },
+          error: null,
+        } as never)
+
+        const result = await repository.login('test@example.com', 'Password1!')
+
+        expect(isSuccess(result)).toBe(true)
+        if (isSuccess(result)) {
+          expect(result.data.user.email).toBe('test@example.com')
+          expect(result.data.session.accessToken).toBe('access-token')
+        }
+      })
+    })
+
+    describe('異常系', () => {
+      it('Supabase呼び出しが例外を投げる場合ServerErrorを返すこと', async () => {
+        client.auth.signInWithPassword.mockRejectedValue(new Error('network down'))
+
+        const result = await repository.login('test@example.com', 'Password1!')
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ServerError)
+        }
+      })
+
+      it('AuthInvalidCredentialsError(instanceofヒット)時はClientError(401)を返すこと', async () => {
+        const authError = new AuthInvalidCredentialsError('Invalid login credentials')
+        client.auth.signInWithPassword.mockResolvedValue({
+          data: { user: null, session: null },
+          error: authError,
+        } as never)
+
+        const result = await repository.login('test@example.com', 'WrongPassword!')
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ClientError)
+          expect((result.error as ClientError).statusCode).toBe(401)
+          expect(result.error.message).toBe('Invalid email or password')
+        }
+      })
+
+      it('Invalid login credentials メッセージのフォールバック判定でClientErrorを返すこと', async () => {
+        client.auth.signInWithPassword.mockResolvedValue({
+          data: { user: null, session: null },
+          error: { message: 'Invalid login credentials', name: 'AuthError', status: 400 },
+        } as never)
+
+        const result = await repository.login('test@example.com', 'WrongPassword!')
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ClientError)
+          expect((result.error as ClientError).statusCode).toBe(401)
+        }
+      })
+
+      it('Invalid credentials メッセージでもClientErrorを返すこと', async () => {
+        client.auth.signInWithPassword.mockResolvedValue({
+          data: { user: null, session: null },
+          error: { message: 'Invalid credentials', name: 'AuthError', status: 400 },
+        } as never)
+
+        const result = await repository.login('test@example.com', 'WrongPassword!')
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ClientError)
+        }
+      })
+
+      it('それ以外のエラーはServerErrorを返すこと', async () => {
+        client.auth.signInWithPassword.mockResolvedValue({
+          data: { user: null, session: null },
+          error: { message: 'database error', name: 'AuthError', status: 500 },
+        } as never)
+
+        const result = await repository.login('test@example.com', 'Password1!')
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ServerError)
+        }
+      })
+
+      it('userまたはsessionが欠落している場合ServerErrorを返すこと', async () => {
+        const supabaseUser = buildSupabaseUser()
+        client.auth.signInWithPassword.mockResolvedValue({
+          data: { user: supabaseUser, session: null },
+          error: null,
+        } as never)
+
+        const result = await repository.login('test@example.com', 'Password1!')
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ServerError)
+          expect(result.error.message).toBe('Authentication failed')
+        }
+      })
+
+      it('emailが取得できない場合ServerErrorを返すこと', async () => {
+        const supabaseUser = buildSupabaseUser({ email: undefined })
+        client.auth.signInWithPassword.mockResolvedValue({
+          data: {
+            user: supabaseUser,
+            session: buildSupabaseSession({ user: supabaseUser }),
+          },
+          error: null,
+        } as never)
+
+        const result = await repository.login('', 'Password1!')
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ServerError)
+          expect(result.error.message).toContain('User email is missing')
+        }
+      })
+    })
+  })
+
+  describe('logout', () => {
+    describe('正常系', () => {
+      it('ログアウト成功時にvoidを返すこと', async () => {
+        client.auth.signOut.mockResolvedValue({ error: null } as never)
+
+        const result = await repository.logout()
+
+        expect(isSuccess(result)).toBe(true)
+      })
+    })
+
+    describe('異常系', () => {
+      it('Supabase呼び出しが例外を投げる場合ServerErrorを返すこと', async () => {
+        client.auth.signOut.mockRejectedValue(new Error('network down'))
+
+        const result = await repository.logout()
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ServerError)
+        }
+      })
+
+      it('errorが存在する場合ServerErrorを返すこと', async () => {
+        client.auth.signOut.mockResolvedValue({
+          error: { message: 'logout error', name: 'AuthError', status: 500 },
+        } as never)
+
+        const result = await repository.logout()
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ServerError)
+          expect(result.error.message).toContain('Logout failed')
+        }
+      })
+    })
+  })
+
+  describe('getCurrentUser', () => {
+    describe('正常系', () => {
+      it('現在のユーザーを返すこと', async () => {
+        const supabaseUser = buildSupabaseUser()
+        client.auth.getUser.mockResolvedValue({
+          data: { user: supabaseUser },
+          error: null,
+        } as never)
+
+        const result = await repository.getCurrentUser()
+
+        expect(isSuccess(result)).toBe(true)
+        if (isSuccess(result)) {
+          expect(result.data.id).toBe(supabaseUser.id)
+          expect(result.data.email).toBe('test@example.com')
+        }
+      })
+    })
+
+    describe('異常系', () => {
+      it('AuthSessionMissingErrorの場合UnauthorizedError(sessionExists=false)を返すこと', async () => {
+        client.auth.getUser.mockRejectedValue(new AuthSessionMissingError())
+
+        const result = await repository.getCurrentUser()
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(UnauthorizedError)
+          const unauthorized = result.error as UnauthorizedError
+          expect(unauthorized.context?.sessionExists).toBe(false)
+        }
+      })
+
+      it('それ以外の例外はServerErrorで包んで返すこと', async () => {
+        client.auth.getUser.mockRejectedValue(new Error('network'))
+
+        const result = await repository.getCurrentUser()
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ServerError)
+        }
+      })
+
+      it('userがnullの場合UnauthorizedError(sessionExists=true)を返すこと', async () => {
+        client.auth.getUser.mockResolvedValue({
+          data: { user: null },
+          error: null,
+        } as never)
+
+        const result = await repository.getCurrentUser()
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(UnauthorizedError)
+          const unauthorized = result.error as UnauthorizedError
+          expect(unauthorized.context?.sessionExists).toBe(true)
+        }
+      })
+
+      it('emailが取得できない場合ServerErrorを返すこと', async () => {
+        const supabaseUser = buildSupabaseUser({ email: undefined })
+        client.auth.getUser.mockResolvedValue({
+          data: { user: supabaseUser },
+          error: null,
+        } as never)
+
+        const result = await repository.getCurrentUser()
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ServerError)
+        }
+      })
+    })
+  })
+
+  describe('refreshSession', () => {
+    describe('正常系', () => {
+      it('セッション更新成功時に新セッションを返すこと', async () => {
+        const supabaseUser = buildSupabaseUser()
+        const supabaseSession = buildSupabaseSession({ user: supabaseUser })
+        client.auth.refreshSession.mockResolvedValue({
+          data: { user: supabaseUser, session: supabaseSession },
+          error: null,
+        } as never)
+
+        const result = await repository.refreshSession()
+
+        expect(isSuccess(result)).toBe(true)
+        if (isSuccess(result)) {
+          expect(result.data.user.id).toBe(supabaseUser.id)
+          expect(result.data.session.accessToken).toBe('access-token')
+        }
+      })
+    })
+
+    describe('異常系', () => {
+      it('Supabase呼び出しが例外を投げる場合ServerErrorを返すこと', async () => {
+        client.auth.refreshSession.mockRejectedValue(new Error('network'))
+
+        const result = await repository.refreshSession()
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ServerError)
+        }
+      })
+
+      it('errorが存在する場合ServerErrorを返すこと', async () => {
+        client.auth.refreshSession.mockResolvedValue({
+          data: { user: null, session: null },
+          error: { message: 'refresh failed', name: 'AuthError', status: 401 },
+        } as never)
+
+        const result = await repository.refreshSession()
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ServerError)
+        }
+      })
+
+      it('sessionがnullの場合ServerErrorを返すこと', async () => {
+        client.auth.refreshSession.mockResolvedValue({
+          data: { user: null, session: null },
+          error: null,
+        } as never)
+
+        const result = await repository.refreshSession()
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ServerError)
+        }
+      })
+
+      it('emailが取得できない場合ServerErrorを返すこと', async () => {
+        const supabaseUser = buildSupabaseUser({ email: undefined })
+        client.auth.refreshSession.mockResolvedValue({
+          data: {
+            user: supabaseUser,
+            session: buildSupabaseSession({ user: supabaseUser }),
+          },
+          error: null,
+        } as never)
+
+        const result = await repository.refreshSession()
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ServerError)
+        }
+      })
+    })
+  })
+
+  describe('deleteUser', () => {
+    describe('正常系', () => {
+      it('削除成功時にvoidを返すこと', async () => {
+        client.auth.admin.deleteUser.mockResolvedValue({
+          data: { user: null },
+          error: null,
+        } as never)
+
+        const result = await repository.deleteUser('auth-user-id-123')
+
+        expect(isSuccess(result)).toBe(true)
+      })
+    })
+
+    describe('異常系', () => {
+      it('Supabase呼び出しが例外を投げる場合ServerErrorを返すこと', async () => {
+        client.auth.admin.deleteUser.mockRejectedValue(new Error('network'))
+
+        const result = await repository.deleteUser('auth-user-id-123')
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ServerError)
+        }
+      })
+
+      it('errorが存在する場合ServerErrorを返すこと', async () => {
+        client.auth.admin.deleteUser.mockResolvedValue({
+          data: { user: null },
+          error: { message: 'delete failed', name: 'AuthError', status: 500 },
+        } as never)
+
+        const result = await repository.deleteUser('auth-user-id-123')
+
+        expect(isFailure(result)).toBe(true)
+        if (isFailure(result)) {
+          expect(result.error).toBeInstanceOf(ServerError)
+          expect(result.error.message).toContain('User deletion failed')
+        }
+      })
+    })
+  })
+})

--- a/application/src/domain/user/infrastructure/supabase-auth-repository.test.ts
+++ b/application/src/domain/user/infrastructure/supabase-auth-repository.test.ts
@@ -1,7 +1,9 @@
 import {
   AuthInvalidCredentialsError,
   AuthSessionMissingError,
+  type Session,
   type SupabaseClient,
+  type User,
 } from '@supabase/supabase-js'
 import { isFailure, isSuccess } from '@yuukihayashi0510/core'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -10,7 +12,7 @@ import { AlreadyExistsError, ClientError, ServerError } from '@/common/errors'
 import UnauthorizedError from '@/common/errors/client-error/unauthorized-error'
 import { SupabaseAuthRepository } from './supabase-auth-repository'
 
-const buildSupabaseUser = (overrides: Record<string, unknown> = {}) => ({
+const buildSupabaseUser = (overrides: Partial<User> = {}): User => ({
   id: 'auth-user-id-123',
   app_metadata: {},
   user_metadata: {},
@@ -21,7 +23,7 @@ const buildSupabaseUser = (overrides: Record<string, unknown> = {}) => ({
   ...overrides,
 })
 
-const buildSupabaseSession = (overrides: Record<string, unknown> = {}) => ({
+const buildSupabaseSession = (overrides: Partial<Session> = {}): Session => ({
   access_token: 'access-token',
   refresh_token: 'refresh-token',
   expires_in: 3600,
@@ -57,6 +59,10 @@ describe('SupabaseAuthRepository', () => {
           expect(result.data.user.email).toBe('test@example.com')
           expect(result.data.user.createdAt).toBeInstanceOf(Date)
           expect(result.data.user.emailConfirmedAt).toBeInstanceOf(Date)
+          expect(result.data.user.createdAt.toISOString()).toBe(supabaseUser.created_at)
+          expect(result.data.user.emailConfirmedAt?.toISOString()).toBe(
+            supabaseUser.email_confirmed_at,
+          )
           expect(result.data.session?.accessToken).toBe('access-token')
           expect(result.data.session?.refreshToken).toBe('refresh-token')
           expect(result.data.session?.expiresIn).toBe(3600)

--- a/application/src/test/vitest/domain/config.ts
+++ b/application/src/test/vitest/domain/config.ts
@@ -15,9 +15,7 @@ export default defineConfig({
       // ベタガキしないと、Github Actionsに閾値が反映されない
       thresholds: {
         statements: 60, // 命令網羅, ソースコードの全ての命令が実行されるかどうか
-        // Vitest v4 の AST-based remapping に伴い計測値が下がったため一時的に緩和
-        // 不足しているテストの追加で復帰させる予定
-        branches: 50, // 分岐網羅, 処理のパスの通過率とほぼ同義
+        branches: 80, // 分岐網羅, 処理のパスの通過率とほぼ同義
         functions: 60, // 関数網羅, 関数の実行パスの通過率
         lines: 60, // 行網羅, ソースコードの全ての行が実行されるかどうか
       },


### PR DESCRIPTION
## Summary

Vitest v4 の AST-based remapping により branches 計測値が下がり、 `src/test/vitest/domain/config.ts` の branches 閾値が一時的に **50%** へ緩和されていた（[#598](https://github.com/Geek-Teck-Mentors/trend_diary/pull/598) 参照）。本PRで不足していたユニットテストを追加し、閾値を従来の **80%** に復帰させる。

## 追加・修正内容

### 追加テスト

- **`src/domain/user/infrastructure/supabase-auth-repository.ts`**（最大の分岐網羅貢献）
  - `signup` / `login` / `logout` / `getCurrentUser` / `refreshSession` / `deleteUser` の正常系・異常系を網羅
  - `AuthInvalidCredentialsError` の `instanceof` 判定 と メッセージフォールバック判定の両ルート
  - `AuthSessionMissingError` ⇒ `UnauthorizedError(sessionExists=false)` 変換
  - `user` / `session` / `email` 欠落時の `ServerError` ルート
  - `AlreadyExistsError` への変換ルート（"already registered" メッセージ判定）
- **`src/domain/article/media.ts`**: `isArticleMedia` の真偽分岐 / 定数 / ラベル定義
- **`src/domain/article/schema/diary-schema.ts`**: `diarySummarySchema` / `diarySourceSchema` / `diaryReadItemSchema`
- **`src/domain/article/schema/read-history-schema.ts`**: bigint / Date 検証
- **`src/domain/article/schema/skipped-article-schema.ts`**: bigint / Date 検証
- **`src/domain/user/factory.ts`**: `createAuthUseCase` が `AuthUseCase` インスタンスを返すことを確認

### 設定変更

- `src/test/vitest/domain/config.ts`: `branches` 閾値を `50` → `80` に復帰し、暫定緩和コメントを削除

## Test plan

- [ ] CI の `Test (domain)` が成功する
- [ ] coverage report で `src/domain/**` の branches が 80% 以上であることを確認
- [ ] 追加テストが既存のテストパターン（`describe('正常系')` / `describe('異常系')`）に沿っている

https://claude.ai/code/session_01W372oDc1tbuutTqV3orr9Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01W372oDc1tbuutTqV3orr9Z)_