### PR TITLE
chore(deps): bump zod to v4.4.3 and migrate flatten() to z.flattenError()

### DIFF
--- a/application/package-lock.json
+++ b/application/package-lock.json
@@ -42,7 +42,7 @@
         "uuid": "^14.0.0",
         "vaul": "^1.1.2",
         "vite-plugin-babel": "^1.6.0",
-        "zod": "^3.24.1"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@biomejs/biome": "2.0.6",
@@ -11095,9 +11095,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/application/package.json
+++ b/application/package.json
@@ -72,7 +72,7 @@
     "uuid": "^14.0.0",
     "vaul": "^1.1.2",
     "vite-plugin-babel": "^1.6.0",
-    "zod": "^3.24.1"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@biomejs/biome": "2.0.6",

--- a/application/src/web/client/features/authenticate/validation.ts
+++ b/application/src/web/client/features/authenticate/validation.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod'
 import { AuthInput, authInputSchema } from '@/domain/user'
 import { newValidationError, newValidationSuccess, ValidationResult } from '../validation'
 
@@ -21,7 +22,7 @@ export function validateAuthenticateForm(
 
   if (!result.success) {
     return newValidationError<AuthenticateErrors>(
-      result.error.flatten().fieldErrors as AuthenticateErrors,
+      z.flattenError(result.error).fieldErrors as AuthenticateErrors,
     )
   }
 

--- a/application/src/web/middleware/zod-validator.ts
+++ b/application/src/web/middleware/zod-validator.ts
@@ -1,7 +1,7 @@
 import { zValidator } from '@hono/zod-validator'
 import type { Context, ValidationTargets } from 'hono'
 import { HTTPException } from 'hono/http-exception'
-import { ZodSchema } from 'zod'
+import { z, ZodSchema } from 'zod'
 import { Env } from '../env'
 
 // 参考: https://github.com/honojs/middleware/blob/main/packages/zod-validator/README.md
@@ -11,7 +11,7 @@ const zodValidator = <Target extends keyof ValidationTargets, T extends ZodSchem
 ) =>
   zValidator(target, schema, (result) => {
     if (!result.success) {
-      const errorMessages = result.error.flatten().fieldErrors
+      const errorMessages = z.flattenError(result.error).fieldErrors
       throw new HTTPException(422, {
         message: 'Invalid input',
         cause: errorMessages,

--- a/application/src/web/middleware/zod-validator.ts
+++ b/application/src/web/middleware/zod-validator.ts
@@ -1,7 +1,7 @@
 import { zValidator } from '@hono/zod-validator'
 import type { Context, ValidationTargets } from 'hono'
 import { HTTPException } from 'hono/http-exception'
-import { z, ZodSchema } from 'zod'
+import { ZodSchema, z } from 'zod'
 import { Env } from '../env'
 
 // 参考: https://github.com/honojs/middleware/blob/main/packages/zod-validator/README.md

--- a/application/src/web/server/article/handler/get-diary.test.ts
+++ b/application/src/web/server/article/handler/get-diary.test.ts
@@ -1,4 +1,5 @@
 import { isFailure } from '@yuukihayashi0510/core'
+import { z } from 'zod'
 import { addJstDays, toJstDateString } from '@/common/locale/date'
 import TEST_ENV from '@/test/env'
 import * as articleHelper from '@/test/helper/article'
@@ -73,7 +74,7 @@ describe('diaryQuerySchema', () => {
     expect(result.success).toBe(false)
     if (result.success) return
 
-    const errors = result.error.flatten().fieldErrors
+    const errors = z.flattenError(result.error).fieldErrors
     expect(errors.from).toContain('date must be a valid JST date')
     expect(errors.to).toContain('date must be a valid JST date')
   })
@@ -87,7 +88,7 @@ describe('diaryQuerySchema', () => {
     expect(result.success).toBe(false)
     if (result.success) return
 
-    const errors = result.error.flatten().fieldErrors
+    const errors = z.flattenError(result.error).fieldErrors
     expect(errors.page).toContain('page is available only when from and to are the same date')
   })
 })


### PR DESCRIPTION
## Summary

- zod v3.25.76 → v4.4.3 にアップグレード（Dependabot #611 由来）
- `ZodError.flatten()` が v4 で削除されたため、トップレベル `z.flattenError()` に移行

## 背景

#611 はDependabot自動生成のzodメジャーアップPRだが、ブランチ保護により Dependabot 自身が rebase できず、また外部からも push が拒否される（HTTP 403）。本PRで zodバンプ + 移行対応をまとめて取り込み、#611 はクローズする。

## 変更箇所

| ファイル | 内容 |
|---|---|
| `application/src/web/middleware/zod-validator.ts` | `result.error.flatten().fieldErrors` → `z.flattenError(result.error).fieldErrors` |
| `application/src/web/client/features/authenticate/validation.ts` | 同上 |
| `application/src/web/server/article/handler/get-diary.test.ts` | 同上（2箇所） |
| `application/package.json` / `package-lock.json` | zod ^4.4.3 |

## Test plan

- [ ] CI: ts-compile が通る
- [ ] CI: test ジョブが通る（既存のバリデーション系テスト）
- [ ] CI: build / code-quality / Diff（E2E）が通る

Closes #611

---
_Generated by [Claude Code](https://claude.ai/code/session_01X47x1SQ4Hvx4BEqyEvC711)_