### PR TITLE
docs: 組織名変更に伴うリンクの更新 (Geek-Teck-Mentors → geek-beyond)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Lint](https://github.com/Geek-Teck-Mentors/trend_diary/actions/workflows/lint.yaml/badge.svg)](https://github.com/Geek-Teck-Mentors/trend_diary/actions/workflows/lint.yaml)
-[![Test](https://github.com/Geek-Teck-Mentors/trend_diary/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/Geek-Teck-Mentors/trend_diary/actions/workflows/test.yaml)
-[![CD](https://github.com/Geek-Teck-Mentors/trend_diary/actions/workflows/cd.yaml/badge.svg)](https://github.com/Geek-Teck-Mentors/trend_diary/actions/workflows/cd.yaml)
+[![Lint](https://github.com/geek-beyond/trend_diary/actions/workflows/lint.yaml/badge.svg)](https://github.com/geek-beyond/trend_diary/actions/workflows/lint.yaml)
+[![Test](https://github.com/geek-beyond/trend_diary/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/geek-beyond/trend_diary/actions/workflows/test.yaml)
+[![CD](https://github.com/geek-beyond/trend_diary/actions/workflows/cd.yaml/badge.svg)](https://github.com/geek-beyond/trend_diary/actions/workflows/cd.yaml)
 
 ## 環境構築
 

--- a/docs/adr/20250325_DBで使用する主キーの型について.md
+++ b/docs/adr/20250325_DBで使用する主キーの型について.md
@@ -4,8 +4,8 @@ Status: Accepted
 
 Relevant PR:
 
-- https://github.com/Geek-Teck-Mentors/trend_diary/pull/71
-- https://github.com/Geek-Teck-Mentors/trend_diary/pull/79
+- https://github.com/geek-beyond/trend_diary/pull/71
+- https://github.com/geek-beyond/trend_diary/pull/79
 
 # Context
 

--- a/docs/adr/20250416_記事テーブルの設計.md
+++ b/docs/adr/20250416_記事テーブルの設計.md
@@ -4,7 +4,7 @@ Status: Accepted
 
 Relevant PR:
 
-- https://github.com/Geek-Teck-Mentors/trend_diary/pull/107
+- https://github.com/geek-beyond/trend_diary/pull/107
 
 # Context
 
@@ -13,7 +13,7 @@ Relevant PR:
 
 ## References
 
-- [issue](https://github.com/Geek-Teck-Mentors/trend_diary/issues/90)
+- [issue](https://github.com/geek-beyond/trend_diary/issues/90)
 - [Discordの関連スレッド](https://discord.com/channels/1126373101832257628/1361646771696304200)
 
 # Decision

--- a/docs/adr/20250427_SupabaseのfunctionsからのDB接続の方法について.md
+++ b/docs/adr/20250427_SupabaseのfunctionsからのDB接続の方法について.md
@@ -4,7 +4,7 @@ Status: Accepted
 
 Relevant PR:
 
-- https://github.com/Geek-Teck-Mentors/trend_diary/pull/107
+- https://github.com/geek-beyond/trend_diary/pull/107
 
 # Context
 

--- a/docs/adr/20250428_Supabaseのfuctions内のディレクトリ構成について.md
+++ b/docs/adr/20250428_Supabaseのfuctions内のディレクトリ構成について.md
@@ -4,7 +4,7 @@ Status: Accepted
 
 Relevant PR:
 
-- https://github.com/Geek-Teck-Mentors/trend_diary/pull/107
+- https://github.com/geek-beyond/trend_diary/pull/107
 
 # Context
 
@@ -13,7 +13,7 @@ Relevant PR:
 
 ## References
 
-- https://github.com/Geek-Teck-Mentors/trend_diary/pull/107#pullrequestreview-2797667986
+- https://github.com/geek-beyond/trend_diary/pull/107#pullrequestreview-2797667986
 
 # Decision
 

--- a/docs/adr/20250523_テスト戦略.md
+++ b/docs/adr/20250523_テスト戦略.md
@@ -18,7 +18,7 @@ Relevant PR:
 
 ## References
 
-- https://github.com/Geek-Teck-Mentors/trend_diary/pull/150
+- https://github.com/geek-beyond/trend_diary/pull/150
 - https://www.prisma.io/blog/testing-series-5-xWogenROXm#set-up-a-workflow
 
 # Decision

--- a/docs/adr/20250525_neverthrowの運用.md
+++ b/docs/adr/20250525_neverthrowの運用.md
@@ -10,7 +10,7 @@ Status: Deprecated
 
 Relevant PR:
 
-https://github.com/Geek-Teck-Mentors/trend_diary/pull/154
+https://github.com/geek-beyond/trend_diary/pull/154
 
 <!-- reference できるプルリクがあればそのリンクを貼ってください -->
 

--- a/docs/adr/20250609_フロントエンドテスト戦略.md
+++ b/docs/adr/20250609_フロントエンドテスト戦略.md
@@ -10,7 +10,7 @@ Status: Accepted
 
 Relevant PR:
 
-https://github.com/Geek-Teck-Mentors/trend_diary/pull/172
+https://github.com/geek-beyond/trend_diary/pull/172
 
 <!-- reference できるプルリクがあればそのリンクを貼ってください -->
 

--- a/docs/adr/20250719_記事一覧での記事の追加読み込みの方法.md
+++ b/docs/adr/20250719_記事一覧での記事の追加読み込みの方法.md
@@ -10,7 +10,7 @@ Status: Accepted
 
 Relevant PR:
 
-https://github.com/Geek-Teck-Mentors/trend_diary/pull/197
+https://github.com/geek-beyond/trend_diary/pull/197
 
 <!-- reference できるプルリクがあればそのリンクを貼ってください -->
 

--- a/docs/adr/20260114_記事一覧hookの再フェッチ機構の実装方法.md
+++ b/docs/adr/20260114_記事一覧hookの再フェッチ機構の実装方法.md
@@ -8,7 +8,7 @@ Status: Accepted
 
 Relevant PR:
 
-https://github.com/Geek-Teck-Mentors/trend_diary/pull/428
+https://github.com/geek-beyond/trend_diary/pull/428
 <!-- reference できるプルリクがあればそのリンクを貼ってください -->
 
 


### PR DESCRIPTION
## Summary

- 組織名が `Geek-Teck-Mentors` から `geek-beyond` に変更されたため、リポジトリ内に残っていた旧組織名の参照を更新
- GitHubの自動リダイレクトで動作上の影響はないものの、リンクを正しい名前に揃えるための更新

## 変更箇所

- `README.md` — CI/CD バッジ3つ（Lint / Test / CD）
- `docs/adr/*.md` — 過去 PR / issue へのリンク計10件
  - `20250325_DBで使用する主キーの型について.md`
  - `20250416_記事テーブルの設計.md`
  - `20250427_SupabaseのfunctionsからのDB接続の方法について.md`
  - `20250428_Supabaseのfuctions内のディレクトリ構成について.md`
  - `20250523_テスト戦略.md`
  - `20250525_neverthrowの運用.md`
  - `20250609_フロントエンドテスト戦略.md`
  - `20250719_記事一覧での記事の追加読み込みの方法.md`
  - `20260114_記事一覧hookの再フェッチ機構の実装方法.md`

## 影響範囲

- コード・ワークフロー・Action・依存設定・CODEOWNERS には旧組織名のハードコードなし → 動作影響なし
- ドキュメント内のリンクのみ更新

## Test plan

- [ ] README のCIバッジが新組織のActions URLを指していることを確認
- [ ] ADR内のPR/issueリンクが `geek-beyond/trend_diary` を指していることを確認

https://claude.ai/code/session_017AkfWSmeYMXpZPpcyM1uHc

---
_Generated by [Claude Code](https://claude.ai/code/session_017AkfWSmeYMXpZPpcyM1uHc)_