### PR TITLE
fix(zod): migrate ZodError.flatten() to z.flattenError() for v4

### DIFF
--- a/application/src/web/client/features/authenticate/validation.ts
+++ b/application/src/web/client/features/authenticate/validation.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod'
 import { AuthInput, authInputSchema } from '@/domain/user'
 import { newValidationError, newValidationSuccess, ValidationResult } from '../validation'
 
@@ -21,7 +22,7 @@ export function validateAuthenticateForm(
 
   if (!result.success) {
     return newValidationError<AuthenticateErrors>(
-      result.error.flatten().fieldErrors as AuthenticateErrors,
+      z.flattenError(result.error).fieldErrors as AuthenticateErrors,
     )
   }
 

--- a/application/src/web/middleware/zod-validator.ts
+++ b/application/src/web/middleware/zod-validator.ts
@@ -1,7 +1,7 @@
 import { zValidator } from '@hono/zod-validator'
 import type { Context, ValidationTargets } from 'hono'
 import { HTTPException } from 'hono/http-exception'
-import { ZodSchema } from 'zod'
+import { ZodSchema, z } from 'zod'
 import { Env } from '../env'
 
 // 参考: https://github.com/honojs/middleware/blob/main/packages/zod-validator/README.md
@@ -11,7 +11,7 @@ const zodValidator = <Target extends keyof ValidationTargets, T extends ZodSchem
 ) =>
   zValidator(target, schema, (result) => {
     if (!result.success) {
-      const errorMessages = result.error.flatten().fieldErrors
+      const errorMessages = z.flattenError(result.error).fieldErrors
       throw new HTTPException(422, {
         message: 'Invalid input',
         cause: errorMessages,

--- a/application/src/web/server/article/handler/get-diary.test.ts
+++ b/application/src/web/server/article/handler/get-diary.test.ts
@@ -1,4 +1,5 @@
 import { isFailure } from '@yuukihayashi0510/core'
+import { z } from 'zod'
 import { addJstDays, toJstDateString } from '@/common/locale/date'
 import TEST_ENV from '@/test/env'
 import * as articleHelper from '@/test/helper/article'
@@ -73,7 +74,7 @@ describe('diaryQuerySchema', () => {
     expect(result.success).toBe(false)
     if (result.success) return
 
-    const errors = result.error.flatten().fieldErrors
+    const errors = z.flattenError(result.error).fieldErrors
     expect(errors.from).toContain('date must be a valid JST date')
     expect(errors.to).toContain('date must be a valid JST date')
   })
@@ -87,7 +88,7 @@ describe('diaryQuerySchema', () => {
     expect(result.success).toBe(false)
     if (result.success) return
 
-    const errors = result.error.flatten().fieldErrors
+    const errors = z.flattenError(result.error).fieldErrors
     expect(errors.page).toContain('page is available only when from and to are the same date')
   })
 })


### PR DESCRIPTION
## Summary

zod v4で `ZodError.flatten()` が削除されたため、トップレベル `z.flattenError()` に移行する。

## 背景

#611 (Dependabot: zod v3.25.76 → v4.4.3) は `flatten()` 使用箇所の ts-compile が落ちる。本PRを #611 のブランチに対してマージし、#611 自体を main へマージできる状態にする。

## 変更箇所

| ファイル | 内容 |
|---|---|
| `application/src/web/middleware/zod-validator.ts` | `result.error.flatten().fieldErrors` → `z.flattenError(result.error).fieldErrors` |
| `application/src/web/client/features/authenticate/validation.ts` | 同上 |
| `application/src/web/server/article/handler/get-diary.test.ts` | 同上（2箇所） |

## Test plan

- [ ] CI: ts-compile が通る
- [ ] CI: test ジョブが通る
- [ ] CI: build / code-quality / Diff（E2E）が通る

---
_Generated by [Claude Code](https://claude.ai/code/session_01X47x1SQ4Hvx4BEqyEvC711)_