### PR TITLE
fix(test): zod v4のエラーメッセージに合わせてpaginationテストを更新

### DIFF
--- a/application/src/common/pagination/schema.test.ts
+++ b/application/src/common/pagination/schema.test.ts
@@ -31,44 +31,48 @@ describe('offsetPaginationSchema', () => {
   }
 
   const invalidCases = [
-    { name: 'pageが文字列', input: { page: 'abc' }, message: 'Expected number, received nan' },
+    {
+      name: 'pageが文字列',
+      input: { page: 'abc' },
+      message: 'Invalid input: expected number, received NaN',
+    },
     {
       name: 'limitが文字列',
       input: { limit: 'invalid' },
-      message: 'Expected number, received nan',
+      message: 'Invalid input: expected number, received NaN',
     },
-    { name: 'pageが0', input: { page: 0 }, message: 'Number must be greater than or equal to 1' },
+    { name: 'pageが0', input: { page: 0 }, message: 'Too small: expected number to be >=1' },
     {
       name: 'pageが負の値',
       input: { page: -1 },
-      message: 'Number must be greater than or equal to 1',
+      message: 'Too small: expected number to be >=1',
     },
     {
       name: 'pageが大きな負の値',
       input: { page: -999 },
-      message: 'Number must be greater than or equal to 1',
+      message: 'Too small: expected number to be >=1',
     },
-    { name: 'pageが小数', input: { page: 1.5 }, message: 'Expected integer' },
-    { name: 'pageが1未満の小数', input: { page: 0.9 }, message: 'Expected integer' },
+    { name: 'pageが小数', input: { page: 1.5 }, message: 'Invalid input: expected int' },
+    { name: 'pageが1未満の小数', input: { page: 0.9 }, message: 'Invalid input: expected int' },
     {
       name: `limitが${MIN_LIMIT}未満`,
       input: { limit: 0 },
-      message: `Number must be greater than or equal to ${MIN_LIMIT}`,
+      message: `Too small: expected number to be >=${MIN_LIMIT}`,
     },
     {
       name: 'limitが負の値',
       input: { limit: -10 },
-      message: `Number must be greater than or equal to ${MIN_LIMIT}`,
+      message: `Too small: expected number to be >=${MIN_LIMIT}`,
     },
     {
       name: `limitが${MAX_LIMIT}より大きい`,
       input: { limit: 101 },
-      message: `Number must be less than or equal to ${MAX_LIMIT}`,
+      message: `Too big: expected number to be <=${MAX_LIMIT}`,
     },
     {
       name: 'limitが大きな値',
       input: { limit: 500 },
-      message: `Number must be less than or equal to ${MAX_LIMIT}`,
+      message: `Too big: expected number to be <=${MAX_LIMIT}`,
     },
   ]
 
@@ -100,38 +104,42 @@ describe('offsetPaginationMobileSchema', () => {
   }
 
   const invalidCases = [
-    { name: 'pageが文字列', input: { page: 'abc' }, message: 'Expected number, received nan' },
+    {
+      name: 'pageが文字列',
+      input: { page: 'abc' },
+      message: 'Invalid input: expected number, received NaN',
+    },
     {
       name: 'limitが文字列',
       input: { limit: 'invalid' },
-      message: 'Expected number, received nan',
+      message: 'Invalid input: expected number, received NaN',
     },
-    { name: 'pageが0', input: { page: 0 }, message: 'Number must be greater than or equal to 1' },
+    { name: 'pageが0', input: { page: 0 }, message: 'Too small: expected number to be >=1' },
     {
       name: 'pageが負の値',
       input: { page: -1 },
-      message: 'Number must be greater than or equal to 1',
+      message: 'Too small: expected number to be >=1',
     },
-    { name: 'pageが小数', input: { page: 1.5 }, message: 'Expected integer' },
+    { name: 'pageが小数', input: { page: 1.5 }, message: 'Invalid input: expected int' },
     {
       name: `limitが${MIN_LIMIT}未満`,
       input: { limit: 0 },
-      message: `Number must be greater than or equal to ${MIN_LIMIT}`,
+      message: `Too small: expected number to be >=${MIN_LIMIT}`,
     },
     {
       name: 'limitが負の値',
       input: { limit: -10 },
-      message: `Number must be greater than or equal to ${MIN_LIMIT}`,
+      message: `Too small: expected number to be >=${MIN_LIMIT}`,
     },
     {
       name: `limitが${MAX_LIMIT}より大きい`,
       input: { limit: 101 },
-      message: `Number must be less than or equal to ${MAX_LIMIT}`,
+      message: `Too big: expected number to be <=${MAX_LIMIT}`,
     },
     {
       name: 'limitが大きな値',
       input: { limit: 500 },
-      message: `Number must be less than or equal to ${MAX_LIMIT}`,
+      message: `Too big: expected number to be <=${MAX_LIMIT}`,
     },
   ]
 


### PR DESCRIPTION
## 背景

`npm run test:common` で `src/common/pagination/schema.test.ts` の **20件** がfailしていた。

原因はzod v3 → v4 (#611) 移行でエラーメッセージのフォーマットが変わったため。テスト側は旧フォーマットのまま残っていた。

## 変更内容

`src/common/pagination/schema.test.ts` の `toThrow()` 期待値をzod v4の出力に合わせて更新。

| 旧 (zod v3) | 新 (zod v4) |
| --- | --- |
| `Expected number, received nan` | `Invalid input: expected number, received NaN` |
| `Number must be greater than or equal to X` | `Too small: expected number to be >=X` |
| `Number must be less than or equal to X` | `Too big: expected number to be <=X` |
| `Expected integer` | `Invalid input: expected int` |

実装側 (`src/common/pagination/schema.ts`) は変更なし。

## 検証

```
Before: Test Files  2 failed | 11 passed (13)
              Tests  20 failed | 51 passed (71)

After:  Tests  71 passed (71)
```

（手元では `@yuukihayashi0510/core` のJSRレジストリが403で取得できず `date.test.ts` がimport失敗したが、これはサンドボックス固有のネットワーク問題でCIには影響しない）

## Test plan

- [ ] CI の `common` ジョブが green


---
_Generated by [Claude Code](https://claude.ai/code/session_01CWPs67pBXUaXrnCrJwZYLv)_