### PR TITLE
refactor: Result型をneverthrowへ移行し直接利用する

### DIFF
--- a/application/package-lock.json
+++ b/application/package-lock.json
@@ -27,6 +27,7 @@
         "hono": "^4.12.18",
         "hono-react-router-adapter": "^0.6.5",
         "lucide-react": "^0.563.0",
+        "neverthrow": "^8.2.0",
         "next-themes": "^0.4.6",
         "pino": "^10.3.1",
         "react": "^19.2.3",
@@ -7456,6 +7457,18 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/neverthrow": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-8.2.0.tgz",
+      "integrity": "sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.24.0"
       }
     },
     "node_modules/next-themes": {

--- a/application/package.json
+++ b/application/package.json
@@ -57,6 +57,7 @@
     "hono": "^4.12.18",
     "hono-react-router-adapter": "^0.6.5",
     "lucide-react": "^0.563.0",
+    "neverthrow": "^8.2.0",
     "next-themes": "^0.4.6",
     "pino": "^10.3.1",
     "react": "^19.2.3",

--- a/application/src/common/locale/date.test.ts
+++ b/application/src/common/locale/date.test.ts
@@ -48,7 +48,7 @@ describe('Common Date Module', () => {
       const result = toJstDateString(new Date('2024-01-01T00:00:00Z'))
       expect(isSuccess(result)).toBe(true)
       if (isSuccess(result)) {
-        expect(result.data).toBe('2024-01-01')
+        expect(result.value).toBe('2024-01-01')
       }
     })
 
@@ -101,7 +101,7 @@ describe('Common Date Module', () => {
       const result = toTodayJstDateString()
       expect(isSuccess(result)).toBe(true)
       if (isSuccess(result)) {
-        expect(result.data).toBe('2024-01-02')
+        expect(result.value).toBe('2024-01-02')
       }
     })
   })
@@ -111,7 +111,7 @@ describe('Common Date Module', () => {
       const result = addJstDays('2024-01-01', -1)
       expect(isSuccess(result)).toBe(true)
       if (isSuccess(result)) {
-        expect(result.data).toBe('2023-12-31')
+        expect(result.value).toBe('2023-12-31')
       }
     })
 

--- a/application/src/common/locale/date.test.ts
+++ b/application/src/common/locale/date.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, vi } from 'vitest'
-import { isFailure, isSuccess } from '@/common/result'
 import {
   addJstDays,
   formatSummaryDateTick,
@@ -46,16 +45,16 @@ describe('Common Date Module', () => {
   describe('toJstDateString', () => {
     it('DateをJSTのYYYY-MM-DD形式に変換できること', () => {
       const result = toJstDateString(new Date('2024-01-01T00:00:00Z'))
-      expect(isSuccess(result)).toBe(true)
-      if (isSuccess(result)) {
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
         expect(result.value).toBe('2024-01-01')
       }
     })
 
     it('無効なDateの場合はfailureを返すこと', () => {
       const result = toJstDateString(new Date('invalid-date'))
-      expect(isFailure(result)).toBe(true)
-      if (isFailure(result)) {
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
         expect(result.error.message).toBe('無効な日付です')
       }
     })
@@ -99,8 +98,8 @@ describe('Common Date Module', () => {
       vi.setSystemTime(new Date('2024-01-01T23:30:00Z'))
 
       const result = toTodayJstDateString()
-      expect(isSuccess(result)).toBe(true)
-      if (isSuccess(result)) {
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
         expect(result.value).toBe('2024-01-02')
       }
     })
@@ -109,8 +108,8 @@ describe('Common Date Module', () => {
   describe('addJstDays', () => {
     it('JST基準で日付加算できること', () => {
       const result = addJstDays('2024-01-01', -1)
-      expect(isSuccess(result)).toBe(true)
-      if (isSuccess(result)) {
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
         expect(result.value).toBe('2023-12-31')
       }
     })
@@ -118,8 +117,8 @@ describe('Common Date Module', () => {
     it('不正な日付文字列の場合はfailureを返し、詳細メッセージを保持すること', () => {
       const invalidInput = 'invalid'
       const result = addJstDays(invalidInput, 1)
-      expect(isFailure(result)).toBe(true)
-      if (isFailure(result)) {
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
         expect(result.error.message).toBe(`不正な日付文字列です: ${invalidInput}`)
       }
     })

--- a/application/src/common/locale/date.ts
+++ b/application/src/common/locale/date.ts
@@ -35,10 +35,10 @@ const getJstDateParts = (
 export const toJstDateString = (rawDate: Date): Result<string, Error> => {
   const jstDatePartsResult = getJstDateParts(rawDate)
   if (isFailure(jstDatePartsResult)) {
-    return jstDatePartsResult
+    return failure(jstDatePartsResult.error)
   }
 
-  const { year, month, day } = jstDatePartsResult.data
+  const { year, month, day } = jstDatePartsResult.value
   return success(`${year}-${month}-${day}`)
 }
 

--- a/application/src/common/locale/date.ts
+++ b/application/src/common/locale/date.ts
@@ -1,5 +1,5 @@
+import { err, ok, type Result } from 'neverthrow'
 import { z } from 'zod'
-import { failure, isFailure, type Result, success } from '@/common/result'
 
 const dateSchema = z.union([z.string().datetime(), z.date()])
 const jstDateFormatter = new Intl.DateTimeFormat('ja-JP', {
@@ -17,7 +17,7 @@ const getJstDateParts = (
   rawDate: Date,
 ): Result<{ year: string; month: string; day: string }, Error> => {
   if (Number.isNaN(rawDate.getTime())) {
-    return failure(new Error('無効な日付です'))
+    return err(new Error('無効な日付です'))
   }
 
   const jstParts = jstDateFormatter.formatToParts(rawDate)
@@ -26,26 +26,26 @@ const getJstDateParts = (
   const day = jstParts.find((part) => part.type === 'day')?.value
 
   if (!year || !month || !day) {
-    return failure(new Error('JST日付の取得に失敗しました'))
+    return err(new Error('JST日付の取得に失敗しました'))
   }
 
-  return success({ year, month, day })
+  return ok({ year, month, day })
 }
 
 export const toJstDateString = (rawDate: Date): Result<string, Error> => {
   const jstDatePartsResult = getJstDateParts(rawDate)
-  if (isFailure(jstDatePartsResult)) {
-    return failure(jstDatePartsResult.error)
+  if (jstDatePartsResult.isErr()) {
+    return err(jstDatePartsResult.error)
   }
 
   const { year, month, day } = jstDatePartsResult.value
-  return success(`${year}-${month}-${day}`)
+  return ok(`${year}-${month}-${day}`)
 }
 
 export const addJstDays = (baseDateString: string, days: number): Result<string, Error> => {
   const baseDate = toJstDate(baseDateString)
   if (Number.isNaN(baseDate.getTime())) {
-    return failure(new Error(`不正な日付文字列です: ${baseDateString}`))
+    return err(new Error(`不正な日付文字列です: ${baseDateString}`))
   }
 
   // +09:00 固定の日時を UTC で日付加算すると、JST の暦日をずらした結果と一致する。

--- a/application/src/common/result/index.test.ts
+++ b/application/src/common/result/index.test.ts
@@ -3,35 +3,45 @@ import { failure, isFailure, isSuccess, success, wrapAsyncCall } from './index'
 
 describe('Result', () => {
   describe('success', () => {
-    it('dataを保持したResultを返すこと', () => {
+    it('valueを保持したOkを返すこと', () => {
       const result = success(42)
-      expect(result.data).toBe(42)
-      expect(result.error).toBeUndefined()
+      expect(result.isOk()).toBe(true)
+      if (isSuccess(result)) {
+        expect(result.value).toBe(42)
+      }
     })
 
-    it('nullをデータとして保持できること', () => {
+    it('nullをvalueとして保持できること', () => {
       const result = success(null)
-      expect(result.data).toBeNull()
+      if (isSuccess(result)) {
+        expect(result.value).toBeNull()
+      }
     })
 
-    it('オブジェクトをデータとして保持できること', () => {
+    it('オブジェクトをvalueとして保持できること', () => {
       const value = { id: 1, name: 'test' }
       const result = success(value)
-      expect(result.data).toEqual(value)
+      if (isSuccess(result)) {
+        expect(result.value).toEqual(value)
+      }
     })
   })
 
   describe('failure', () => {
-    it('errorを保持したResultを返すこと', () => {
+    it('errorを保持したErrを返すこと', () => {
       const error = new Error('something went wrong')
       const result = failure(error)
-      expect(result.error).toBe(error)
-      expect(result.data).toBeUndefined()
+      expect(result.isErr()).toBe(true)
+      if (isFailure(result)) {
+        expect(result.error).toBe(error)
+      }
     })
 
     it('Error以外のエラー値も保持できること', () => {
       const result = failure('error string')
-      expect(result.error).toBe('error string')
+      if (isFailure(result)) {
+        expect(result.error).toBe('error string')
+      }
     })
   })
 
@@ -44,10 +54,10 @@ describe('Result', () => {
       expect(isSuccess(failure(new Error('e')))).toBe(false)
     })
 
-    it('型ガードとしてdataにアクセスできること', () => {
+    it('型ガードとしてvalueにアクセスできること', () => {
       const result = success('value')
       if (isSuccess(result)) {
-        expect(result.data).toBe('value')
+        expect(result.value).toBe('value')
       }
     })
   })
@@ -75,7 +85,7 @@ describe('Result', () => {
       const result = await wrapAsyncCall(async () => 'ok')
       expect(isSuccess(result)).toBe(true)
       if (isSuccess(result)) {
-        expect(result.data).toBe('ok')
+        expect(result.value).toBe('ok')
       }
     })
 

--- a/application/src/common/result/index.test.ts
+++ b/application/src/common/result/index.test.ts
@@ -1,162 +1,82 @@
 import { describe, expect, it } from 'vitest'
-import { failure, isFailure, isSuccess, success, wrapAsyncCall } from './index'
+import { wrapAsyncCall } from './index'
 
-describe('Result', () => {
-  describe('success', () => {
-    it('valueを保持したOkを返すこと', () => {
-      const result = success(42)
-      expect(result.isOk()).toBe(true)
-      if (isSuccess(result)) {
-        expect(result.value).toBe(42)
-      }
-    })
-
-    it('nullをvalueとして保持できること', () => {
-      const result = success(null)
-      if (isSuccess(result)) {
-        expect(result.value).toBeNull()
-      }
-    })
-
-    it('オブジェクトをvalueとして保持できること', () => {
-      const value = { id: 1, name: 'test' }
-      const result = success(value)
-      if (isSuccess(result)) {
-        expect(result.value).toEqual(value)
-      }
-    })
+describe('wrapAsyncCall', () => {
+  it('正常終了時はokを返すこと', async () => {
+    const result = await wrapAsyncCall(async () => 'ok')
+    expect(result.isOk()).toBe(true)
+    if (result.isOk()) {
+      expect(result.value).toBe('ok')
+    }
   })
 
-  describe('failure', () => {
-    it('errorを保持したErrを返すこと', () => {
-      const error = new Error('something went wrong')
-      const result = failure(error)
-      expect(result.isErr()).toBe(true)
-      if (isFailure(result)) {
-        expect(result.error).toBe(error)
-      }
+  it('Errorが投げられた場合はそのErrorを保持したerrを返すこと', async () => {
+    const error = new Error('boom')
+    const result = await wrapAsyncCall(async () => {
+      throw error
     })
-
-    it('Error以外のエラー値も保持できること', () => {
-      const result = failure('error string')
-      if (isFailure(result)) {
-        expect(result.error).toBe('error string')
-      }
-    })
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error).toBe(error)
+    }
   })
 
-  describe('isSuccess', () => {
-    it('successで生成されたResultに対してtrueを返すこと', () => {
-      expect(isSuccess(success(1))).toBe(true)
+  it('Error以外が投げられた場合はErrorにラップしてerrを返すこと', async () => {
+    const result = await wrapAsyncCall(async () => {
+      throw 'string error'
     })
-
-    it('failureで生成されたResultに対してfalseを返すこと', () => {
-      expect(isSuccess(failure(new Error('e')))).toBe(false)
-    })
-
-    it('型ガードとしてvalueにアクセスできること', () => {
-      const result = success('value')
-      if (isSuccess(result)) {
-        expect(result.value).toBe('value')
-      }
-    })
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error).toBeInstanceOf(Error)
+      expect(result.error.message).toBe('string error')
+    }
   })
 
-  describe('isFailure', () => {
-    it('failureで生成されたResultに対してtrueを返すこと', () => {
-      expect(isFailure(failure(new Error('e')))).toBe(true)
+  it('同期的に投げられた例外もerrとして扱うこと', async () => {
+    const result = await wrapAsyncCall(() => {
+      throw new Error('sync throw')
     })
-
-    it('successで生成されたResultに対してfalseを返すこと', () => {
-      expect(isFailure(success(1))).toBe(false)
-    })
-
-    it('型ガードとしてerrorにアクセスできること', () => {
-      const error = new Error('e')
-      const result = failure(error)
-      if (isFailure(result)) {
-        expect(result.error).toBe(error)
-      }
-    })
+    expect(result.isErr()).toBe(true)
+    if (result.isErr()) {
+      expect(result.error.message).toBe('sync throw')
+    }
   })
 
-  describe('wrapAsyncCall', () => {
-    it('正常終了時はsuccessを返すこと', async () => {
-      const result = await wrapAsyncCall(async () => 'ok')
-      expect(isSuccess(result)).toBe(true)
-      if (isSuccess(result)) {
-        expect(result.value).toBe('ok')
-      }
-    })
+  it('cleanupは成功時に呼ばれること', async () => {
+    let cleanedUp = false
+    const result = await wrapAsyncCall(
+      async () => 'ok',
+      () => {
+        cleanedUp = true
+      },
+    )
+    expect(result.isOk()).toBe(true)
+    expect(cleanedUp).toBe(true)
+  })
 
-    it('Errorが投げられた場合はそのErrorを保持したfailureを返すこと', async () => {
-      const error = new Error('boom')
-      const result = await wrapAsyncCall(async () => {
-        throw error
-      })
-      expect(isFailure(result)).toBe(true)
-      if (isFailure(result)) {
-        expect(result.error).toBe(error)
-      }
-    })
+  it('cleanupは失敗時にも呼ばれること', async () => {
+    let cleanedUp = false
+    const result = await wrapAsyncCall(
+      async () => {
+        throw new Error('boom')
+      },
+      () => {
+        cleanedUp = true
+      },
+    )
+    expect(result.isErr()).toBe(true)
+    expect(cleanedUp).toBe(true)
+  })
 
-    it('Error以外が投げられた場合はErrorにラップしてfailureを返すこと', async () => {
-      const result = await wrapAsyncCall(async () => {
-        throw 'string error'
-      })
-      expect(isFailure(result)).toBe(true)
-      if (isFailure(result)) {
-        expect(result.error).toBeInstanceOf(Error)
-        expect(result.error.message).toBe('string error')
-      }
-    })
-
-    it('同期的に投げられた例外もfailureとして扱うこと', async () => {
-      const result = await wrapAsyncCall(() => {
-        throw new Error('sync throw')
-      })
-      expect(isFailure(result)).toBe(true)
-      if (isFailure(result)) {
-        expect(result.error.message).toBe('sync throw')
-      }
-    })
-
-    it('cleanupは成功時に呼ばれること', async () => {
-      let cleanedUp = false
-      const result = await wrapAsyncCall(
-        async () => 'ok',
-        () => {
-          cleanedUp = true
-        },
-      )
-      expect(isSuccess(result)).toBe(true)
-      expect(cleanedUp).toBe(true)
-    })
-
-    it('cleanupは失敗時にも呼ばれること', async () => {
-      let cleanedUp = false
-      const result = await wrapAsyncCall(
-        async () => {
-          throw new Error('boom')
-        },
-        () => {
-          cleanedUp = true
-        },
-      )
-      expect(isFailure(result)).toBe(true)
-      expect(cleanedUp).toBe(true)
-    })
-
-    it('非同期cleanupの完了を待つこと', async () => {
-      let cleanedUp = false
-      await wrapAsyncCall(
-        async () => 'ok',
-        async () => {
-          await new Promise((resolve) => setTimeout(resolve, 1))
-          cleanedUp = true
-        },
-      )
-      expect(cleanedUp).toBe(true)
-    })
+  it('非同期cleanupの完了を待つこと', async () => {
+    let cleanedUp = false
+    await wrapAsyncCall(
+      async () => 'ok',
+      async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1))
+        cleanedUp = true
+      },
+    )
+    expect(cleanedUp).toBe(true)
   })
 })

--- a/application/src/common/result/index.ts
+++ b/application/src/common/result/index.ts
@@ -1,27 +1,25 @@
-type Success<T> = { data: T; error?: never }
-type Failure<E> = { data?: never; error: E }
+import { type Err, err, type Result as NeverthrowResult, type Ok, ok } from 'neverthrow'
 
-export type Result<T, E> = Success<T> | Failure<E>
+export type { Err, Ok }
+export type Result<T, E> = NeverthrowResult<T, E>
 export type AsyncResult<T, E> = Promise<Result<T, E>>
 
-export const success = <T>(data: T): Result<T, never> => ({ data })
+export const success = ok
 
-export const failure = <E>(error: E): Result<never, E> => ({ error })
+export const failure = err
 
-export const isSuccess = <T, E>(result: Result<T, E>): result is Success<T> =>
-  result.error === undefined
+export const isSuccess = <T, E>(result: Result<T, E>): result is Ok<T, E> => result.isOk()
 
-export const isFailure = <T, E>(result: Result<T, E>): result is Failure<E> =>
-  result.error !== undefined
+export const isFailure = <T, E>(result: Result<T, E>): result is Err<T, E> => result.isErr()
 
 export const wrapAsyncCall = async <T>(
   fn: () => Promise<T>,
   cleanup?: () => unknown | Promise<unknown>,
 ): AsyncResult<T, Error> => {
   try {
-    return success(await fn())
+    return ok(await fn())
   } catch (e) {
-    return failure(e instanceof Error ? e : new Error(String(e)))
+    return err(e instanceof Error ? e : new Error(String(e)))
   } finally {
     if (cleanup) await cleanup()
   }

--- a/application/src/common/result/index.ts
+++ b/application/src/common/result/index.ts
@@ -1,21 +1,9 @@
-import { type Err, err, type Result as NeverthrowResult, type Ok, ok } from 'neverthrow'
-
-export type { Err, Ok }
-export type Result<T, E> = NeverthrowResult<T, E>
-export type AsyncResult<T, E> = Promise<Result<T, E>>
-
-export const success = ok
-
-export const failure = err
-
-export const isSuccess = <T, E>(result: Result<T, E>): result is Ok<T, E> => result.isOk()
-
-export const isFailure = <T, E>(result: Result<T, E>): result is Err<T, E> => result.isErr()
+import { err, ok, type Result } from 'neverthrow'
 
 export const wrapAsyncCall = async <T>(
   fn: () => Promise<T>,
   cleanup?: () => unknown | Promise<unknown>,
-): AsyncResult<T, Error> => {
+): Promise<Result<T, Error>> => {
   try {
     return ok(await fn())
   } catch (e) {

--- a/application/src/cron/fetch-articles.ts
+++ b/application/src/cron/fetch-articles.ts
@@ -1,5 +1,5 @@
 import Parser from 'rss-parser'
-import { isFailure, wrapAsyncCall } from '@/common/result'
+import { wrapAsyncCall } from '@/common/result'
 import type { ArticleMedia } from '@/domain/article/media'
 import getRdbClient from '@/infrastructure/rdb'
 
@@ -105,7 +105,7 @@ async function storeArticles(media: ArticleMedia, items: FeedItem[], env: CronEn
     },
     () => db.$disconnect(),
   )
-  if (isFailure(result)) {
+  if (result.isErr()) {
     throw result.error
   }
   return result.value

--- a/application/src/cron/fetch-articles.ts
+++ b/application/src/cron/fetch-articles.ts
@@ -108,7 +108,7 @@ async function storeArticles(media: ArticleMedia, items: FeedItem[], env: CronEn
   if (isFailure(result)) {
     throw result.error
   }
-  return result.data
+  return result.value
 }
 
 function isUniqueConstraintError(error: unknown): boolean {

--- a/application/src/domain/article/infrastructure/command-impl.test.ts
+++ b/application/src/domain/article/infrastructure/command-impl.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { isFailure, isSuccess } from '@/common/result'
 import mockDb from '@/test/__mocks__/prisma'
 import CommandImpl from './command-impl'
 
@@ -28,8 +27,8 @@ describe('CommandImpl', () => {
       expect(mockDb.readHistory.create).toHaveBeenCalledWith({
         data: { activeUserId: 1, articleId: 100, readAt },
       })
-      expect(isSuccess(result)).toBe(true)
-      if (isSuccess(result)) {
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
         expect(result.value.readHistoryId).toBe(10n)
         expect(result.value.activeUserId).toBe(1n)
         expect(result.value.articleId).toBe(100n)
@@ -47,8 +46,8 @@ describe('CommandImpl', () => {
           new Date('2024-01-15T09:30:00Z'),
         )
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error.message).toBe(errorMessage)
         }
       },
@@ -79,8 +78,8 @@ describe('CommandImpl', () => {
           articleId: 100,
         },
       })
-      expect(isSuccess(result)).toBe(true)
-      if (isSuccess(result)) {
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
         expect(result.value.skippedArticleId).toBe(10n)
         expect(result.value.activeUserId).toBe(1n)
         expect(result.value.articleId).toBe(100n)
@@ -94,8 +93,8 @@ describe('CommandImpl', () => {
 
         const result = await commandImpl.createSkippedArticle(1n, 100n)
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error.message).toBe(errorMessage)
         }
       },
@@ -111,7 +110,7 @@ describe('CommandImpl', () => {
       expect(mockDb.readHistory.deleteMany).toHaveBeenCalledWith({
         where: { activeUserId: 2, articleId: 200 },
       })
-      expect(isSuccess(result)).toBe(true)
+      expect(result.isOk()).toBe(true)
     })
 
     it.each([{ errorMessage: 'Database connection failed' }])(
@@ -121,8 +120,8 @@ describe('CommandImpl', () => {
 
         const result = await commandImpl.deleteAllReadHistory(1n, 100n)
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error.message).toBe(errorMessage)
         }
       },

--- a/application/src/domain/article/infrastructure/command-impl.test.ts
+++ b/application/src/domain/article/infrastructure/command-impl.test.ts
@@ -30,9 +30,9 @@ describe('CommandImpl', () => {
       })
       expect(isSuccess(result)).toBe(true)
       if (isSuccess(result)) {
-        expect(result.data.readHistoryId).toBe(10n)
-        expect(result.data.activeUserId).toBe(1n)
-        expect(result.data.articleId).toBe(100n)
+        expect(result.value.readHistoryId).toBe(10n)
+        expect(result.value.activeUserId).toBe(1n)
+        expect(result.value.articleId).toBe(100n)
       }
     })
 
@@ -81,9 +81,9 @@ describe('CommandImpl', () => {
       })
       expect(isSuccess(result)).toBe(true)
       if (isSuccess(result)) {
-        expect(result.data.skippedArticleId).toBe(10n)
-        expect(result.data.activeUserId).toBe(1n)
-        expect(result.data.articleId).toBe(100n)
+        expect(result.value.skippedArticleId).toBe(10n)
+        expect(result.value.activeUserId).toBe(1n)
+        expect(result.value.articleId).toBe(100n)
       }
     })
 

--- a/application/src/domain/article/infrastructure/command-impl.ts
+++ b/application/src/domain/article/infrastructure/command-impl.ts
@@ -29,7 +29,7 @@ export default class CommandImpl implements Command {
       return failure(new ServerError(result.error))
     }
 
-    const createdReadHistory = result.data
+    const createdReadHistory = result.value
     const readHistory: ReadHistory = {
       readHistoryId: fromDbId(createdReadHistory.readHistoryId),
       activeUserId: fromDbId(createdReadHistory.activeUserId),
@@ -84,7 +84,7 @@ export default class CommandImpl implements Command {
       return failure(new ServerError(result.error))
     }
 
-    const skippedArticle = result.data
+    const skippedArticle = result.value
     return success({
       skippedArticleId: fromDbId(skippedArticle.skippedArticleId),
       activeUserId: fromDbId(skippedArticle.activeUserId),

--- a/application/src/domain/article/infrastructure/command-impl.ts
+++ b/application/src/domain/article/infrastructure/command-impl.ts
@@ -1,5 +1,6 @@
+import { err, ok, type Result } from 'neverthrow'
 import { ServerError } from '@/common/errors'
-import { AsyncResult, failure, isFailure, success, wrapAsyncCall } from '@/common/result'
+import { wrapAsyncCall } from '@/common/result'
 import { Command } from '@/domain/article/repository'
 import type { ReadHistory } from '@/domain/article/schema/read-history-schema'
 import type { SkippedArticle } from '@/domain/article/schema/skipped-article-schema'
@@ -13,7 +14,7 @@ export default class CommandImpl implements Command {
     activeUserId: bigint,
     articleId: bigint,
     readAt: Date,
-  ): AsyncResult<ReadHistory, Error> {
+  ): Promise<Result<ReadHistory, Error>> {
     const dbActiveUserId = toDbId(activeUserId)
     const dbArticleId = toDbId(articleId)
     const result = await wrapAsyncCall(() =>
@@ -25,8 +26,8 @@ export default class CommandImpl implements Command {
         },
       }),
     )
-    if (isFailure(result)) {
-      return failure(new ServerError(result.error))
+    if (result.isErr()) {
+      return err(new ServerError(result.error))
     }
 
     const createdReadHistory = result.value
@@ -37,10 +38,13 @@ export default class CommandImpl implements Command {
       readAt: createdReadHistory.readAt,
       createdAt: createdReadHistory.createdAt,
     }
-    return success(readHistory)
+    return ok(readHistory)
   }
 
-  async deleteAllReadHistory(activeUserId: bigint, articleId: bigint): AsyncResult<void, Error> {
+  async deleteAllReadHistory(
+    activeUserId: bigint,
+    articleId: bigint,
+  ): Promise<Result<void, Error>> {
     const dbActiveUserId = toDbId(activeUserId)
     const dbArticleId = toDbId(articleId)
     const result = await wrapAsyncCall(() =>
@@ -51,17 +55,17 @@ export default class CommandImpl implements Command {
         },
       }),
     )
-    if (isFailure(result)) {
-      return failure(new ServerError(result.error))
+    if (result.isErr()) {
+      return err(new ServerError(result.error))
     }
 
-    return success(undefined)
+    return ok(undefined)
   }
 
   async createSkippedArticle(
     activeUserId: bigint,
     articleId: bigint,
-  ): AsyncResult<SkippedArticle, Error> {
+  ): Promise<Result<SkippedArticle, Error>> {
     const dbActiveUserId = toDbId(activeUserId)
     const dbArticleId = toDbId(articleId)
 
@@ -80,12 +84,12 @@ export default class CommandImpl implements Command {
         },
       }),
     )
-    if (isFailure(result)) {
-      return failure(new ServerError(result.error))
+    if (result.isErr()) {
+      return err(new ServerError(result.error))
     }
 
     const skippedArticle = result.value
-    return success({
+    return ok({
       skippedArticleId: fromDbId(skippedArticle.skippedArticleId),
       activeUserId: fromDbId(skippedArticle.activeUserId),
       articleId: fromDbId(skippedArticle.articleId),

--- a/application/src/domain/article/infrastructure/query-impl.test.ts
+++ b/application/src/domain/article/infrastructure/query-impl.test.ts
@@ -63,9 +63,9 @@ describe('QueryImpl', () => {
 
       expect(isSuccess(result)).toBe(true)
       if (isSuccess(result)) {
-        expect(result.data.total).toBe(2)
-        expect(result.data.data).toHaveLength(2)
-        expect(result.data.data[0].isRead).toBeUndefined()
+        expect(result.value.total).toBe(2)
+        expect(result.value.data).toHaveLength(2)
+        expect(result.value.data[0].isRead).toBeUndefined()
       }
     })
 
@@ -97,8 +97,8 @@ describe('QueryImpl', () => {
 
       expect(isSuccess(result)).toBe(true)
       if (isSuccess(result)) {
-        expect(result.data.data[0].isRead).toBe(true)
-        expect(result.data.data[1].isRead).toBe(false)
+        expect(result.value.data[0].isRead).toBe(true)
+        expect(result.value.data[1].isRead).toBe(false)
       }
     })
 
@@ -160,10 +160,10 @@ describe('QueryImpl', () => {
       expect(mockDb.$queryRaw).toHaveBeenCalledTimes(2)
 
       if (isSuccess(result)) {
-        expect(result.data.total).toBe(2)
-        expect(result.data.data).toHaveLength(2)
-        expect(result.data.data[0].title).toBe('対象記事1')
-        expect(result.data.data[1].title).toBe('対象記事2')
+        expect(result.value.total).toBe(2)
+        expect(result.value.data).toHaveLength(2)
+        expect(result.value.data[0].title).toBe('対象記事1')
+        expect(result.value.data[1].title).toBe('対象記事2')
       }
     })
   })
@@ -176,7 +176,7 @@ describe('QueryImpl', () => {
 
       expect(isSuccess(result)).toBe(true)
       if (isSuccess(result)) {
-        expect(result.data?.articleId).toBe(1n)
+        expect(result.value?.articleId).toBe(1n)
       }
     })
   })
@@ -218,10 +218,10 @@ describe('QueryImpl', () => {
 
       expect(isSuccess(result)).toBe(true)
       if (isSuccess(result)) {
-        expect(result.data).toHaveLength(1)
-        expect(result.data[0].articleId).toBe(1n)
-        expect(result.data[0].title).toBe('未読消化対象')
-        expect(result.data[0].createdAt.toISOString()).toBe(expectedIso)
+        expect(result.value).toHaveLength(1)
+        expect(result.value[0].articleId).toBe(1n)
+        expect(result.value[0].title).toBe('未読消化対象')
+        expect(result.value[0].createdAt.toISOString()).toBe(expectedIso)
       }
     })
 
@@ -270,17 +270,17 @@ describe('QueryImpl', () => {
       expect(isSuccess(result)).toBe(true)
       expect(mockDb.$queryRaw).toHaveBeenCalledTimes(2)
       if (isSuccess(result)) {
-        expect(result.data.summary).toEqual({ read: 3, skip: 2 })
-        expect(result.data.sources).toEqual([
+        expect(result.value.summary).toEqual({ read: 3, skip: 2 })
+        expect(result.value.sources).toEqual([
           { media: 'qiita', read: 2, skip: 1 },
           { media: 'zenn', read: 1, skip: 0 },
           { media: 'hatena', read: 0, skip: 1 },
         ])
-        expect(result.data.reads.total).toBe(3)
-        expect(result.data.reads.data).toHaveLength(2)
-        expect(result.data.reads.data[0].readHistoryId).toBe(10n)
-        expect(result.data.reads.data[0].url).toBe('https://example.com/go-error-handling')
-        expect(result.data.reads.data[1].readHistoryId).toBe(9n)
+        expect(result.value.reads.total).toBe(3)
+        expect(result.value.reads.data).toHaveLength(2)
+        expect(result.value.reads.data[0].readHistoryId).toBe(10n)
+        expect(result.value.reads.data[0].url).toBe('https://example.com/go-error-handling')
+        expect(result.value.reads.data[1].readHistoryId).toBe(9n)
       }
     })
 
@@ -309,7 +309,7 @@ describe('QueryImpl', () => {
       expect(isSuccess(result)).toBe(true)
       expect(mockDb.$queryRaw).toHaveBeenCalledTimes(1)
       if (isSuccess(result)) {
-        expect(result.data).toEqual([
+        expect(result.value).toEqual([
           {
             date: '2026-03-06',
             summary: { read: 2, skip: 0 },

--- a/application/src/domain/article/infrastructure/query-impl.test.ts
+++ b/application/src/domain/article/infrastructure/query-impl.test.ts
@@ -1,6 +1,5 @@
 import { Article as PrismaArticle } from '@prisma/client'
 import { beforeEach, describe, expect, it } from 'vitest'
-import { isFailure, isSuccess } from '@/common/result'
 import mockDb from '@/test/__mocks__/prisma'
 import QueryImpl from './query-impl'
 
@@ -61,8 +60,8 @@ describe('QueryImpl', () => {
 
       const result = await queryImpl.searchArticles({ page: 1, limit: 20 })
 
-      expect(isSuccess(result)).toBe(true)
-      if (isSuccess(result)) {
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
         expect(result.value.total).toBe(2)
         expect(result.value.data).toHaveLength(2)
         expect(result.value.data[0].isRead).toBeUndefined()
@@ -95,8 +94,8 @@ describe('QueryImpl', () => {
 
       const result = await queryImpl.searchArticles({ page: 1, limit: 20 }, 10n)
 
-      expect(isSuccess(result)).toBe(true)
-      if (isSuccess(result)) {
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
         expect(result.value.data[0].isRead).toBe(true)
         expect(result.value.data[1].isRead).toBe(false)
       }
@@ -107,7 +106,7 @@ describe('QueryImpl', () => {
 
       const result = await queryImpl.searchArticles({ page: 1, limit: 20 }, 10n)
 
-      expect(isSuccess(result)).toBe(true)
+      expect(result.isOk()).toBe(true)
       expect(mockDb.$queryRaw).toHaveBeenCalledTimes(2)
       const rawSql = mockDb.$queryRaw.mock.calls[0]?.[0] as { strings?: string[] }
       const joinedSql = rawSql?.strings?.join(' ') ?? ''
@@ -119,8 +118,8 @@ describe('QueryImpl', () => {
 
       const result = await queryImpl.searchArticles({ page: 1, limit: 20 })
 
-      expect(isFailure(result)).toBe(true)
-      if (isFailure(result)) {
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
         expect(result.error.message).toBe('count failed')
       }
     })
@@ -154,12 +153,12 @@ describe('QueryImpl', () => {
         to: '2026-03-05',
       })
 
-      expect(isSuccess(result)).toBe(true)
+      expect(result.isOk()).toBe(true)
       expect(mockDb.article.count).not.toHaveBeenCalled()
       expect(mockDb.article.findMany).not.toHaveBeenCalled()
       expect(mockDb.$queryRaw).toHaveBeenCalledTimes(2)
 
-      if (isSuccess(result)) {
+      if (result.isOk()) {
         expect(result.value.total).toBe(2)
         expect(result.value.data).toHaveLength(2)
         expect(result.value.data[0].title).toBe('対象記事1')
@@ -174,8 +173,8 @@ describe('QueryImpl', () => {
 
       const result = await queryImpl.findArticleById(1n)
 
-      expect(isSuccess(result)).toBe(true)
-      if (isSuccess(result)) {
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
         expect(result.value?.articleId).toBe(1n)
       }
     })
@@ -216,8 +215,8 @@ describe('QueryImpl', () => {
 
       const result = await queryImpl.getUnreadDigestionArticles(10n, '2026-03-07', media)
 
-      expect(isSuccess(result)).toBe(true)
-      if (isSuccess(result)) {
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
         expect(result.value).toHaveLength(1)
         expect(result.value[0].articleId).toBe(1n)
         expect(result.value[0].title).toBe('未読消化対象')
@@ -230,8 +229,8 @@ describe('QueryImpl', () => {
 
       const result = await queryImpl.getUnreadDigestionArticles(10n, '2026-03-07')
 
-      expect(isFailure(result)).toBe(true)
-      if (isFailure(result)) {
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
         expect(result.error.message).toBe('unread digestion failed')
       }
     })
@@ -267,9 +266,9 @@ describe('QueryImpl', () => {
 
       const result = await queryImpl.getDailyDiary(10n, '2026-03-07', 1, 10)
 
-      expect(isSuccess(result)).toBe(true)
+      expect(result.isOk()).toBe(true)
       expect(mockDb.$queryRaw).toHaveBeenCalledTimes(2)
-      if (isSuccess(result)) {
+      if (result.isOk()) {
         expect(result.value.summary).toEqual({ read: 3, skip: 2 })
         expect(result.value.sources).toEqual([
           { media: 'qiita', read: 2, skip: 1 },
@@ -289,8 +288,8 @@ describe('QueryImpl', () => {
 
       const result = await queryImpl.getDailyDiary(10n, '2026-03-07', 1, 10)
 
-      expect(isFailure(result)).toBe(true)
-      if (isFailure(result)) {
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
         expect(result.error.message).toBe('daily diary failed')
       }
     })
@@ -306,9 +305,9 @@ describe('QueryImpl', () => {
 
       const result = await queryImpl.getDailyDiaryRange(10n, '2026-03-06', '2026-03-07')
 
-      expect(isSuccess(result)).toBe(true)
+      expect(result.isOk()).toBe(true)
       expect(mockDb.$queryRaw).toHaveBeenCalledTimes(1)
-      if (isSuccess(result)) {
+      if (result.isOk()) {
         expect(result.value).toEqual([
           {
             date: '2026-03-06',
@@ -337,8 +336,8 @@ describe('QueryImpl', () => {
 
       const result = await queryImpl.getDailyDiaryRange(10n, '2026-03-06', '2026-03-07')
 
-      expect(isFailure(result)).toBe(true)
-      if (isFailure(result)) {
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
         expect(result.error.message).toBe('daily diary range failed')
       }
     })

--- a/application/src/domain/article/infrastructure/query-impl.ts
+++ b/application/src/domain/article/infrastructure/query-impl.ts
@@ -133,8 +133,8 @@ export default class QueryImpl implements Query {
       return failure(new ServerError(articlesResult.error))
     }
 
-    const total = Number(totalResult.data[0]?.total ?? 0)
-    const mappedArticles = articlesResult.data.map(QueryImpl.mapRawArticleToDomain)
+    const total = Number(totalResult.value[0]?.total ?? 0)
+    const mappedArticles = articlesResult.value.map(QueryImpl.mapRawArticleToDomain)
 
     const totalPages = Math.ceil(total / limit)
     return success({
@@ -159,7 +159,7 @@ export default class QueryImpl implements Query {
       return failure(new ServerError(result.error))
     }
 
-    const article = result.data
+    const article = result.value
     if (!article) return success(null)
     return success(fromPrismaToArticle(article))
   }
@@ -207,7 +207,7 @@ export default class QueryImpl implements Query {
       return failure(new ServerError(result.error))
     }
 
-    return success(result.data.map(QueryImpl.mapRawArticle))
+    return success(result.value.map(QueryImpl.mapRawArticle))
   }
 
   async getDailyDiary(
@@ -289,7 +289,7 @@ export default class QueryImpl implements Query {
       return failure(resolvedQueryResults.error)
     }
 
-    const [sourceRows, readsRows] = resolvedQueryResults.data
+    const [sourceRows, readsRows] = resolvedQueryResults.value
     const { readRows: readSourcesRows, skipRows: skipSourcesRows } =
       QueryImpl.splitDiarySourceRows(sourceRows)
     const readCount = QueryImpl.sumDiarySourceCounts(readSourcesRows)
@@ -376,7 +376,7 @@ export default class QueryImpl implements Query {
       return failure(new ServerError(sourceResult.error))
     }
     const { readRows: readSourceRows, skipRows: skipSourceRows } =
-      QueryImpl.splitDiaryDateSourceRows(sourceResult.data)
+      QueryImpl.splitDiaryDateSourceRows(sourceResult.value)
 
     const readByDate = QueryImpl.groupSourcesByDate(readSourceRows)
     const skipByDate = QueryImpl.groupSourcesByDate(skipSourceRows)
@@ -489,7 +489,7 @@ export default class QueryImpl implements Query {
       if (isFailure(result)) {
         return failure(new ServerError(result.error))
       }
-      unwrapped.push(result.data)
+      unwrapped.push(result.value)
     }
 
     return success(unwrapped as unknown as T)
@@ -666,7 +666,7 @@ export default class QueryImpl implements Query {
       dates.push(current)
       const next = addJstDays(current, 1)
       if (isFailure(next)) break
-      current = next.data
+      current = next.value
     }
     return dates
   }

--- a/application/src/domain/article/infrastructure/query-impl.ts
+++ b/application/src/domain/article/infrastructure/query-impl.ts
@@ -1,15 +1,9 @@
 import { Prisma } from '@prisma/client'
+import { err, ok, type Result } from 'neverthrow'
 import { ServerError } from '@/common/errors'
 import { addJstDays, toJstDate } from '@/common/locale/date'
 import { DEFAULT_LIMIT, DEFAULT_PAGE, OffsetPaginationResult } from '@/common/pagination'
-import {
-  type AsyncResult,
-  failure,
-  isFailure,
-  type Result,
-  success,
-  wrapAsyncCall,
-} from '@/common/result'
+import { wrapAsyncCall } from '@/common/result'
 import { Nullable } from '@/common/types/utility'
 import fromPrismaToArticle from '@/domain/article/infrastructure/mapper'
 import { ARTICLE_MEDIA, type ArticleMedia } from '@/domain/article/media'
@@ -85,7 +79,7 @@ export default class QueryImpl implements Query {
   async searchArticles(
     params: QueryParams,
     activeUserId?: bigint,
-  ): AsyncResult<OffsetPaginationResult<ArticleWithOptionalReadStatus>, ServerError> {
+  ): Promise<Result<OffsetPaginationResult<ArticleWithOptionalReadStatus>, ServerError>> {
     const { page = DEFAULT_PAGE, limit = DEFAULT_LIMIT, from, to, ...searchParams } = params
     const dbActiveUserId = activeUserId !== undefined ? toDbId(activeUserId) : undefined
     const whereSql = QueryImpl.buildSqlWhereClause({
@@ -105,8 +99,8 @@ export default class QueryImpl implements Query {
         ${whereSql}
       `),
     )
-    if (isFailure(totalResult)) {
-      return failure(new ServerError(totalResult.error))
+    if (totalResult.isErr()) {
+      return err(new ServerError(totalResult.error))
     }
 
     const readStatusSql = QueryImpl.buildIsReadSelectSql(dbActiveUserId)
@@ -129,15 +123,15 @@ export default class QueryImpl implements Query {
         OFFSET ${(page - 1) * limit}
       `),
     )
-    if (isFailure(articlesResult)) {
-      return failure(new ServerError(articlesResult.error))
+    if (articlesResult.isErr()) {
+      return err(new ServerError(articlesResult.error))
     }
 
     const total = Number(totalResult.value[0]?.total ?? 0)
     const mappedArticles = articlesResult.value.map(QueryImpl.mapRawArticleToDomain)
 
     const totalPages = Math.ceil(total / limit)
-    return success({
+    return ok({
       data: mappedArticles,
       page,
       limit,
@@ -148,27 +142,27 @@ export default class QueryImpl implements Query {
     })
   }
 
-  async findArticleById(articleId: bigint): AsyncResult<Nullable<Article>, ServerError> {
+  async findArticleById(articleId: bigint): Promise<Result<Nullable<Article>, ServerError>> {
     const dbArticleId = toDbId(articleId)
     const result = await wrapAsyncCall(() =>
       this.db.article.findUnique({
         where: { articleId: dbArticleId },
       }),
     )
-    if (isFailure(result)) {
-      return failure(new ServerError(result.error))
+    if (result.isErr()) {
+      return err(new ServerError(result.error))
     }
 
     const article = result.value
-    if (!article) return success(null)
-    return success(fromPrismaToArticle(article))
+    if (!article) return ok(null)
+    return ok(fromPrismaToArticle(article))
   }
 
   async getUnreadDigestionArticles(
     activeUserId: bigint,
     targetDateJst: string,
     media?: ArticleMedia,
-  ): AsyncResult<Article[], ServerError> {
+  ): Promise<Result<Article[], ServerError>> {
     const dbActiveUserId = toDbId(activeUserId)
     const { fromDate, toDateExclusive } = QueryImpl.buildDateRange(targetDateJst, targetDateJst)
     const createdAtRangeSql = QueryImpl.buildClosedOpenDateRangeSql(
@@ -203,11 +197,11 @@ export default class QueryImpl implements Query {
         ORDER BY ${QueryImpl.getNormalizedDateTimeSql('created_at')} DESC, article_id DESC
       `),
     )
-    if (isFailure(result)) {
-      return failure(new ServerError(result.error))
+    if (result.isErr()) {
+      return err(new ServerError(result.error))
     }
 
-    return success(result.value.map(QueryImpl.mapRawArticle))
+    return ok(result.value.map(QueryImpl.mapRawArticle))
   }
 
   async getDailyDiary(
@@ -215,7 +209,7 @@ export default class QueryImpl implements Query {
     targetDateJst: string,
     page: number,
     limit: number,
-  ): AsyncResult<DailyDiary, ServerError> {
+  ): Promise<Result<DailyDiary, ServerError>> {
     const dbActiveUserId = toDbId(activeUserId)
     const { fromDate, toDateExclusive } = QueryImpl.buildDateRange(targetDateJst, targetDateJst)
     const readAtRangeSql = QueryImpl.buildClosedOpenDateRangeSql(
@@ -285,8 +279,8 @@ export default class QueryImpl implements Query {
       ),
     ])
     const resolvedQueryResults = QueryImpl.unwrapResultTuple(queryResultTuple)
-    if (isFailure(resolvedQueryResults)) {
-      return failure(resolvedQueryResults.error)
+    if (resolvedQueryResults.isErr()) {
+      return err(resolvedQueryResults.error)
     }
 
     const [sourceRows, readsRows] = resolvedQueryResults.value
@@ -297,7 +291,7 @@ export default class QueryImpl implements Query {
     const readsTotal = readCount
     const totalPages = Math.ceil(readsTotal / limit)
 
-    return success({
+    return ok({
       date: targetDateJst,
       summary: {
         read: readCount,
@@ -320,7 +314,7 @@ export default class QueryImpl implements Query {
     activeUserId: bigint,
     fromDateJst: string,
     toDateJst: string,
-  ): AsyncResult<DailyDiaryRangeItem[], ServerError> {
+  ): Promise<Result<DailyDiaryRangeItem[], ServerError>> {
     const dbActiveUserId = toDbId(activeUserId)
     const { fromDate, toDateExclusive } = QueryImpl.buildDateRange(fromDateJst, toDateJst)
     const readAtRangeSql = QueryImpl.buildClosedOpenDateRangeSql(
@@ -372,8 +366,8 @@ export default class QueryImpl implements Query {
         ) diary_date_sources
       `),
     )
-    if (isFailure(sourceResult)) {
-      return failure(new ServerError(sourceResult.error))
+    if (sourceResult.isErr()) {
+      return err(new ServerError(sourceResult.error))
     }
     const { readRows: readSourceRows, skipRows: skipSourceRows } =
       QueryImpl.splitDiaryDateSourceRows(sourceResult.value)
@@ -382,7 +376,7 @@ export default class QueryImpl implements Query {
     const skipByDate = QueryImpl.groupSourcesByDate(skipSourceRows)
     const dates = QueryImpl.enumerateJstDateRange(fromDateJst, toDateJst)
 
-    return success(
+    return ok(
       dates.map((date) => {
         const sources = QueryImpl.mergeDiarySources(
           readByDate.get(date) ?? [],
@@ -486,13 +480,13 @@ export default class QueryImpl implements Query {
     const unwrapped: unknown[] = []
 
     for (const result of results) {
-      if (isFailure(result)) {
-        return failure(new ServerError(result.error))
+      if (result.isErr()) {
+        return err(new ServerError(result.error))
       }
       unwrapped.push(result.value)
     }
 
-    return success(unwrapped as unknown as T)
+    return ok(unwrapped as unknown as T)
   }
 
   private static buildLikeConditionSql(column: string, value: string) {
@@ -665,7 +659,7 @@ export default class QueryImpl implements Query {
     while (current <= toDateJst) {
       dates.push(current)
       const next = addJstDays(current, 1)
-      if (isFailure(next)) break
+      if (next.isErr()) break
       current = next.value
     }
     return dates

--- a/application/src/domain/article/repository.ts
+++ b/application/src/domain/article/repository.ts
@@ -1,6 +1,6 @@
+import { type Result } from 'neverthrow'
 import { ServerError } from '@/common/errors'
 import { OffsetPaginationResult } from '@/common/pagination'
-import { AsyncResult } from '@/common/result'
 import { Nullable } from '@/common/types/utility'
 import type { ArticleMedia } from '@/domain/article/media'
 import type { Article, ArticleWithOptionalReadStatus } from './schema/article-schema'
@@ -18,28 +18,28 @@ export interface Query {
   searchArticles(
     params: QueryParams,
     activeUserId?: bigint,
-  ): AsyncResult<OffsetPaginationResult<ArticleWithOptionalReadStatus>, ServerError>
+  ): Promise<Result<OffsetPaginationResult<ArticleWithOptionalReadStatus>, ServerError>>
 
   getUnreadDigestionArticles(
     activeUserId: bigint,
     targetDateJst: string,
     media?: ArticleMedia,
-  ): AsyncResult<Article[], ServerError>
+  ): Promise<Result<Article[], ServerError>>
 
   getDailyDiary(
     activeUserId: bigint,
     targetDateJst: string,
     page: number,
     limit: number,
-  ): AsyncResult<DailyDiary, ServerError>
+  ): Promise<Result<DailyDiary, ServerError>>
 
   getDailyDiaryRange(
     activeUserId: bigint,
     fromDateJst: string,
     toDateJst: string,
-  ): AsyncResult<DailyDiaryRangeItem[], ServerError>
+  ): Promise<Result<DailyDiaryRangeItem[], ServerError>>
 
-  findArticleById(articleId: bigint): AsyncResult<Nullable<Article>, ServerError>
+  findArticleById(articleId: bigint): Promise<Result<Nullable<Article>, ServerError>>
 }
 
 export interface Command {
@@ -47,9 +47,12 @@ export interface Command {
     activeUserId: bigint,
     articleId: bigint,
     readAt: Date,
-  ): AsyncResult<ReadHistory, Error>
+  ): Promise<Result<ReadHistory, Error>>
 
-  createSkippedArticle(activeUserId: bigint, articleId: bigint): AsyncResult<SkippedArticle, Error>
+  createSkippedArticle(
+    activeUserId: bigint,
+    articleId: bigint,
+  ): Promise<Result<SkippedArticle, Error>>
 
-  deleteAllReadHistory(activeUserId: bigint, articleId: bigint): AsyncResult<void, Error>
+  deleteAllReadHistory(activeUserId: bigint, articleId: bigint): Promise<Result<void, Error>>
 }

--- a/application/src/domain/article/use-case.test.ts
+++ b/application/src/domain/article/use-case.test.ts
@@ -1,8 +1,8 @@
 import { faker } from '@faker-js/faker'
+import { err, ok } from 'neverthrow'
 import { mockDeep } from 'vitest-mock-extended'
 import { NotFoundError, ServerError } from '@/common/errors'
 import { OffsetPaginationResult } from '@/common/pagination'
-import { failure, isFailure, isSuccess, success } from '@/common/result'
 import { Command, Query } from '@/domain/article/repository'
 import type { Article, ArticleWithOptionalReadStatus } from '@/domain/article/schema/article-schema'
 import type { DailyDiary } from '@/domain/article/schema/diary-schema'
@@ -92,11 +92,11 @@ describe('ArticleUseCase', () => {
           page: 1,
         }
 
-        queryMock.searchArticles.mockResolvedValue(success(mockPaginationResult))
+        queryMock.searchArticles.mockResolvedValue(ok(mockPaginationResult))
 
         const result = await useCase.searchArticles(params)
 
-        expect(result).toEqual(success(mockPaginationResult))
+        expect(result).toEqual(ok(mockPaginationResult))
         expect(queryMock.searchArticles).toHaveBeenCalledTimes(1)
         const calledArgs = queryMock.searchArticles.mock.calls[0][0]
         expect(calledArgs).toEqual(params)
@@ -114,11 +114,11 @@ describe('ArticleUseCase', () => {
           page: 2,
         }
 
-        queryMock.searchArticles.mockResolvedValue(success(mockPaginationResult))
+        queryMock.searchArticles.mockResolvedValue(ok(mockPaginationResult))
 
         const result = await useCase.searchArticles(params as QueryParams)
 
-        expect(result).toEqual(success(mockPaginationResult))
+        expect(result).toEqual(ok(mockPaginationResult))
         expect(queryMock.searchArticles).toHaveBeenCalledTimes(1)
         const calledArgs = queryMock.searchArticles.mock.calls[0][0]
         expect(calledArgs).toEqual(params)
@@ -131,11 +131,11 @@ describe('ArticleUseCase', () => {
           page: 1,
         }
 
-        queryMock.searchArticles.mockResolvedValue(success(mockPaginationResult))
+        queryMock.searchArticles.mockResolvedValue(ok(mockPaginationResult))
 
         const result = await useCase.searchArticles(params as QueryParams)
 
-        expect(result).toEqual(success(mockPaginationResult))
+        expect(result).toEqual(ok(mockPaginationResult))
         expect(queryMock.searchArticles).toHaveBeenCalledWith(
           {
             title: 'test title',
@@ -153,11 +153,11 @@ describe('ArticleUseCase', () => {
           page: 1,
         }
 
-        queryMock.searchArticles.mockResolvedValue(success(mockPaginationResult))
+        queryMock.searchArticles.mockResolvedValue(ok(mockPaginationResult))
 
         const result = await useCase.searchArticles(params as QueryParams)
 
-        expect(result).toEqual(success(mockPaginationResult))
+        expect(result).toEqual(ok(mockPaginationResult))
         expect(queryMock.searchArticles).toHaveBeenCalledWith(
           {
             author: 'test author',
@@ -175,11 +175,11 @@ describe('ArticleUseCase', () => {
           page: 1,
         }
 
-        queryMock.searchArticles.mockResolvedValue(success(mockPaginationResult))
+        queryMock.searchArticles.mockResolvedValue(ok(mockPaginationResult))
 
         const result = await useCase.searchArticles(params as QueryParams)
 
-        expect(result).toEqual(success(mockPaginationResult))
+        expect(result).toEqual(ok(mockPaginationResult))
         expect(queryMock.searchArticles).toHaveBeenCalledWith(
           {
             media: 'zenn',
@@ -197,11 +197,11 @@ describe('ArticleUseCase', () => {
           page: 1,
         }
 
-        queryMock.searchArticles.mockResolvedValue(success(mockPaginationResult))
+        queryMock.searchArticles.mockResolvedValue(ok(mockPaginationResult))
 
         const result = await useCase.searchArticles(params as QueryParams)
 
-        expect(result).toEqual(success(mockPaginationResult))
+        expect(result).toEqual(ok(mockPaginationResult))
         expect(queryMock.searchArticles).toHaveBeenCalledWith(
           {
             from: '2024-01-01',
@@ -219,11 +219,11 @@ describe('ArticleUseCase', () => {
           page: 1,
         }
 
-        queryMock.searchArticles.mockResolvedValue(success(mockPaginationResult))
+        queryMock.searchArticles.mockResolvedValue(ok(mockPaginationResult))
 
         const result = await useCase.searchArticles(params as QueryParams)
 
-        expect(result).toEqual(success(mockPaginationResult))
+        expect(result).toEqual(ok(mockPaginationResult))
         expect(queryMock.searchArticles).toHaveBeenCalledWith(
           {
             to: '2024-01-31',
@@ -242,11 +242,11 @@ describe('ArticleUseCase', () => {
           page: 1,
         }
 
-        queryMock.searchArticles.mockResolvedValue(success(mockPaginationResult))
+        queryMock.searchArticles.mockResolvedValue(ok(mockPaginationResult))
 
         const result = await useCase.searchArticles(params as QueryParams)
 
-        expect(result).toEqual(success(mockPaginationResult))
+        expect(result).toEqual(ok(mockPaginationResult))
         expect(queryMock.searchArticles).toHaveBeenCalledWith(
           {
             from: '2024-01-01',
@@ -265,11 +265,11 @@ describe('ArticleUseCase', () => {
           page: 1,
         }
 
-        queryMock.searchArticles.mockResolvedValue(success(mockPaginationResult))
+        queryMock.searchArticles.mockResolvedValue(ok(mockPaginationResult))
 
         const result = await useCase.searchArticles(params as QueryParams)
 
-        expect(result).toEqual(success(mockPaginationResult))
+        expect(result).toEqual(ok(mockPaginationResult))
         expect(queryMock.searchArticles).toHaveBeenCalledWith(
           {
             readStatus: true,
@@ -287,11 +287,11 @@ describe('ArticleUseCase', () => {
         }
         const activeUserId = 100n
 
-        queryMock.searchArticles.mockResolvedValue(success(mockPaginationResultWithReadStatus))
+        queryMock.searchArticles.mockResolvedValue(ok(mockPaginationResultWithReadStatus))
 
         const result = await useCase.searchArticles(params, activeUserId)
 
-        expect(result).toEqual(success(mockPaginationResultWithReadStatus))
+        expect(result).toEqual(ok(mockPaginationResultWithReadStatus))
         expect(queryMock.searchArticles).toHaveBeenCalledWith(
           {
             limit: 20,
@@ -310,11 +310,11 @@ describe('ArticleUseCase', () => {
       }
 
       const dbError = new ServerError('Database error')
-      queryMock.searchArticles.mockResolvedValue(failure(dbError))
+      queryMock.searchArticles.mockResolvedValue(err(dbError))
 
       const result = await useCase.searchArticles(params)
 
-      expect(result).toEqual(failure(dbError))
+      expect(result).toEqual(err(dbError))
     })
   })
 
@@ -325,7 +325,7 @@ describe('ArticleUseCase', () => {
       const readAt = new Date('2024-01-01T10:00:00Z')
 
       // 記事存在確認のモック
-      queryMock.findArticleById.mockResolvedValue(success(mockArticle))
+      queryMock.findArticleById.mockResolvedValue(ok(mockArticle))
 
       const mockReadHistory: ReadHistory = {
         readHistoryId: 1n,
@@ -334,12 +334,12 @@ describe('ArticleUseCase', () => {
         readAt: readAt,
         createdAt: new Date(),
       }
-      commandMock.createReadHistory.mockResolvedValue(success(mockReadHistory))
+      commandMock.createReadHistory.mockResolvedValue(ok(mockReadHistory))
 
       const result = await useCase.createReadHistory(userId, articleId, readAt)
 
-      expect(isSuccess(result)).toBe(true)
-      if (isSuccess(result)) {
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
         expect(result.value.activeUserId).toBe(userId)
         expect(result.value.articleId).toBe(articleId)
         expect(result.value.readAt).toBe(readAt)
@@ -355,15 +355,15 @@ describe('ArticleUseCase', () => {
       const readAt = new Date('2024-01-01T10:00:00Z')
 
       // 記事存在確認のモック
-      queryMock.findArticleById.mockResolvedValue(success(mockArticle))
+      queryMock.findArticleById.mockResolvedValue(ok(mockArticle))
 
       const dbError = new ServerError('Database error')
-      commandMock.createReadHistory.mockResolvedValue(failure(dbError))
+      commandMock.createReadHistory.mockResolvedValue(err(dbError))
 
       const result = await useCase.createReadHistory(userId, articleId, readAt)
 
-      expect(isFailure(result)).toBe(true)
-      if (isFailure(result)) {
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
         expect(result.error).toBe(dbError)
       }
     })
@@ -374,12 +374,12 @@ describe('ArticleUseCase', () => {
       const readAt = new Date('2024-01-01T10:00:00Z')
 
       // 記事が存在しない場合のモック
-      queryMock.findArticleById.mockResolvedValue(success(null))
+      queryMock.findArticleById.mockResolvedValue(ok(null))
 
       const result = await useCase.createReadHistory(userId, articleId, readAt)
 
-      expect(isFailure(result)).toBe(true)
-      if (isFailure(result)) {
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
         expect(result.error).toBeInstanceOf(NotFoundError)
         expect(result.error.message).toBe('Article with ID 999 not found')
       }
@@ -394,12 +394,12 @@ describe('ArticleUseCase', () => {
       const userId = 100n
       const articleId = 200n
 
-      queryMock.findArticleById.mockResolvedValue(success(mockArticle))
-      commandMock.deleteAllReadHistory.mockResolvedValue(success(undefined))
+      queryMock.findArticleById.mockResolvedValue(ok(mockArticle))
+      commandMock.deleteAllReadHistory.mockResolvedValue(ok(undefined))
 
       const result = await useCase.deleteAllReadHistory(userId, articleId)
 
-      expect(isSuccess(result)).toBe(true)
+      expect(result.isOk()).toBe(true)
       expect(commandMock.deleteAllReadHistory).toHaveBeenCalledWith(userId, mockArticle.articleId)
     })
 
@@ -407,14 +407,14 @@ describe('ArticleUseCase', () => {
       const userId = 100n
       const articleId = 200n
 
-      queryMock.findArticleById.mockResolvedValue(success(mockArticle))
+      queryMock.findArticleById.mockResolvedValue(ok(mockArticle))
       const dbError = new ServerError('Database error')
-      commandMock.deleteAllReadHistory.mockResolvedValue(failure(dbError))
+      commandMock.deleteAllReadHistory.mockResolvedValue(err(dbError))
 
       const result = await useCase.deleteAllReadHistory(userId, articleId)
 
-      expect(isFailure(result)).toBe(true)
-      if (isFailure(result)) {
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
         expect(result.error).toBe(dbError)
       }
     })
@@ -431,25 +431,25 @@ describe('ArticleUseCase', () => {
         media: 'qiita' as const,
       },
     ])('$name で当日JST日付を使って取得できる', async ({ media }) => {
-      queryMock.getUnreadDigestionArticles.mockResolvedValue(success([mockArticle]))
+      queryMock.getUnreadDigestionArticles.mockResolvedValue(ok([mockArticle]))
       const now = new Date('2026-03-07T00:00:00.000Z')
 
       const result = await useCase.getUnreadDigestionArticles(100n, media, now)
 
-      expect(isSuccess(result)).toBe(true)
+      expect(result.isOk()).toBe(true)
       expect(queryMock.getUnreadDigestionArticles).toHaveBeenCalledWith(100n, '2026-03-07', media)
     })
   })
 
   describe('getDailyDiary', () => {
     it('指定日の日次ダイアリーを取得できる', async () => {
-      queryMock.getDailyDiary.mockResolvedValue(success(mockDailyDiary))
+      queryMock.getDailyDiary.mockResolvedValue(ok(mockDailyDiary))
 
       const result = await useCase.getDailyDiary(100n, '2026-03-07', 1, 10)
 
-      expect(isSuccess(result)).toBe(true)
+      expect(result.isOk()).toBe(true)
       expect(queryMock.getDailyDiary).toHaveBeenCalledWith(100n, '2026-03-07', 1, 10)
-      if (isSuccess(result)) {
+      if (result.isOk()) {
         expect(result.value.summary.read).toBe(8)
       }
     })
@@ -466,12 +466,12 @@ describe('ArticleUseCase', () => {
         createdAt: new Date(),
       }
 
-      queryMock.findArticleById.mockResolvedValue(success(mockArticle))
-      commandMock.createSkippedArticle.mockResolvedValue(success(mockSkippedArticle))
+      queryMock.findArticleById.mockResolvedValue(ok(mockArticle))
+      commandMock.createSkippedArticle.mockResolvedValue(ok(mockSkippedArticle))
 
       const result = await useCase.createSkippedArticle(activeUserId, articleId)
 
-      expect(isSuccess(result)).toBe(true)
+      expect(result.isOk()).toBe(true)
       expect(commandMock.createSkippedArticle).toHaveBeenCalledWith(
         activeUserId,
         mockArticle.articleId,
@@ -481,12 +481,12 @@ describe('ArticleUseCase', () => {
     it.each([
       {
         name: '記事が存在しない',
-        arrange: () => queryMock.findArticleById.mockResolvedValue(success(null)),
+        arrange: () => queryMock.findArticleById.mockResolvedValue(ok(null)),
         expectedError: NotFoundError,
       },
       {
         name: '記事検索で失敗',
-        arrange: () => queryMock.findArticleById.mockResolvedValue(failure(new ServerError('db'))),
+        arrange: () => queryMock.findArticleById.mockResolvedValue(err(new ServerError('db'))),
         expectedError: ServerError,
       },
     ])('$name 場合は失敗を返す', async ({ arrange, expectedError }) => {
@@ -494,8 +494,8 @@ describe('ArticleUseCase', () => {
 
       const result = await useCase.createSkippedArticle(100n, 200n)
 
-      expect(isFailure(result)).toBe(true)
-      if (isFailure(result)) {
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
         expect(result.error).toBeInstanceOf(expectedError)
       }
     })

--- a/application/src/domain/article/use-case.test.ts
+++ b/application/src/domain/article/use-case.test.ts
@@ -340,9 +340,9 @@ describe('ArticleUseCase', () => {
 
       expect(isSuccess(result)).toBe(true)
       if (isSuccess(result)) {
-        expect(result.data.activeUserId).toBe(userId)
-        expect(result.data.articleId).toBe(articleId)
-        expect(result.data.readAt).toBe(readAt)
+        expect(result.value.activeUserId).toBe(userId)
+        expect(result.value.articleId).toBe(articleId)
+        expect(result.value.readAt).toBe(readAt)
       }
 
       expect(queryMock.findArticleById).toHaveBeenCalledWith(articleId)
@@ -450,7 +450,7 @@ describe('ArticleUseCase', () => {
       expect(isSuccess(result)).toBe(true)
       expect(queryMock.getDailyDiary).toHaveBeenCalledWith(100n, '2026-03-07', 1, 10)
       if (isSuccess(result)) {
-        expect(result.data.summary.read).toBe(8)
+        expect(result.value.summary.read).toBe(8)
       }
     })
   })

--- a/application/src/domain/article/use-case.ts
+++ b/application/src/domain/article/use-case.ts
@@ -61,7 +61,7 @@ export class UseCase {
       return failure(new ServerError(targetDateJstResult.error))
     }
 
-    return this.query.getUnreadDigestionArticles(activeUserId, targetDateJstResult.data, media)
+    return this.query.getUnreadDigestionArticles(activeUserId, targetDateJstResult.value, media)
   }
 
   async getDailyDiary(
@@ -101,19 +101,19 @@ export class UseCase {
     action: (validatedArticleId: bigint) => AsyncResult<T, Error>,
   ): AsyncResult<T, Error> {
     const articleValidation = await this.validateArticleExists(articleId)
-    if (isFailure(articleValidation)) return articleValidation
+    if (isFailure(articleValidation)) return failure(articleValidation.error)
 
-    return action(articleValidation.data.articleId)
+    return action(articleValidation.value.articleId)
   }
 
   private async validateArticleExists(articleId: bigint): AsyncResult<Article, Error> {
     const res = await this.query.findArticleById(articleId)
-    if (isFailure(res)) return res
+    if (isFailure(res)) return failure(res.error)
 
-    if (isNull(res.data)) {
+    if (isNull(res.value)) {
       return failure(new NotFoundError(`Article with ID ${articleId} not found`))
     }
 
-    return success(res.data)
+    return success(res.value)
   }
 }

--- a/application/src/domain/article/use-case.ts
+++ b/application/src/domain/article/use-case.ts
@@ -1,7 +1,7 @@
+import { err, ok, type Result } from 'neverthrow'
 import { NotFoundError, ServerError } from '@/common/errors'
 import { toJstDateString } from '@/common/locale/date'
 import { DEFAULT_LIMIT, DEFAULT_PAGE, OffsetPaginationResult } from '@/common/pagination'
-import { AsyncResult, failure, isFailure, success } from '@/common/result'
 import extractTrimmed from '@/common/sanitization'
 import { isNull } from '@/common/types/utility'
 import type { ArticleMedia } from '@/domain/article/media'
@@ -26,7 +26,7 @@ export class UseCase {
   async searchArticles(
     params: QueryParams,
     activeUserId?: bigint,
-  ): AsyncResult<OffsetPaginationResult<ArticleWithOptionalReadStatus>, ServerError> {
+  ): Promise<Result<OffsetPaginationResult<ArticleWithOptionalReadStatus>, ServerError>> {
     const optimizedParams: QueryParams = {
       title: extractTrimmed(params.title),
       author: extractTrimmed(params.author),
@@ -45,7 +45,7 @@ export class UseCase {
     activeUserId: bigint,
     articleId: bigint,
     readAt: Date,
-  ): AsyncResult<ReadHistory, Error> {
+  ): Promise<Result<ReadHistory, Error>> {
     return this.withValidatedArticle(articleId, () =>
       this.command.createReadHistory(activeUserId, articleId, readAt),
     )
@@ -55,10 +55,10 @@ export class UseCase {
     activeUserId: bigint,
     media?: ArticleMedia,
     now: Date = new Date(),
-  ): AsyncResult<Article[], Error> {
+  ): Promise<Result<Article[], Error>> {
     const targetDateJstResult = toJstDateString(now)
-    if (isFailure(targetDateJstResult)) {
-      return failure(new ServerError(targetDateJstResult.error))
+    if (targetDateJstResult.isErr()) {
+      return err(new ServerError(targetDateJstResult.error))
     }
 
     return this.query.getUnreadDigestionArticles(activeUserId, targetDateJstResult.value, media)
@@ -69,7 +69,7 @@ export class UseCase {
     targetDateJst: string,
     page: number,
     limit: number,
-  ): AsyncResult<DailyDiary, Error> {
+  ): Promise<Result<DailyDiary, Error>> {
     return this.query.getDailyDiary(activeUserId, targetDateJst, page, limit)
   }
 
@@ -77,20 +77,23 @@ export class UseCase {
     activeUserId: bigint,
     fromDateJst: string,
     toDateJst: string,
-  ): AsyncResult<DailyDiaryRangeItem[], Error> {
+  ): Promise<Result<DailyDiaryRangeItem[], Error>> {
     return this.query.getDailyDiaryRange(activeUserId, fromDateJst, toDateJst)
   }
 
   async createSkippedArticle(
     activeUserId: bigint,
     articleId: bigint,
-  ): AsyncResult<SkippedArticle, Error> {
+  ): Promise<Result<SkippedArticle, Error>> {
     return this.withValidatedArticle(articleId, (validatedArticleId) =>
       this.command.createSkippedArticle(activeUserId, validatedArticleId),
     )
   }
 
-  async deleteAllReadHistory(activeUserId: bigint, articleId: bigint): AsyncResult<void, Error> {
+  async deleteAllReadHistory(
+    activeUserId: bigint,
+    articleId: bigint,
+  ): Promise<Result<void, Error>> {
     return this.withValidatedArticle(articleId, (validatedArticleId) =>
       this.command.deleteAllReadHistory(activeUserId, validatedArticleId),
     )
@@ -98,22 +101,22 @@ export class UseCase {
 
   private async withValidatedArticle<T>(
     articleId: bigint,
-    action: (validatedArticleId: bigint) => AsyncResult<T, Error>,
-  ): AsyncResult<T, Error> {
+    action: (validatedArticleId: bigint) => Promise<Result<T, Error>>,
+  ): Promise<Result<T, Error>> {
     const articleValidation = await this.validateArticleExists(articleId)
-    if (isFailure(articleValidation)) return failure(articleValidation.error)
+    if (articleValidation.isErr()) return err(articleValidation.error)
 
     return action(articleValidation.value.articleId)
   }
 
-  private async validateArticleExists(articleId: bigint): AsyncResult<Article, Error> {
+  private async validateArticleExists(articleId: bigint): Promise<Result<Article, Error>> {
     const res = await this.query.findArticleById(articleId)
-    if (isFailure(res)) return failure(res.error)
+    if (res.isErr()) return err(res.error)
 
     if (isNull(res.value)) {
-      return failure(new NotFoundError(`Article with ID ${articleId} not found`))
+      return err(new NotFoundError(`Article with ID ${articleId} not found`))
     }
 
-    return success(res.value)
+    return ok(res.value)
   }
 }

--- a/application/src/domain/user/infrastructure/command-impl.test.ts
+++ b/application/src/domain/user/infrastructure/command-impl.test.ts
@@ -32,10 +32,10 @@ describe('CommandImpl', () => {
 
       expect(isSuccess(result)).toBe(true)
       if (isSuccess(result)) {
-        expect(result.data.email).toBe('test@example.com')
-        expect(result.data.displayName).toBe('表示名')
-        expect(result.data.activeUserId).toBe(1n)
-        expect(result.data.userId).toBe(2n)
+        expect(result.value.email).toBe('test@example.com')
+        expect(result.value.displayName).toBe('表示名')
+        expect(result.value.activeUserId).toBe(1n)
+        expect(result.value.userId).toBe(2n)
       }
       const activeUserCreateArgs = prisma.activeUser.create.mock.calls[0]?.[0]
       expect(activeUserCreateArgs?.data).toMatchObject({

--- a/application/src/domain/user/infrastructure/command-impl.test.ts
+++ b/application/src/domain/user/infrastructure/command-impl.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { isFailure, isSuccess } from '@/common/result'
 import prisma from '@/test/__mocks__/prisma'
 import CommandImpl from './command-impl'
 
@@ -30,8 +29,8 @@ describe('CommandImpl', () => {
         '表示名',
       )
 
-      expect(isSuccess(result)).toBe(true)
-      if (isSuccess(result)) {
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
         expect(result.value.email).toBe('test@example.com')
         expect(result.value.displayName).toBe('表示名')
         expect(result.value.activeUserId).toBe(1n)
@@ -55,9 +54,9 @@ describe('CommandImpl', () => {
         'auth-id-123',
       )
 
-      expect(isFailure(result)).toBe(true)
+      expect(result.isErr()).toBe(true)
       expect(prisma.user.delete).not.toHaveBeenCalled()
-      if (isFailure(result)) {
+      if (result.isErr()) {
         expect(result.error.message).toBe('Failed to create active user')
       }
     })

--- a/application/src/domain/user/infrastructure/command-impl.ts
+++ b/application/src/domain/user/infrastructure/command-impl.ts
@@ -30,6 +30,6 @@ export default class CommandImpl implements Command {
       return failure(new ServerError('Failed to create active user'))
     }
 
-    return success(mapToActiveUser(activeUserResult.data))
+    return success(mapToActiveUser(activeUserResult.value))
   }
 }

--- a/application/src/domain/user/infrastructure/command-impl.ts
+++ b/application/src/domain/user/infrastructure/command-impl.ts
@@ -1,5 +1,6 @@
+import { err, ok, type Result } from 'neverthrow'
 import { ServerError } from '@/common/errors'
-import { AsyncResult, failure, isFailure, success, wrapAsyncCall } from '@/common/result'
+import { wrapAsyncCall } from '@/common/result'
 import { RdbClient } from '@/infrastructure/rdb'
 import { Command } from '../repository'
 import type { CurrentUser } from '../schema/active-user-schema'
@@ -12,7 +13,7 @@ export default class CommandImpl implements Command {
     email: string,
     authenticationId: string,
     displayName?: string | null,
-  ): AsyncResult<CurrentUser, ServerError> {
+  ): Promise<Result<CurrentUser, ServerError>> {
     const activeUserResult = await wrapAsyncCall(() =>
       this.db.activeUser.create({
         data: {
@@ -26,10 +27,10 @@ export default class CommandImpl implements Command {
       }),
     )
 
-    if (isFailure(activeUserResult)) {
-      return failure(new ServerError('Failed to create active user'))
+    if (activeUserResult.isErr()) {
+      return err(new ServerError('Failed to create active user'))
     }
 
-    return success(mapToActiveUser(activeUserResult.value))
+    return ok(mapToActiveUser(activeUserResult.value))
   }
 }

--- a/application/src/domain/user/infrastructure/query-impl.test.ts
+++ b/application/src/domain/user/infrastructure/query-impl.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { isFailure, isSuccess } from '@/common/result'
 import prisma from '@/test/__mocks__/prisma'
 import QueryImpl from './query-impl'
 
@@ -33,8 +32,8 @@ describe('QueryImpl', () => {
         const result = await useCase.findActiveById(activeUserId)
 
         // Assert
-        expect(isSuccess(result)).toBe(true)
-        if (isSuccess(result)) {
+        expect(result.isOk()).toBe(true)
+        if (result.isOk()) {
           expect(result.value?.activeUserId).toBe(1n)
           expect(result.value?.email).toBe('test@example.com')
         }
@@ -52,8 +51,8 @@ describe('QueryImpl', () => {
         const result = await useCase.findActiveById(activeUserId)
 
         // Assert
-        expect(isSuccess(result)).toBe(true)
-        if (isSuccess(result)) {
+        expect(result.isOk()).toBe(true)
+        if (result.isOk()) {
           expect(result.value).toBeNull()
         }
       })
@@ -70,8 +69,8 @@ describe('QueryImpl', () => {
         const result = await useCase.findActiveById(activeUserId)
 
         // Assert
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error.message).toBe('Database connection failed')
         }
       })
@@ -100,8 +99,8 @@ describe('QueryImpl', () => {
         const result = await useCase.findActiveByEmail(email)
 
         // Assert
-        expect(isSuccess(result)).toBe(true)
-        if (isSuccess(result)) {
+        expect(result.isOk()).toBe(true)
+        if (result.isOk()) {
           expect(result.value?.email).toBe(email)
           expect(result.value?.activeUserId).toBe(1n)
         }
@@ -119,8 +118,8 @@ describe('QueryImpl', () => {
         const result = await useCase.findActiveByEmail(email)
 
         // Assert
-        expect(isSuccess(result)).toBe(true)
-        if (isSuccess(result)) {
+        expect(result.isOk()).toBe(true)
+        if (result.isOk()) {
           expect(result.value).toBeNull()
         }
       })
@@ -137,8 +136,8 @@ describe('QueryImpl', () => {
         const result = await useCase.findActiveByEmail(email)
 
         // Assert
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error.message).toBe('Database connection failed')
         }
       })
@@ -167,8 +166,8 @@ describe('QueryImpl', () => {
         const result = await useCase.findActiveByAuthenticationId(authenticationId)
 
         // Assert
-        expect(isSuccess(result)).toBe(true)
-        if (isSuccess(result)) {
+        expect(result.isOk()).toBe(true)
+        if (result.isOk()) {
           expect(result.value?.activeUserId).toBe(1n)
           expect(result.value?.email).toBe('test@example.com')
         }
@@ -188,8 +187,8 @@ describe('QueryImpl', () => {
         const result = await useCase.findActiveByAuthenticationId(authenticationId)
 
         // Assert
-        expect(isSuccess(result)).toBe(true)
-        if (isSuccess(result)) {
+        expect(result.isOk()).toBe(true)
+        if (result.isOk()) {
           expect(result.value).toBeNull()
         }
       })
@@ -206,8 +205,8 @@ describe('QueryImpl', () => {
         const result = await useCase.findActiveByAuthenticationId(authenticationId)
 
         // Assert
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error.message).toBe('Database connection failed')
         }
       })

--- a/application/src/domain/user/infrastructure/query-impl.test.ts
+++ b/application/src/domain/user/infrastructure/query-impl.test.ts
@@ -35,8 +35,8 @@ describe('QueryImpl', () => {
         // Assert
         expect(isSuccess(result)).toBe(true)
         if (isSuccess(result)) {
-          expect(result.data?.activeUserId).toBe(1n)
-          expect(result.data?.email).toBe('test@example.com')
+          expect(result.value?.activeUserId).toBe(1n)
+          expect(result.value?.email).toBe('test@example.com')
         }
         expect(prisma.activeUser.findUnique).toHaveBeenCalled()
       })
@@ -54,7 +54,7 @@ describe('QueryImpl', () => {
         // Assert
         expect(isSuccess(result)).toBe(true)
         if (isSuccess(result)) {
-          expect(result.data).toBeNull()
+          expect(result.value).toBeNull()
         }
       })
     })
@@ -102,8 +102,8 @@ describe('QueryImpl', () => {
         // Assert
         expect(isSuccess(result)).toBe(true)
         if (isSuccess(result)) {
-          expect(result.data?.email).toBe(email)
-          expect(result.data?.activeUserId).toBe(1n)
+          expect(result.value?.email).toBe(email)
+          expect(result.value?.activeUserId).toBe(1n)
         }
         expect(prisma.activeUser.findUnique).toHaveBeenCalled()
       })
@@ -121,7 +121,7 @@ describe('QueryImpl', () => {
         // Assert
         expect(isSuccess(result)).toBe(true)
         if (isSuccess(result)) {
-          expect(result.data).toBeNull()
+          expect(result.value).toBeNull()
         }
       })
     })
@@ -169,8 +169,8 @@ describe('QueryImpl', () => {
         // Assert
         expect(isSuccess(result)).toBe(true)
         if (isSuccess(result)) {
-          expect(result.data?.activeUserId).toBe(1n)
-          expect(result.data?.email).toBe('test@example.com')
+          expect(result.value?.activeUserId).toBe(1n)
+          expect(result.value?.email).toBe('test@example.com')
         }
         expect(prisma.activeUser.findUnique).toHaveBeenCalledWith({
           where: { authenticationId },
@@ -190,7 +190,7 @@ describe('QueryImpl', () => {
         // Assert
         expect(isSuccess(result)).toBe(true)
         if (isSuccess(result)) {
-          expect(result.data).toBeNull()
+          expect(result.value).toBeNull()
         }
       })
     })

--- a/application/src/domain/user/infrastructure/query-impl.ts
+++ b/application/src/domain/user/infrastructure/query-impl.ts
@@ -1,5 +1,6 @@
+import { err, ok, type Result } from 'neverthrow'
 import { ServerError } from '@/common/errors'
-import { AsyncResult, failure, isFailure, success, wrapAsyncCall } from '@/common/result'
+import { wrapAsyncCall } from '@/common/result'
 import { Nullable } from '@/common/types/utility'
 import { RdbClient } from '@/infrastructure/rdb'
 import { toDbId } from '@/infrastructure/rdb-id'
@@ -10,60 +11,60 @@ import { mapToActiveUser } from './mapper'
 export default class QueryImpl implements Query {
   constructor(private readonly db: RdbClient) {}
 
-  async findActiveById(id: bigint): AsyncResult<Nullable<CurrentUser>, Error> {
+  async findActiveById(id: bigint): Promise<Result<Nullable<CurrentUser>, Error>> {
     const dbId = toDbId(id)
     const activeUserResult = await wrapAsyncCall(() =>
       this.db.activeUser.findUnique({
         where: { activeUserId: dbId },
       }),
     )
-    if (isFailure(activeUserResult)) {
-      return failure(new ServerError(activeUserResult.error))
+    if (activeUserResult.isErr()) {
+      return err(new ServerError(activeUserResult.error))
     }
 
     const activeUser = activeUserResult.value
     if (!activeUser) {
-      return success(null)
+      return ok(null)
     }
 
-    return success(mapToActiveUser(activeUser))
+    return ok(mapToActiveUser(activeUser))
   }
 
-  async findActiveByEmail(email: string): AsyncResult<Nullable<CurrentUser>, Error> {
+  async findActiveByEmail(email: string): Promise<Result<Nullable<CurrentUser>, Error>> {
     const activeUserResult = await wrapAsyncCall(() =>
       this.db.activeUser.findUnique({
         where: { email },
       }),
     )
-    if (isFailure(activeUserResult)) {
-      return failure(new ServerError(activeUserResult.error))
+    if (activeUserResult.isErr()) {
+      return err(new ServerError(activeUserResult.error))
     }
 
     const activeUser = activeUserResult.value
     if (!activeUser) {
-      return success(null)
+      return ok(null)
     }
 
-    return success(mapToActiveUser(activeUser))
+    return ok(mapToActiveUser(activeUser))
   }
 
   async findActiveByAuthenticationId(
     authenticationId: string,
-  ): AsyncResult<Nullable<CurrentUser>, Error> {
+  ): Promise<Result<Nullable<CurrentUser>, Error>> {
     const activeUserResult = await wrapAsyncCall(() =>
       this.db.activeUser.findUnique({
         where: { authenticationId },
       }),
     )
-    if (isFailure(activeUserResult)) {
-      return failure(new ServerError(activeUserResult.error))
+    if (activeUserResult.isErr()) {
+      return err(new ServerError(activeUserResult.error))
     }
 
     const activeUser = activeUserResult.value
     if (!activeUser) {
-      return success(null)
+      return ok(null)
     }
 
-    return success(mapToActiveUser(activeUser))
+    return ok(mapToActiveUser(activeUser))
   }
 }

--- a/application/src/domain/user/infrastructure/query-impl.ts
+++ b/application/src/domain/user/infrastructure/query-impl.ts
@@ -21,7 +21,7 @@ export default class QueryImpl implements Query {
       return failure(new ServerError(activeUserResult.error))
     }
 
-    const activeUser = activeUserResult.data
+    const activeUser = activeUserResult.value
     if (!activeUser) {
       return success(null)
     }
@@ -39,7 +39,7 @@ export default class QueryImpl implements Query {
       return failure(new ServerError(activeUserResult.error))
     }
 
-    const activeUser = activeUserResult.data
+    const activeUser = activeUserResult.value
     if (!activeUser) {
       return success(null)
     }
@@ -59,7 +59,7 @@ export default class QueryImpl implements Query {
       return failure(new ServerError(activeUserResult.error))
     }
 
-    const activeUser = activeUserResult.data
+    const activeUser = activeUserResult.value
     if (!activeUser) {
       return success(null)
     }

--- a/application/src/domain/user/infrastructure/supabase-auth-repository.test.ts
+++ b/application/src/domain/user/infrastructure/supabase-auth-repository.test.ts
@@ -55,17 +55,17 @@ describe('SupabaseAuthRepository', () => {
 
         expect(isSuccess(result)).toBe(true)
         if (isSuccess(result)) {
-          expect(result.data.user.id).toBe(supabaseUser.id)
-          expect(result.data.user.email).toBe('test@example.com')
-          expect(result.data.user.createdAt).toBeInstanceOf(Date)
-          expect(result.data.user.emailConfirmedAt).toBeInstanceOf(Date)
-          expect(result.data.user.createdAt.toISOString()).toBe(supabaseUser.created_at)
-          expect(result.data.user.emailConfirmedAt?.toISOString()).toBe(
+          expect(result.value.user.id).toBe(supabaseUser.id)
+          expect(result.value.user.email).toBe('test@example.com')
+          expect(result.value.user.createdAt).toBeInstanceOf(Date)
+          expect(result.value.user.emailConfirmedAt).toBeInstanceOf(Date)
+          expect(result.value.user.createdAt.toISOString()).toBe(supabaseUser.created_at)
+          expect(result.value.user.emailConfirmedAt?.toISOString()).toBe(
             supabaseUser.email_confirmed_at,
           )
-          expect(result.data.session?.accessToken).toBe('access-token')
-          expect(result.data.session?.refreshToken).toBe('refresh-token')
-          expect(result.data.session?.expiresIn).toBe(3600)
+          expect(result.value.session?.accessToken).toBe('access-token')
+          expect(result.value.session?.refreshToken).toBe('refresh-token')
+          expect(result.value.session?.expiresIn).toBe(3600)
         }
       })
 
@@ -80,7 +80,7 @@ describe('SupabaseAuthRepository', () => {
 
         expect(isSuccess(result)).toBe(true)
         if (isSuccess(result)) {
-          expect(result.data.session).toBeNull()
+          expect(result.value.session).toBeNull()
         }
       })
 
@@ -95,7 +95,7 @@ describe('SupabaseAuthRepository', () => {
 
         expect(isSuccess(result)).toBe(true)
         if (isSuccess(result)) {
-          expect(result.data.user.emailConfirmedAt).toBeNull()
+          expect(result.value.user.emailConfirmedAt).toBeNull()
         }
       })
 
@@ -111,8 +111,8 @@ describe('SupabaseAuthRepository', () => {
 
         expect(isSuccess(result)).toBe(true)
         if (isSuccess(result)) {
-          expect(result.data.user.email).toBe('fallback@example.com')
-          expect(result.data.session?.expiresIn).toBe(3600)
+          expect(result.value.user.email).toBe('fallback@example.com')
+          expect(result.value.session?.expiresIn).toBe(3600)
         }
       })
     })
@@ -206,8 +206,8 @@ describe('SupabaseAuthRepository', () => {
 
         expect(isSuccess(result)).toBe(true)
         if (isSuccess(result)) {
-          expect(result.data.user.email).toBe('test@example.com')
-          expect(result.data.session.accessToken).toBe('access-token')
+          expect(result.value.user.email).toBe('test@example.com')
+          expect(result.value.session.accessToken).toBe('access-token')
         }
       })
     })
@@ -373,8 +373,8 @@ describe('SupabaseAuthRepository', () => {
 
         expect(isSuccess(result)).toBe(true)
         if (isSuccess(result)) {
-          expect(result.data.id).toBe(supabaseUser.id)
-          expect(result.data.email).toBe('test@example.com')
+          expect(result.value.id).toBe(supabaseUser.id)
+          expect(result.value.email).toBe('test@example.com')
         }
       })
     })
@@ -451,8 +451,8 @@ describe('SupabaseAuthRepository', () => {
 
         expect(isSuccess(result)).toBe(true)
         if (isSuccess(result)) {
-          expect(result.data.user.id).toBe(supabaseUser.id)
-          expect(result.data.session.accessToken).toBe('access-token')
+          expect(result.value.user.id).toBe(supabaseUser.id)
+          expect(result.value.session.accessToken).toBe('access-token')
         }
       })
     })

--- a/application/src/domain/user/infrastructure/supabase-auth-repository.test.ts
+++ b/application/src/domain/user/infrastructure/supabase-auth-repository.test.ts
@@ -9,7 +9,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
 import { AlreadyExistsError, ClientError, ServerError } from '@/common/errors'
 import UnauthorizedError from '@/common/errors/client-error/unauthorized-error'
-import { isFailure, isSuccess } from '@/common/result'
 import { SupabaseAuthRepository } from './supabase-auth-repository'
 
 const buildSupabaseUser = (overrides: Partial<User> = {}): User => ({
@@ -53,8 +52,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.signup('test@example.com', 'Password1!')
 
-        expect(isSuccess(result)).toBe(true)
-        if (isSuccess(result)) {
+        expect(result.isOk()).toBe(true)
+        if (result.isOk()) {
           expect(result.value.user.id).toBe(supabaseUser.id)
           expect(result.value.user.email).toBe('test@example.com')
           expect(result.value.user.createdAt).toBeInstanceOf(Date)
@@ -78,8 +77,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.signup('test@example.com', 'Password1!')
 
-        expect(isSuccess(result)).toBe(true)
-        if (isSuccess(result)) {
+        expect(result.isOk()).toBe(true)
+        if (result.isOk()) {
           expect(result.value.session).toBeNull()
         }
       })
@@ -93,8 +92,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.signup('test@example.com', 'Password1!')
 
-        expect(isSuccess(result)).toBe(true)
-        if (isSuccess(result)) {
+        expect(result.isOk()).toBe(true)
+        if (result.isOk()) {
           expect(result.value.user.emailConfirmedAt).toBeNull()
         }
       })
@@ -109,8 +108,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.signup('fallback@example.com', 'Password1!')
 
-        expect(isSuccess(result)).toBe(true)
-        if (isSuccess(result)) {
+        expect(result.isOk()).toBe(true)
+        if (result.isOk()) {
           expect(result.value.user.email).toBe('fallback@example.com')
           expect(result.value.session?.expiresIn).toBe(3600)
         }
@@ -123,8 +122,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.signup('test@example.com', 'Password1!')
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ServerError)
         }
       })
@@ -137,8 +136,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.signup('test@example.com', 'Password1!')
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(AlreadyExistsError)
           expect(result.error.message).toBe('User already exists')
         }
@@ -152,8 +151,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.signup('test@example.com', 'Password1!')
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ServerError)
           expect(result.error.message).toContain('unexpected')
         }
@@ -167,8 +166,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.signup('test@example.com', 'Password1!')
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ServerError)
           expect(result.error.message).toBe('User registration failed')
         }
@@ -183,8 +182,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.signup('', 'Password1!')
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ServerError)
           expect(result.error.message).toContain('User email is missing')
         }
@@ -204,8 +203,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.login('test@example.com', 'Password1!')
 
-        expect(isSuccess(result)).toBe(true)
-        if (isSuccess(result)) {
+        expect(result.isOk()).toBe(true)
+        if (result.isOk()) {
           expect(result.value.user.email).toBe('test@example.com')
           expect(result.value.session.accessToken).toBe('access-token')
         }
@@ -218,8 +217,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.login('test@example.com', 'Password1!')
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ServerError)
         }
       })
@@ -233,8 +232,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.login('test@example.com', 'WrongPassword!')
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ClientError)
           expect((result.error as ClientError).statusCode).toBe(401)
           expect(result.error.message).toBe('Invalid email or password')
@@ -249,8 +248,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.login('test@example.com', 'WrongPassword!')
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ClientError)
           expect((result.error as ClientError).statusCode).toBe(401)
         }
@@ -264,8 +263,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.login('test@example.com', 'WrongPassword!')
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ClientError)
         }
       })
@@ -278,8 +277,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.login('test@example.com', 'Password1!')
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ServerError)
         }
       })
@@ -293,8 +292,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.login('test@example.com', 'Password1!')
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ServerError)
           expect(result.error.message).toBe('Authentication failed')
         }
@@ -312,8 +311,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.login('', 'Password1!')
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ServerError)
           expect(result.error.message).toContain('User email is missing')
         }
@@ -328,7 +327,7 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.logout()
 
-        expect(isSuccess(result)).toBe(true)
+        expect(result.isOk()).toBe(true)
       })
     })
 
@@ -338,8 +337,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.logout()
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ServerError)
         }
       })
@@ -351,8 +350,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.logout()
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ServerError)
           expect(result.error.message).toContain('Logout failed')
         }
@@ -371,8 +370,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.getCurrentUser()
 
-        expect(isSuccess(result)).toBe(true)
-        if (isSuccess(result)) {
+        expect(result.isOk()).toBe(true)
+        if (result.isOk()) {
           expect(result.value.id).toBe(supabaseUser.id)
           expect(result.value.email).toBe('test@example.com')
         }
@@ -385,8 +384,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.getCurrentUser()
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(UnauthorizedError)
           const unauthorized = result.error as UnauthorizedError
           expect(unauthorized.context?.sessionExists).toBe(false)
@@ -398,8 +397,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.getCurrentUser()
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ServerError)
         }
       })
@@ -412,8 +411,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.getCurrentUser()
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(UnauthorizedError)
           const unauthorized = result.error as UnauthorizedError
           expect(unauthorized.context?.sessionExists).toBe(true)
@@ -429,8 +428,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.getCurrentUser()
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ServerError)
         }
       })
@@ -449,8 +448,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.refreshSession()
 
-        expect(isSuccess(result)).toBe(true)
-        if (isSuccess(result)) {
+        expect(result.isOk()).toBe(true)
+        if (result.isOk()) {
           expect(result.value.user.id).toBe(supabaseUser.id)
           expect(result.value.session.accessToken).toBe('access-token')
         }
@@ -463,8 +462,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.refreshSession()
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ServerError)
         }
       })
@@ -477,8 +476,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.refreshSession()
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ServerError)
         }
       })
@@ -491,8 +490,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.refreshSession()
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ServerError)
         }
       })
@@ -509,8 +508,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.refreshSession()
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ServerError)
         }
       })
@@ -527,7 +526,7 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.deleteUser('auth-user-id-123')
 
-        expect(isSuccess(result)).toBe(true)
+        expect(result.isOk()).toBe(true)
       })
     })
 
@@ -537,8 +536,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.deleteUser('auth-user-id-123')
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ServerError)
         }
       })
@@ -551,8 +550,8 @@ describe('SupabaseAuthRepository', () => {
 
         const result = await repository.deleteUser('auth-user-id-123')
 
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBeInstanceOf(ServerError)
           expect(result.error.message).toContain('User deletion failed')
         }

--- a/application/src/domain/user/infrastructure/supabase-auth-repository.ts
+++ b/application/src/domain/user/infrastructure/supabase-auth-repository.ts
@@ -94,7 +94,7 @@ export class SupabaseAuthRepository implements AuthRepository {
       return failure(new ServerError(result.error))
     }
 
-    const { data, error } = result.data
+    const { data, error } = result.value
     if (error) {
       // 既に存在するユーザーの場合は AlreadyExistsError を返す
       // UX上、「既に使用されています」と明示することは一般的であり、
@@ -112,16 +112,16 @@ export class SupabaseAuthRepository implements AuthRepository {
 
     const userResult = this.toAuthenticationUser(data.user, email)
     if (isFailure(userResult)) {
-      return userResult
+      return failure(userResult.error)
     }
 
     let session: AuthSignupResult['session'] = null
     if (data.session) {
-      session = this.toSessionObject(data.session, userResult.data)
+      session = this.toSessionObject(data.session, userResult.value)
     }
 
     return success({
-      user: userResult.data,
+      user: userResult.value,
       session,
     })
   }
@@ -140,7 +140,7 @@ export class SupabaseAuthRepository implements AuthRepository {
       return failure(new ServerError(result.error))
     }
 
-    const { data, error } = result.data
+    const { data, error } = result.value
     if (error) {
       // 認証失敗チェック（instanceofとメッセージの両方で判定）
       if (isInvalidCredentialsError(error)) {
@@ -156,13 +156,13 @@ export class SupabaseAuthRepository implements AuthRepository {
 
     const userResult = this.toAuthenticationUser(data.user, email)
     if (isFailure(userResult)) {
-      return userResult
+      return failure(userResult.error)
     }
 
-    const session = this.toSessionObject(data.session, userResult.data)
+    const session = this.toSessionObject(data.session, userResult.value)
 
     return success({
-      user: userResult.data,
+      user: userResult.value,
       session,
     })
   }
@@ -173,7 +173,7 @@ export class SupabaseAuthRepository implements AuthRepository {
       return failure(new ServerError(result.error))
     }
 
-    const { error } = result.data
+    const { error } = result.value
     if (error) {
       return failure(new ServerError(`Logout failed: ${error.message}`))
     }
@@ -196,7 +196,7 @@ export class SupabaseAuthRepository implements AuthRepository {
 
     const {
       data: { user },
-    } = result.data
+    } = result.value
 
     if (!user) {
       return failure(
@@ -211,7 +211,7 @@ export class SupabaseAuthRepository implements AuthRepository {
       return authUserResult
     }
 
-    return success(authUserResult.data)
+    return success(authUserResult.value)
   }
 
   async refreshSession(): AsyncResult<AuthLoginResult, ServerError> {
@@ -223,19 +223,19 @@ export class SupabaseAuthRepository implements AuthRepository {
     const {
       data: { session },
       error,
-    } = result.data
+    } = result.value
     if (error || !session) {
       return failure(new ServerError(`Session refresh failed: ${error?.message}`))
     }
 
     const userResult = this.toAuthenticationUser(session.user)
     if (isFailure(userResult)) {
-      return userResult
+      return failure(userResult.error)
     }
 
     return success({
-      user: userResult.data,
-      session: this.toSessionObject(session, userResult.data),
+      user: userResult.value,
+      session: this.toSessionObject(session, userResult.value),
     })
   }
 
@@ -245,7 +245,7 @@ export class SupabaseAuthRepository implements AuthRepository {
       return failure(new ServerError(result.error))
     }
 
-    const { error } = result.data
+    const { error } = result.value
     if (error) {
       return failure(new ServerError(`User deletion failed: ${error.message}`))
     }

--- a/application/src/domain/user/infrastructure/supabase-auth-repository.ts
+++ b/application/src/domain/user/infrastructure/supabase-auth-repository.ts
@@ -5,16 +5,10 @@ import {
   type SupabaseClient,
   type User,
 } from '@supabase/supabase-js'
+import { err, ok, type Result } from 'neverthrow'
 import { AlreadyExistsError, ClientError, ServerError } from '@/common/errors'
 import UnauthorizedError from '@/common/errors/client-error/unauthorized-error'
-import {
-  type AsyncResult,
-  failure,
-  isFailure,
-  type Result,
-  success,
-  wrapAsyncCall,
-} from '@/common/result'
+import { wrapAsyncCall } from '@/common/result'
 import type { AuthLoginResult, AuthRepository, AuthSignupResult } from '../repository'
 import type { AuthenticationUser } from '../schema/auth-schema'
 
@@ -56,10 +50,10 @@ export class SupabaseAuthRepository implements AuthRepository {
   ): Result<AuthenticationUser, ServerError> {
     const email = user.email ?? fallbackEmail
     if (!email) {
-      return failure(new ServerError('User email is missing from Supabase response'))
+      return err(new ServerError('User email is missing from Supabase response'))
     }
 
-    return success({
+    return ok({
       id: user.id,
       email,
       emailConfirmedAt: user.email_confirmed_at ? new Date(user.email_confirmed_at) : null,
@@ -83,15 +77,15 @@ export class SupabaseAuthRepository implements AuthRepository {
   async signup(
     email: string,
     password: string,
-  ): AsyncResult<AuthSignupResult, ClientError | ServerError> {
+  ): Promise<Result<AuthSignupResult, ClientError | ServerError>> {
     const result = await wrapAsyncCall(() =>
       this.client.auth.signUp({
         email,
         password,
       }),
     )
-    if (isFailure(result)) {
-      return failure(new ServerError(result.error))
+    if (result.isErr()) {
+      return err(new ServerError(result.error))
     }
 
     const { data, error } = result.value
@@ -100,19 +94,19 @@ export class SupabaseAuthRepository implements AuthRepository {
       // UX上、「既に使用されています」と明示することは一般的であり、
       // セキュリティリスクも比較的小さいと判断
       if (isUserAlreadyExistsError(error)) {
-        return failure(new AlreadyExistsError('User already exists'))
+        return err(new AlreadyExistsError('User already exists'))
       }
 
-      return failure(new ServerError(`Authentication service error: ${error.message}`))
+      return err(new ServerError(`Authentication service error: ${error.message}`))
     }
 
     if (!data.user) {
-      return failure(new ServerError('User registration failed'))
+      return err(new ServerError('User registration failed'))
     }
 
     const userResult = this.toAuthenticationUser(data.user, email)
-    if (isFailure(userResult)) {
-      return failure(userResult.error)
+    if (userResult.isErr()) {
+      return err(userResult.error)
     }
 
     let session: AuthSignupResult['session'] = null
@@ -120,7 +114,7 @@ export class SupabaseAuthRepository implements AuthRepository {
       session = this.toSessionObject(data.session, userResult.value)
     }
 
-    return success({
+    return ok({
       user: userResult.value,
       session,
     })
@@ -129,69 +123,69 @@ export class SupabaseAuthRepository implements AuthRepository {
   async login(
     email: string,
     password: string,
-  ): AsyncResult<AuthLoginResult, ClientError | ServerError> {
+  ): Promise<Result<AuthLoginResult, ClientError | ServerError>> {
     const result = await wrapAsyncCall(() =>
       this.client.auth.signInWithPassword({
         email,
         password,
       }),
     )
-    if (isFailure(result)) {
-      return failure(new ServerError(result.error))
+    if (result.isErr()) {
+      return err(new ServerError(result.error))
     }
 
     const { data, error } = result.value
     if (error) {
       // 認証失敗チェック（instanceofとメッセージの両方で判定）
       if (isInvalidCredentialsError(error)) {
-        return failure(new ClientError('Invalid email or password', 401))
+        return err(new ClientError('Invalid email or password', 401))
       }
 
-      return failure(new ServerError(`Authentication service error: ${error.message}`))
+      return err(new ServerError(`Authentication service error: ${error.message}`))
     }
 
     if (!data.user || !data.session) {
-      return failure(new ServerError('Authentication failed'))
+      return err(new ServerError('Authentication failed'))
     }
 
     const userResult = this.toAuthenticationUser(data.user, email)
-    if (isFailure(userResult)) {
-      return failure(userResult.error)
+    if (userResult.isErr()) {
+      return err(userResult.error)
     }
 
     const session = this.toSessionObject(data.session, userResult.value)
 
-    return success({
+    return ok({
       user: userResult.value,
       session,
     })
   }
 
-  async logout(): AsyncResult<void, ServerError> {
+  async logout(): Promise<Result<void, ServerError>> {
     const result = await wrapAsyncCall(() => this.client.auth.signOut())
-    if (isFailure(result)) {
-      return failure(new ServerError(result.error))
+    if (result.isErr()) {
+      return err(new ServerError(result.error))
     }
 
     const { error } = result.value
     if (error) {
-      return failure(new ServerError(`Logout failed: ${error.message}`))
+      return err(new ServerError(`Logout failed: ${error.message}`))
     }
 
-    return success(undefined)
+    return ok(undefined)
   }
 
-  async getCurrentUser(): AsyncResult<AuthenticationUser, ServerError> {
+  async getCurrentUser(): Promise<Result<AuthenticationUser, ServerError>> {
     const result = await wrapAsyncCall(() => this.client.auth.getUser())
-    if (isFailure(result)) {
+    if (result.isErr()) {
       if (result.error instanceof AuthSessionMissingError) {
-        return failure(
+        return err(
           new UnauthorizedError('session not found', {
             sessionExists: false,
           }),
         )
       }
-      return failure(new ServerError(result.error))
+      return err(new ServerError(result.error))
     }
 
     const {
@@ -199,7 +193,7 @@ export class SupabaseAuthRepository implements AuthRepository {
     } = result.value
 
     if (!user) {
-      return failure(
+      return err(
         new UnauthorizedError('session not found', {
           sessionExists: true,
         }),
@@ -207,17 +201,17 @@ export class SupabaseAuthRepository implements AuthRepository {
     }
 
     const authUserResult = this.toAuthenticationUser(user)
-    if (isFailure(authUserResult)) {
+    if (authUserResult.isErr()) {
       return authUserResult
     }
 
-    return success(authUserResult.value)
+    return ok(authUserResult.value)
   }
 
-  async refreshSession(): AsyncResult<AuthLoginResult, ServerError> {
+  async refreshSession(): Promise<Result<AuthLoginResult, ServerError>> {
     const result = await wrapAsyncCall(() => this.client.auth.refreshSession())
-    if (isFailure(result)) {
-      return failure(new ServerError(result.error))
+    if (result.isErr()) {
+      return err(new ServerError(result.error))
     }
 
     const {
@@ -225,31 +219,31 @@ export class SupabaseAuthRepository implements AuthRepository {
       error,
     } = result.value
     if (error || !session) {
-      return failure(new ServerError(`Session refresh failed: ${error?.message}`))
+      return err(new ServerError(`Session refresh failed: ${error?.message}`))
     }
 
     const userResult = this.toAuthenticationUser(session.user)
-    if (isFailure(userResult)) {
-      return failure(userResult.error)
+    if (userResult.isErr()) {
+      return err(userResult.error)
     }
 
-    return success({
+    return ok({
       user: userResult.value,
       session: this.toSessionObject(session, userResult.value),
     })
   }
 
-  async deleteUser(userId: string): AsyncResult<void, ServerError> {
+  async deleteUser(userId: string): Promise<Result<void, ServerError>> {
     const result = await wrapAsyncCall(() => this.client.auth.admin.deleteUser(userId))
-    if (isFailure(result)) {
-      return failure(new ServerError(result.error))
+    if (result.isErr()) {
+      return err(new ServerError(result.error))
     }
 
     const { error } = result.value
     if (error) {
-      return failure(new ServerError(`User deletion failed: ${error.message}`))
+      return err(new ServerError(`User deletion failed: ${error.message}`))
     }
 
-    return success(undefined)
+    return ok(undefined)
   }
 }

--- a/application/src/domain/user/repository.ts
+++ b/application/src/domain/user/repository.ts
@@ -1,14 +1,16 @@
+import { type Result } from 'neverthrow'
 import { ClientError, ServerError } from '@/common/errors'
-import { AsyncResult } from '@/common/result'
 import { Nullable } from '@/common/types/utility'
 
 import type { CurrentUser } from './schema/active-user-schema'
 import { AuthenticationSession, AuthenticationUser } from './schema/auth-schema'
 
 export interface Query {
-  findActiveById(id: bigint): AsyncResult<Nullable<CurrentUser>, Error>
-  findActiveByEmail(email: string): AsyncResult<Nullable<CurrentUser>, Error>
-  findActiveByAuthenticationId(authenticationId: string): AsyncResult<Nullable<CurrentUser>, Error>
+  findActiveById(id: bigint): Promise<Result<Nullable<CurrentUser>, Error>>
+  findActiveByEmail(email: string): Promise<Result<Nullable<CurrentUser>, Error>>
+  findActiveByAuthenticationId(
+    authenticationId: string,
+  ): Promise<Result<Nullable<CurrentUser>, Error>>
 }
 
 export interface Command {
@@ -16,7 +18,7 @@ export interface Command {
     email: string,
     authenticationId: string,
     displayName?: string | null,
-  ): AsyncResult<CurrentUser, ServerError>
+  ): Promise<Result<CurrentUser, ServerError>>
 }
 
 /**
@@ -39,30 +41,36 @@ export interface AuthRepository {
   /**
    * ユーザーを作成する
    */
-  signup(email: string, password: string): AsyncResult<AuthSignupResult, ClientError | ServerError>
+  signup(
+    email: string,
+    password: string,
+  ): Promise<Result<AuthSignupResult, ClientError | ServerError>>
 
   /**
    * ログインする
    */
-  login(email: string, password: string): AsyncResult<AuthLoginResult, ClientError | ServerError>
+  login(
+    email: string,
+    password: string,
+  ): Promise<Result<AuthLoginResult, ClientError | ServerError>>
 
   /**
    * ログアウトする
    */
-  logout(): AsyncResult<void, ServerError>
+  logout(): Promise<Result<void, ServerError>>
 
   /**
    * 現在のユーザーを取得する
    */
-  getCurrentUser(): AsyncResult<AuthenticationUser, ServerError>
+  getCurrentUser(): Promise<Result<AuthenticationUser, ServerError>>
 
   /**
    * セッションを更新する
    */
-  refreshSession(): AsyncResult<AuthLoginResult, ServerError>
+  refreshSession(): Promise<Result<AuthLoginResult, ServerError>>
 
   /**
    * ユーザーを削除する（補償トランザクション用）
    */
-  deleteUser(userId: string): AsyncResult<void, ServerError>
+  deleteUser(userId: string): Promise<Result<void, ServerError>>
 }

--- a/application/src/domain/user/use-case.test.ts
+++ b/application/src/domain/user/use-case.test.ts
@@ -60,8 +60,8 @@ describe('AuthUseCase', () => {
         // Assert
         expect(isSuccess(result)).toBe(true)
         if (isSuccess(result)) {
-          expect(result.data.session).toEqual(mockSession)
-          expect(result.data.activeUser).toEqual(mockActiveUser)
+          expect(result.value.session).toEqual(mockSession)
+          expect(result.value.activeUser).toEqual(mockActiveUser)
         }
         expect(repositoryMock.signup).toHaveBeenCalledWith('test@example.com', 'Password1!')
         expect(commandMock.createActiveWithAuthenticationId).toHaveBeenCalledWith(
@@ -156,8 +156,8 @@ describe('AuthUseCase', () => {
         // Assert
         expect(isSuccess(result)).toBe(true)
         if (isSuccess(result)) {
-          expect(result.data.session).toEqual(mockSession)
-          expect(result.data.activeUser).toEqual(mockActiveUser)
+          expect(result.value.session).toEqual(mockSession)
+          expect(result.value.activeUser).toEqual(mockActiveUser)
         }
         expect(repositoryMock.login).toHaveBeenCalledWith('test@example.com', 'Password1!')
         expect(queryMock.findActiveByAuthenticationId).toHaveBeenCalledWith(mockAuthUser.id)
@@ -270,7 +270,7 @@ describe('AuthUseCase', () => {
         // Assert
         expect(isSuccess(result)).toBe(true)
         if (isSuccess(result)) {
-          expect(result.data).toEqual(mockActiveUser)
+          expect(result.value).toEqual(mockActiveUser)
         }
         expect(repositoryMock.getCurrentUser).toHaveBeenCalled()
         expect(queryMock.findActiveByAuthenticationId).toHaveBeenCalledWith(mockAuthUser.id)
@@ -355,8 +355,8 @@ describe('AuthUseCase', () => {
         // Assert
         expect(isSuccess(result)).toBe(true)
         if (isSuccess(result)) {
-          expect(result.data.session).toEqual(newSession)
-          expect(result.data.activeUser).toEqual(mockActiveUser)
+          expect(result.value.session).toEqual(newSession)
+          expect(result.value.activeUser).toEqual(mockActiveUser)
         }
         expect(repositoryMock.refreshSession).toHaveBeenCalled()
         expect(queryMock.findActiveByAuthenticationId).toHaveBeenCalledWith(mockAuthUser.id)

--- a/application/src/domain/user/use-case.test.ts
+++ b/application/src/domain/user/use-case.test.ts
@@ -1,7 +1,7 @@
+import { err, ok } from 'neverthrow'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
 import { ClientError, ServerError } from '@/common/errors'
-import { failure, isFailure, isSuccess, success } from '@/common/result'
 import type { AuthRepository, Command, Query } from '@/domain/user/repository'
 import type { CurrentUser } from '@/domain/user/schema/active-user-schema'
 import type { AuthenticationSession, AuthenticationUser } from '@/domain/user/schema/auth-schema'
@@ -47,19 +47,19 @@ describe('AuthUseCase', () => {
       it('サインアップ成功時、sessionとactiveUserを返す', async () => {
         // Arrange
         repositoryMock.signup.mockResolvedValue(
-          success({
+          ok({
             user: mockAuthUser,
             session: mockSession,
           }),
         )
-        commandMock.createActiveWithAuthenticationId.mockResolvedValue(success(mockActiveUser))
+        commandMock.createActiveWithAuthenticationId.mockResolvedValue(ok(mockActiveUser))
 
         // Act
         const result = await useCase.signup('test@example.com', 'Password1!')
 
         // Assert
-        expect(isSuccess(result)).toBe(true)
-        if (isSuccess(result)) {
+        expect(result.isOk()).toBe(true)
+        if (result.isOk()) {
           expect(result.value.session).toEqual(mockSession)
           expect(result.value.activeUser).toEqual(mockActiveUser)
         }
@@ -75,14 +75,14 @@ describe('AuthUseCase', () => {
       it('repository.signup失敗時、エラーを返す', async () => {
         // Arrange
         const authError = new ClientError('Invalid credentials', 400)
-        repositoryMock.signup.mockResolvedValue(failure(authError))
+        repositoryMock.signup.mockResolvedValue(err(authError))
 
         // Act
         const result = await useCase.signup('test@example.com', 'Password1!')
 
         // Assert
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBe(authError)
         }
         expect(commandMock.createActiveWithAuthenticationId).not.toHaveBeenCalled()
@@ -91,7 +91,7 @@ describe('AuthUseCase', () => {
       // describe('認証成功後', () => {
       //   beforeEach(() => {
       //     repositoryMock.signup.mockResolvedValue(
-      //       success({
+      //       ok({
       //         user: mockAuthUser,
       //         session: mockSession,
       //       }),
@@ -101,15 +101,15 @@ describe('AuthUseCase', () => {
       //   // it('ActiveUser作成失敗時、補償トランザクションを実行してエラーを返す', async () => {
       //   //   // Arrange
       //   //   const dbError = new ServerError('Database error')
-      //   //   commandMock.createActiveWithAuthenticationId.mockResolvedValue(failure(dbError))
-      //   //   repositoryMock.deleteUser.mockResolvedValue(success(undefined))
+      //   //   commandMock.createActiveWithAuthenticationId.mockResolvedValue(err(dbError))
+      //   //   repositoryMock.deleteUser.mockResolvedValue(ok(undefined))
       //   //
       //   //   // Act
       //   //   const result = await useCase.signup('test@example.com', 'Password1!')
       //   //
       //   //   // Assert
-      //   //   expect(isFailure(result)).toBe(true)
-      //   //   if (isFailure(result)) {
+      //   //   expect(result.isErr()).toBe(true)
+      //   //   if (result.isErr()) {
       //   //     expect(result.error).toBe(dbError)
       //   //   }
       //   //   expect(repositoryMock.deleteUser).toHaveBeenCalledWith(mockAuthUser.id)
@@ -118,16 +118,16 @@ describe('AuthUseCase', () => {
       //   // it('補償トランザクション失敗時、ExternalServiceErrorを返す', async () => {
       //   //   // Arrange
       //   //   const dbError = new ServerError('Database error')
-      //   //   commandMock.createActiveWithAuthenticationId.mockResolvedValue(failure(dbError))
+      //   //   commandMock.createActiveWithAuthenticationId.mockResolvedValue(err(dbError))
       //   //   const deleteError = new ServerError('Delete failed')
-      //   //   repositoryMock.deleteUser.mockResolvedValue(failure(deleteError))
+      //   //   repositoryMock.deleteUser.mockResolvedValue(err(deleteError))
       //   //
       //   //   // Act
       //   //   const result = await useCase.signup('test@example.com', 'Password1!')
       //   //
       //   //   // Assert
-      //   //   expect(isFailure(result)).toBe(true)
-      //   //   if (isFailure(result)) {
+      //   //   expect(result.isErr()).toBe(true)
+      //   //   if (result.isErr()) {
       //   //     expect(result.error).toBeInstanceOf(ExternalServiceError)
       //   //     expect(result.error.message).toBe(
       //   //       'Failed to delete Supabase Auth user during compensation',
@@ -143,19 +143,19 @@ describe('AuthUseCase', () => {
       it('ログイン成功時、sessionとactiveUserを返す', async () => {
         // Arrange
         repositoryMock.login.mockResolvedValue(
-          success({
+          ok({
             user: mockAuthUser,
             session: mockSession,
           }),
         )
-        queryMock.findActiveByAuthenticationId.mockResolvedValue(success(mockActiveUser))
+        queryMock.findActiveByAuthenticationId.mockResolvedValue(ok(mockActiveUser))
 
         // Act
         const result = await useCase.login('test@example.com', 'Password1!')
 
         // Assert
-        expect(isSuccess(result)).toBe(true)
-        if (isSuccess(result)) {
+        expect(result.isOk()).toBe(true)
+        if (result.isOk()) {
           expect(result.value.session).toEqual(mockSession)
           expect(result.value.activeUser).toEqual(mockActiveUser)
         }
@@ -168,14 +168,14 @@ describe('AuthUseCase', () => {
       it('repository.login失敗時、エラーを返す', async () => {
         // Arrange
         const authError = new ClientError('Invalid credentials', 401)
-        repositoryMock.login.mockResolvedValue(failure(authError))
+        repositoryMock.login.mockResolvedValue(err(authError))
 
         // Act
         const result = await useCase.login('test@example.com', 'WrongPassword!')
 
         // Assert
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBe(authError)
         }
         expect(queryMock.findActiveByAuthenticationId).not.toHaveBeenCalled()
@@ -184,7 +184,7 @@ describe('AuthUseCase', () => {
       describe('認証成功後', () => {
         beforeEach(() => {
           repositoryMock.login.mockResolvedValue(
-            success({
+            ok({
               user: mockAuthUser,
               session: mockSession,
             }),
@@ -193,14 +193,14 @@ describe('AuthUseCase', () => {
 
         it('ActiveUserが見つからない場合、ClientError(404)を返す', async () => {
           // Arrange
-          queryMock.findActiveByAuthenticationId.mockResolvedValue(success(null))
+          queryMock.findActiveByAuthenticationId.mockResolvedValue(ok(null))
 
           // Act
           const result = await useCase.login('test@example.com', 'Password1!')
 
           // Assert
-          expect(isFailure(result)).toBe(true)
-          if (isFailure(result)) {
+          expect(result.isErr()).toBe(true)
+          if (result.isErr()) {
             expect(result.error).toBeInstanceOf(ClientError)
             expect(result.error.message).toBe('User not found')
           }
@@ -209,14 +209,14 @@ describe('AuthUseCase', () => {
         it('クエリ失敗時、ServerErrorを返す', async () => {
           // Arrange
           const dbError = new Error('Database connection failed')
-          queryMock.findActiveByAuthenticationId.mockResolvedValue(failure(dbError))
+          queryMock.findActiveByAuthenticationId.mockResolvedValue(err(dbError))
 
           // Act
           const result = await useCase.login('test@example.com', 'Password1!')
 
           // Assert
-          expect(isFailure(result)).toBe(true)
-          if (isFailure(result)) {
+          expect(result.isErr()).toBe(true)
+          if (result.isErr()) {
             expect(result.error).toBeInstanceOf(ServerError)
           }
         })
@@ -228,13 +228,13 @@ describe('AuthUseCase', () => {
     describe('正常系', () => {
       it('ログアウト成功時、voidを返す', async () => {
         // Arrange
-        repositoryMock.logout.mockResolvedValue(success(undefined))
+        repositoryMock.logout.mockResolvedValue(ok(undefined))
 
         // Act
         const result = await useCase.logout()
 
         // Assert
-        expect(isSuccess(result)).toBe(true)
+        expect(result.isOk()).toBe(true)
         expect(repositoryMock.logout).toHaveBeenCalled()
       })
     })
@@ -243,14 +243,14 @@ describe('AuthUseCase', () => {
       it('repository.logout失敗時、ServerErrorを返す', async () => {
         // Arrange
         const serverError = new ServerError('Logout failed')
-        repositoryMock.logout.mockResolvedValue(failure(serverError))
+        repositoryMock.logout.mockResolvedValue(err(serverError))
 
         // Act
         const result = await useCase.logout()
 
         // Assert
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBe(serverError)
         }
       })
@@ -261,15 +261,15 @@ describe('AuthUseCase', () => {
     describe('正常系', () => {
       it('認証ユーザーからactiveUserを取得して返す', async () => {
         // Arrange
-        repositoryMock.getCurrentUser.mockResolvedValue(success(mockAuthUser))
-        queryMock.findActiveByAuthenticationId.mockResolvedValue(success(mockActiveUser))
+        repositoryMock.getCurrentUser.mockResolvedValue(ok(mockAuthUser))
+        queryMock.findActiveByAuthenticationId.mockResolvedValue(ok(mockActiveUser))
 
         // Act
         const result = await useCase.getCurrentActiveUser()
 
         // Assert
-        expect(isSuccess(result)).toBe(true)
-        if (isSuccess(result)) {
+        expect(result.isOk()).toBe(true)
+        if (result.isOk()) {
           expect(result.value).toEqual(mockActiveUser)
         }
         expect(repositoryMock.getCurrentUser).toHaveBeenCalled()
@@ -281,14 +281,14 @@ describe('AuthUseCase', () => {
       it('repository.getCurrentUser失敗時、エラーを返す', async () => {
         // Arrange
         const authError = new ClientError('Not authenticated', 401)
-        repositoryMock.getCurrentUser.mockResolvedValue(failure(authError))
+        repositoryMock.getCurrentUser.mockResolvedValue(err(authError))
 
         // Act
         const result = await useCase.getCurrentActiveUser()
 
         // Assert
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBe(authError)
         }
         expect(queryMock.findActiveByAuthenticationId).not.toHaveBeenCalled()
@@ -296,19 +296,19 @@ describe('AuthUseCase', () => {
 
       describe('認証成功後', () => {
         beforeEach(() => {
-          repositoryMock.getCurrentUser.mockResolvedValue(success(mockAuthUser))
+          repositoryMock.getCurrentUser.mockResolvedValue(ok(mockAuthUser))
         })
 
         it('ActiveUserが見つからない場合、ClientError(404)を返す', async () => {
           // Arrange
-          queryMock.findActiveByAuthenticationId.mockResolvedValue(success(null))
+          queryMock.findActiveByAuthenticationId.mockResolvedValue(ok(null))
 
           // Act
           const result = await useCase.getCurrentActiveUser()
 
           // Assert
-          expect(isFailure(result)).toBe(true)
-          if (isFailure(result)) {
+          expect(result.isErr()).toBe(true)
+          if (result.isErr()) {
             expect(result.error).toBeInstanceOf(ClientError)
             expect(result.error.message).toBe('User not found')
           }
@@ -317,14 +317,14 @@ describe('AuthUseCase', () => {
         it('クエリ失敗時、ServerErrorを返す', async () => {
           // Arrange
           const dbError = new Error('Database connection failed')
-          queryMock.findActiveByAuthenticationId.mockResolvedValue(failure(dbError))
+          queryMock.findActiveByAuthenticationId.mockResolvedValue(err(dbError))
 
           // Act
           const result = await useCase.getCurrentActiveUser()
 
           // Assert
-          expect(isFailure(result)).toBe(true)
-          if (isFailure(result)) {
+          expect(result.isErr()).toBe(true)
+          if (result.isErr()) {
             expect(result.error).toBeInstanceOf(ServerError)
           }
         })
@@ -342,19 +342,19 @@ describe('AuthUseCase', () => {
           refreshToken: 'new-refresh-token',
         }
         repositoryMock.refreshSession.mockResolvedValue(
-          success({
+          ok({
             user: mockAuthUser,
             session: newSession,
           }),
         )
-        queryMock.findActiveByAuthenticationId.mockResolvedValue(success(mockActiveUser))
+        queryMock.findActiveByAuthenticationId.mockResolvedValue(ok(mockActiveUser))
 
         // Act
         const result = await useCase.refreshSession()
 
         // Assert
-        expect(isSuccess(result)).toBe(true)
-        if (isSuccess(result)) {
+        expect(result.isOk()).toBe(true)
+        if (result.isOk()) {
           expect(result.value.session).toEqual(newSession)
           expect(result.value.activeUser).toEqual(mockActiveUser)
         }
@@ -367,14 +367,14 @@ describe('AuthUseCase', () => {
       it('repository.refreshSession失敗時、エラーを返す', async () => {
         // Arrange
         const authError = new ClientError('Session expired', 401)
-        repositoryMock.refreshSession.mockResolvedValue(failure(authError))
+        repositoryMock.refreshSession.mockResolvedValue(err(authError))
 
         // Act
         const result = await useCase.refreshSession()
 
         // Assert
-        expect(isFailure(result)).toBe(true)
-        if (isFailure(result)) {
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
           expect(result.error).toBe(authError)
         }
         expect(queryMock.findActiveByAuthenticationId).not.toHaveBeenCalled()
@@ -383,7 +383,7 @@ describe('AuthUseCase', () => {
       describe('認証成功後', () => {
         beforeEach(() => {
           repositoryMock.refreshSession.mockResolvedValue(
-            success({
+            ok({
               user: mockAuthUser,
               session: mockSession,
             }),
@@ -392,14 +392,14 @@ describe('AuthUseCase', () => {
 
         it('ActiveUserが見つからない場合、ClientError(404)を返す', async () => {
           // Arrange
-          queryMock.findActiveByAuthenticationId.mockResolvedValue(success(null))
+          queryMock.findActiveByAuthenticationId.mockResolvedValue(ok(null))
 
           // Act
           const result = await useCase.refreshSession()
 
           // Assert
-          expect(isFailure(result)).toBe(true)
-          if (isFailure(result)) {
+          expect(result.isErr()).toBe(true)
+          if (result.isErr()) {
             expect(result.error).toBeInstanceOf(ClientError)
             expect(result.error.message).toBe('User not found')
           }
@@ -408,14 +408,14 @@ describe('AuthUseCase', () => {
         it('クエリ失敗時、ServerErrorを返す', async () => {
           // Arrange
           const dbError = new Error('Database connection failed')
-          queryMock.findActiveByAuthenticationId.mockResolvedValue(failure(dbError))
+          queryMock.findActiveByAuthenticationId.mockResolvedValue(err(dbError))
 
           // Act
           const result = await useCase.refreshSession()
 
           // Assert
-          expect(isFailure(result)).toBe(true)
-          if (isFailure(result)) {
+          expect(result.isErr()).toBe(true)
+          if (result.isErr()) {
             expect(result.error).toBeInstanceOf(ServerError)
           }
         })

--- a/application/src/domain/user/use-case.ts
+++ b/application/src/domain/user/use-case.ts
@@ -45,20 +45,6 @@ export class AuthUseCase {
     )
 
     if (activeUserResult.isErr()) {
-      // Supabase Admin Roleが必要でエラーになるので、コメントアウト
-      // // 補償トランザクション: Supabase Authで作成したユーザーを削除
-      // const deleteResult = await this.repository.deleteUser(user.id)
-      // if (deleteResult.isErr()) {
-      //   // 補償トランザクション失敗時はExternalServiceErrorを返す
-      //   return err(
-      //     new ExternalServiceError(
-      //       'Failed to delete Supabase Auth user during compensation',
-      //       activeUserResult.error,
-      //       deleteResult.error,
-      //       { userId: user.id },
-      //     ),
-      //   )
-      // }
       return err(activeUserResult.error)
     }
 

--- a/application/src/domain/user/use-case.ts
+++ b/application/src/domain/user/use-case.ts
@@ -34,9 +34,9 @@ export class AuthUseCase {
   ): AsyncResult<SignupResult, ClientError | ServerError> {
     // 認証でユーザー作成
     const authResult = await this.repository.signup(email, password)
-    if (isFailure(authResult)) return authResult
+    if (isFailure(authResult)) return failure(authResult.error)
 
-    const { user, session } = authResult.data
+    const { user, session } = authResult.value
 
     // active_userを作成
     const activeUserResult = await this.userCommand.createActiveWithAuthenticationId(
@@ -64,7 +64,7 @@ export class AuthUseCase {
 
     return success({
       session,
-      activeUser: activeUserResult.data,
+      activeUser: activeUserResult.value,
     })
   }
 
@@ -74,17 +74,17 @@ export class AuthUseCase {
   ): AsyncResult<LoginResult, ClientError | ServerError> {
     // 認証でログイン
     const authResult = await this.repository.login(email, password)
-    if (isFailure(authResult)) return authResult
+    if (isFailure(authResult)) return failure(authResult.error)
 
-    const { user, session } = authResult.data
+    const { user, session } = authResult.value
 
     const activeUserResult = await this.findActiveUserByAuthenticationId(user.id)
 
-    if (isFailure(activeUserResult)) return activeUserResult
+    if (isFailure(activeUserResult)) return failure(activeUserResult.error)
 
     return success({
       session,
-      activeUser: activeUserResult.data,
+      activeUser: activeUserResult.value,
     })
   }
 
@@ -95,26 +95,26 @@ export class AuthUseCase {
   async getCurrentActiveUser(): AsyncResult<CurrentUser, ClientError | ServerError> {
     const authUserResult = await this.repository.getCurrentUser()
     if (isFailure(authUserResult)) {
-      return authUserResult
+      return failure(authUserResult.error)
     }
 
-    return this.findActiveUserByAuthenticationId(authUserResult.data.id)
+    return this.findActiveUserByAuthenticationId(authUserResult.value.id)
   }
 
   async refreshSession(): AsyncResult<LoginResult, ClientError | ServerError> {
     // 認証でセッション更新
     const authResult = await this.repository.refreshSession()
-    if (isFailure(authResult)) return authResult
+    if (isFailure(authResult)) return failure(authResult.error)
 
-    const { user, session } = authResult.data
+    const { user, session } = authResult.value
 
     const activeUserResult = await this.findActiveUserByAuthenticationId(user.id)
 
-    if (isFailure(activeUserResult)) return activeUserResult
+    if (isFailure(activeUserResult)) return failure(activeUserResult.error)
 
     return success({
       session,
-      activeUser: activeUserResult.data,
+      activeUser: activeUserResult.value,
     })
   }
 
@@ -127,10 +127,10 @@ export class AuthUseCase {
       return failure(new ServerError(activeUserResult.error))
     }
 
-    if (!activeUserResult.data) {
+    if (!activeUserResult.value) {
       return failure(new ClientError('User not found', 404))
     }
 
-    return success(activeUserResult.data)
+    return success(activeUserResult.value)
   }
 }

--- a/application/src/domain/user/use-case.ts
+++ b/application/src/domain/user/use-case.ts
@@ -1,5 +1,5 @@
+import { err, ok, type Result } from 'neverthrow'
 import { ClientError, ServerError } from '@/common/errors'
-import { type AsyncResult, failure, isFailure, success } from '@/common/result'
 import type { Command, Query } from '@/domain/user/repository'
 import type { CurrentUser } from '@/domain/user/schema/active-user-schema'
 import type { AuthRepository } from './repository'
@@ -31,10 +31,10 @@ export class AuthUseCase {
   async signup(
     email: string,
     password: string,
-  ): AsyncResult<SignupResult, ClientError | ServerError> {
+  ): Promise<Result<SignupResult, ClientError | ServerError>> {
     // 認証でユーザー作成
     const authResult = await this.repository.signup(email, password)
-    if (isFailure(authResult)) return failure(authResult.error)
+    if (authResult.isErr()) return err(authResult.error)
 
     const { user, session } = authResult.value
 
@@ -44,13 +44,13 @@ export class AuthUseCase {
       user.id,
     )
 
-    if (isFailure(activeUserResult)) {
+    if (activeUserResult.isErr()) {
       // Supabase Admin Roleが必要でエラーになるので、コメントアウト
       // // 補償トランザクション: Supabase Authで作成したユーザーを削除
       // const deleteResult = await this.repository.deleteUser(user.id)
-      // if (isFailure(deleteResult)) {
+      // if (deleteResult.isErr()) {
       //   // 補償トランザクション失敗時はExternalServiceErrorを返す
-      //   return failure(
+      //   return err(
       //     new ExternalServiceError(
       //       'Failed to delete Supabase Auth user during compensation',
       //       activeUserResult.error,
@@ -59,10 +59,10 @@ export class AuthUseCase {
       //     ),
       //   )
       // }
-      return failure(activeUserResult.error)
+      return err(activeUserResult.error)
     }
 
-    return success({
+    return ok({
       session,
       activeUser: activeUserResult.value,
     })
@@ -71,48 +71,48 @@ export class AuthUseCase {
   async login(
     email: string,
     password: string,
-  ): AsyncResult<LoginResult, ClientError | ServerError> {
+  ): Promise<Result<LoginResult, ClientError | ServerError>> {
     // 認証でログイン
     const authResult = await this.repository.login(email, password)
-    if (isFailure(authResult)) return failure(authResult.error)
+    if (authResult.isErr()) return err(authResult.error)
 
     const { user, session } = authResult.value
 
     const activeUserResult = await this.findActiveUserByAuthenticationId(user.id)
 
-    if (isFailure(activeUserResult)) return failure(activeUserResult.error)
+    if (activeUserResult.isErr()) return err(activeUserResult.error)
 
-    return success({
+    return ok({
       session,
       activeUser: activeUserResult.value,
     })
   }
 
-  async logout(): AsyncResult<void, ServerError> {
+  async logout(): Promise<Result<void, ServerError>> {
     return this.repository.logout()
   }
 
-  async getCurrentActiveUser(): AsyncResult<CurrentUser, ClientError | ServerError> {
+  async getCurrentActiveUser(): Promise<Result<CurrentUser, ClientError | ServerError>> {
     const authUserResult = await this.repository.getCurrentUser()
-    if (isFailure(authUserResult)) {
-      return failure(authUserResult.error)
+    if (authUserResult.isErr()) {
+      return err(authUserResult.error)
     }
 
     return this.findActiveUserByAuthenticationId(authUserResult.value.id)
   }
 
-  async refreshSession(): AsyncResult<LoginResult, ClientError | ServerError> {
+  async refreshSession(): Promise<Result<LoginResult, ClientError | ServerError>> {
     // 認証でセッション更新
     const authResult = await this.repository.refreshSession()
-    if (isFailure(authResult)) return failure(authResult.error)
+    if (authResult.isErr()) return err(authResult.error)
 
     const { user, session } = authResult.value
 
     const activeUserResult = await this.findActiveUserByAuthenticationId(user.id)
 
-    if (isFailure(activeUserResult)) return failure(activeUserResult.error)
+    if (activeUserResult.isErr()) return err(activeUserResult.error)
 
-    return success({
+    return ok({
       session,
       activeUser: activeUserResult.value,
     })
@@ -120,17 +120,17 @@ export class AuthUseCase {
 
   private async findActiveUserByAuthenticationId(
     authenticationId: string,
-  ): AsyncResult<CurrentUser, ClientError | ServerError> {
+  ): Promise<Result<CurrentUser, ClientError | ServerError>> {
     const activeUserResult = await this.userQuery.findActiveByAuthenticationId(authenticationId)
 
-    if (isFailure(activeUserResult)) {
-      return failure(new ServerError(activeUserResult.error))
+    if (activeUserResult.isErr()) {
+      return err(new ServerError(activeUserResult.error))
     }
 
     if (!activeUserResult.value) {
-      return failure(new ClientError('User not found', 404))
+      return err(new ClientError('User not found', 404))
     }
 
-    return success(activeUserResult.value)
+    return ok(activeUserResult.value)
   }
 }

--- a/application/src/test/e2e/page/trends._index.test.ts
+++ b/application/src/test/e2e/page/trends._index.test.ts
@@ -11,9 +11,9 @@ const ARTICLE_COUNT = 10
 
 function getTodayJstNoon(daysOffset = 0): Date {
   const todayResult = toJstDateString(new Date())
-  const today = isFailure(todayResult) ? '1970-01-01' : todayResult.data
+  const today = isFailure(todayResult) ? '1970-01-01' : todayResult.value
   const dateResult = addJstDays(today, daysOffset)
-  const dateString = isFailure(dateResult) ? today : dateResult.data
+  const dateString = isFailure(dateResult) ? today : dateResult.value
   return new Date(`${dateString}T12:00:00+09:00`)
 }
 

--- a/application/src/test/e2e/page/trends._index.test.ts
+++ b/application/src/test/e2e/page/trends._index.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from '@playwright/test'
 import { addJstDays, toJstDateString } from '@/common/locale/date'
-import { isFailure } from '@/common/result'
 import { ArticleDrawer } from '@/test/e2e/pom/components/article-drawer'
 import { DesktopMediaFilter } from '@/test/e2e/pom/components/desktop-media-filter'
 import { SUPPORTED_ARTICLE_URL_PATTERN } from '@/test/e2e/pom/constants'
@@ -11,9 +10,9 @@ const ARTICLE_COUNT = 10
 
 function getTodayJstNoon(daysOffset = 0): Date {
   const todayResult = toJstDateString(new Date())
-  const today = isFailure(todayResult) ? '1970-01-01' : todayResult.value
+  const today = todayResult.isErr() ? '1970-01-01' : todayResult.value
   const dateResult = addJstDays(today, daysOffset)
-  const dateString = isFailure(dateResult) ? today : dateResult.value
+  const dateString = dateResult.isErr() ? today : dateResult.value
   return new Date(`${dateString}T12:00:00+09:00`)
 }
 

--- a/application/src/test/helper/article.ts
+++ b/application/src/test/helper/article.ts
@@ -7,7 +7,7 @@ import { getTestRdb } from './rdb'
 
 function getTodayJstNoon(): Date {
   const todayJstResult = toJstDateString(new Date())
-  const todayJst = isFailure(todayJstResult) ? '1970-01-01' : todayJstResult.data
+  const todayJst = isFailure(todayJstResult) ? '1970-01-01' : todayJstResult.value
   // INFO: trends APIは日付フィルタをJSTで評価するため、E2EデータもJST当日内に固定する
   return new Date(`${todayJst}T12:00:00+09:00`)
 }

--- a/application/src/test/helper/article.ts
+++ b/application/src/test/helper/article.ts
@@ -1,13 +1,12 @@
 import { faker } from '@faker-js/faker'
 import { toJstDateString } from '@/common/locale/date'
-import { isFailure } from '@/common/result'
 import { ARTICLE_MEDIA, type ArticleMedia } from '@/domain/article/media'
 import { fromDbId, toDbId, toDbIds } from '@/infrastructure/rdb-id'
 import { getTestRdb } from './rdb'
 
 function getTodayJstNoon(): Date {
   const todayJstResult = toJstDateString(new Date())
-  const todayJst = isFailure(todayJstResult) ? '1970-01-01' : todayJstResult.value
+  const todayJst = todayJstResult.isErr() ? '1970-01-01' : todayJstResult.value
   // INFO: trends APIは日付フィルタをJSTで評価するため、E2EデータもJST当日内に固定する
   return new Date(`${todayJst}T12:00:00+09:00`)
 }

--- a/application/src/web/client/features/diary/diary-shared.test.ts
+++ b/application/src/web/client/features/diary/diary-shared.test.ts
@@ -1,6 +1,6 @@
+import { err, ok } from 'neverthrow'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import * as dateModule from '@/common/locale/date'
-import { failure, success } from '@/common/result'
 import { getTodayJst, sumSourceSummary } from './diary-shared'
 
 describe('diary-shared', () => {
@@ -10,14 +10,14 @@ describe('diary-shared', () => {
 
   describe('getTodayJst', () => {
     it('JSTの日付文字列を返す', () => {
-      vi.spyOn(dateModule, 'toTodayJstDateString').mockReturnValue(success('2026-03-08'))
+      vi.spyOn(dateModule, 'toTodayJstDateString').mockReturnValue(ok('2026-03-08'))
 
       expect(getTodayJst()).toBe('2026-03-08')
     })
 
     it('JST解決に失敗したらnullを返す', () => {
       vi.spyOn(dateModule, 'toTodayJstDateString').mockReturnValue(
-        failure(new Error('JST日付の取得に失敗しました')),
+        err(new Error('JST日付の取得に失敗しました')),
       )
 
       expect(getTodayJst()).toBeNull()

--- a/application/src/web/client/features/diary/diary-shared.ts
+++ b/application/src/web/client/features/diary/diary-shared.ts
@@ -11,7 +11,7 @@ export function getTodayJst(): string | null {
   if (isFailure(result)) {
     return null
   }
-  return result.data
+  return result.value
 }
 
 export function sumSourceSummary(sources: SourceSummary[]): SourceSummary {

--- a/application/src/web/client/features/diary/diary-shared.ts
+++ b/application/src/web/client/features/diary/diary-shared.ts
@@ -1,5 +1,4 @@
 import { toTodayJstDateString } from '@/common/locale/date'
-import { isFailure } from '@/common/result'
 
 type SourceSummary = {
   read: number
@@ -8,7 +7,7 @@ type SourceSummary = {
 
 export function getTodayJst(): string | null {
   const result = toTodayJstDateString()
-  if (isFailure(result)) {
+  if (result.isErr()) {
     return null
   }
   return result.value

--- a/application/src/web/client/routes/diary/hooks/use-analytics.test.ts
+++ b/application/src/web/client/routes/diary/hooks/use-analytics.test.ts
@@ -70,14 +70,14 @@ const buildRangeItemResponse = (
 const getTodayJst = () => {
   const result = toJstDateString(new Date())
   if (isFailure(result)) return '1970-01-01'
-  return result.data
+  return result.value
 }
 
 const buildDates = (baseDate: string) =>
   Array.from({ length: 7 }, (_, index) => {
     const dateResult = addJstDays(baseDate, -(6 - index))
     if (isFailure(dateResult)) return baseDate
-    return dateResult.data
+    return dateResult.value
   })
 
 describe('useAnalytics', () => {

--- a/application/src/web/client/routes/diary/hooks/use-analytics.test.ts
+++ b/application/src/web/client/routes/diary/hooks/use-analytics.test.ts
@@ -4,7 +4,6 @@ import { MemoryRouter } from 'react-router'
 import { SWRConfig } from 'swr'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { addJstDays, toJstDateString } from '@/common/locale/date'
-import { isFailure } from '@/common/result'
 import useAnalytics from './use-analytics'
 import useDiaryApi, { type DiaryRangeItemResponse, type DiaryResponse } from './use-diary-api'
 
@@ -69,14 +68,14 @@ const buildRangeItemResponse = (
 
 const getTodayJst = () => {
   const result = toJstDateString(new Date())
-  if (isFailure(result)) return '1970-01-01'
+  if (result.isErr()) return '1970-01-01'
   return result.value
 }
 
 const buildDates = (baseDate: string) =>
   Array.from({ length: 7 }, (_, index) => {
     const dateResult = addJstDays(baseDate, -(6 - index))
-    if (isFailure(dateResult)) return baseDate
+    if (dateResult.isErr()) return baseDate
     return dateResult.value
   })
 

--- a/application/src/web/client/routes/diary/hooks/use-analytics.ts
+++ b/application/src/web/client/routes/diary/hooks/use-analytics.ts
@@ -28,7 +28,7 @@ const buildAvailableDates = (todayJst: string) =>
   Array.from({ length: DIARY_DAYS }, (_, index) => {
     const dateResult = addJstDays(todayJst, -(DIARY_DAYS - 1 - index))
     if (isFailure(dateResult)) return todayJst
-    return dateResult.data
+    return dateResult.value
   })
 
 export default function useAnalytics(enabled: boolean) {

--- a/application/src/web/client/routes/diary/hooks/use-analytics.ts
+++ b/application/src/web/client/routes/diary/hooks/use-analytics.ts
@@ -3,7 +3,6 @@ import { useSearchParams } from 'react-router'
 import useSWR from 'swr'
 import { addJstDays } from '@/common/locale/date'
 import { DEFAULT_PAGE, offsetPaginationSchema } from '@/common/pagination/schema'
-import { isFailure } from '@/common/result'
 import { DIARY_DAYS, DIARY_READ_LIMIT } from '@/domain/article/diary'
 import { ARTICLE_MEDIA, type ArticleMedia } from '@/domain/article/media'
 import { getTodayJst, sumSourceSummary } from '@/web/client/features/diary/diary-shared'
@@ -27,7 +26,7 @@ type SummaryRangeData = {
 const buildAvailableDates = (todayJst: string) =>
   Array.from({ length: DIARY_DAYS }, (_, index) => {
     const dateResult = addJstDays(todayJst, -(DIARY_DAYS - 1 - index))
-    if (isFailure(dateResult)) return todayJst
+    if (dateResult.isErr()) return todayJst
     return dateResult.value
   })
 

--- a/application/src/web/client/routes/login/route.tsx
+++ b/application/src/web/client/routes/login/route.tsx
@@ -6,7 +6,6 @@ import {
   useNavigation,
 } from 'react-router'
 import Logger from '@/common/logger'
-import { isFailure } from '@/common/result'
 import { createAuthActionUseCase } from '@/web/client/features/authenticate/auth-action-use-case'
 import {
   AUTH_ERROR_MESSAGES,
@@ -58,7 +57,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
     const { useCase, headers } = createAuthActionUseCase(request, context)
     const result = await useCase.login(validation.data.email, validation.data.password)
 
-    if (isFailure(result)) {
+    if (result.isErr()) {
       return { formError: resolveLoginErrorMessage(result.error) } satisfies LoginActionData
     }
 

--- a/application/src/web/client/routes/signup/route.tsx
+++ b/application/src/web/client/routes/signup/route.tsx
@@ -6,7 +6,6 @@ import {
   useNavigation,
 } from 'react-router'
 import Logger from '@/common/logger'
-import { isFailure } from '@/common/result'
 import { createAuthActionUseCase } from '@/web/client/features/authenticate/auth-action-use-case'
 import {
   AUTH_ERROR_MESSAGES,
@@ -58,7 +57,7 @@ export async function action({ request, context }: ActionFunctionArgs) {
     const { useCase } = createAuthActionUseCase(request, context)
     const result = await useCase.signup(validation.data.email, validation.data.password)
 
-    if (isFailure(result)) {
+    if (result.isErr()) {
       return { formError: resolveSignupErrorMessage(result.error) } satisfies SignupActionData
     }
 

--- a/application/src/web/client/routes/trends._index/hooks/use-articles.test.ts
+++ b/application/src/web/client/routes/trends._index/hooks/use-articles.test.ts
@@ -7,7 +7,6 @@ import { toast } from 'sonner'
 import { SWRConfig } from 'swr'
 import type { MockedFunction } from 'vitest'
 import { addJstDays, toJstDateString } from '@/common/locale/date'
-import { isFailure } from '@/common/result'
 import getApiClientForClient from '@/infrastructure/api'
 import useArticles, { type Article } from './use-articles'
 
@@ -76,7 +75,7 @@ const generateFakeResponse = (
 
 const resolveJstDateString = (rawDate: Date): string => {
   const result = toJstDateString(rawDate)
-  if (isFailure(result)) {
+  if (result.isErr()) {
     return '1970-01-01'
   }
 
@@ -85,7 +84,7 @@ const resolveJstDateString = (rawDate: Date): string => {
 
 const resolveJstDateWithOffset = (baseDateString: string, days: number): string => {
   const result = addJstDays(baseDateString, days)
-  if (isFailure(result)) {
+  if (result.isErr()) {
     return baseDateString
   }
 

--- a/application/src/web/client/routes/trends._index/hooks/use-articles.test.ts
+++ b/application/src/web/client/routes/trends._index/hooks/use-articles.test.ts
@@ -80,7 +80,7 @@ const resolveJstDateString = (rawDate: Date): string => {
     return '1970-01-01'
   }
 
-  return result.data
+  return result.value
 }
 
 const resolveJstDateWithOffset = (baseDateString: string, days: number): string => {
@@ -89,7 +89,7 @@ const resolveJstDateWithOffset = (baseDateString: string, days: number): string 
     return baseDateString
   }
 
-  return result.data
+  return result.value
 }
 
 // biome-ignore lint/suspicious/noExplicitAny: getApiClientForClientの型が面倒なのでanyを使用

--- a/application/src/web/client/routes/trends._index/hooks/use-articles.ts
+++ b/application/src/web/client/routes/trends._index/hooks/use-articles.ts
@@ -64,7 +64,7 @@ const getDateRangeByPreset = (datePreset: DatePresetType, todayJstDateString: st
   }
 
   return {
-    from: fromDateResult.data,
+    from: fromDateResult.value,
     to: todayJstDateString,
   }
 }
@@ -75,7 +75,7 @@ const getTodayJstDateString = (baseDate: Date): string => {
     return baseDate.toISOString().slice(0, 10)
   }
 
-  return todayJstDateResult.data
+  return todayJstDateResult.value
 }
 
 const parseDatePreset = (

--- a/application/src/web/client/routes/trends._index/hooks/use-articles.ts
+++ b/application/src/web/client/routes/trends._index/hooks/use-articles.ts
@@ -9,7 +9,6 @@ import {
   offsetPaginationMobileSchema,
   offsetPaginationSchema,
 } from '@/common/pagination/schema'
-import { isFailure } from '@/common/result'
 import { isArticleMedia } from '@/domain/article/media'
 import type { ArticleOutput } from '@/domain/article/schema/article-schema'
 import { useIsMobile } from '@/web/client/components/shadcn/hooks/use-mobile'
@@ -59,7 +58,7 @@ const isValidDateString = (value: string | null) => !!value && DATE_STRING_REGEX
 
 const getDateRangeByPreset = (datePreset: DatePresetType, todayJstDateString: string) => {
   const fromDateResult = addJstDays(todayJstDateString, -DATE_PRESET_MAP[datePreset])
-  if (isFailure(fromDateResult)) {
+  if (fromDateResult.isErr()) {
     return { from: todayJstDateString, to: todayJstDateString }
   }
 
@@ -71,7 +70,7 @@ const getDateRangeByPreset = (datePreset: DatePresetType, todayJstDateString: st
 
 const getTodayJstDateString = (baseDate: Date): string => {
   const todayJstDateResult = toJstDateString(baseDate)
-  if (isFailure(todayJstDateResult)) {
+  if (todayJstDateResult.isErr()) {
     return baseDate.toISOString().slice(0, 10)
   }
 

--- a/application/src/web/client/routes/trends._index/hooks/use-read-article.ts
+++ b/application/src/web/client/routes/trends._index/hooks/use-read-article.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react'
 import { toast } from 'sonner'
-import { isFailure, wrapAsyncCall } from '@/common/result'
+import { wrapAsyncCall } from '@/common/result'
 import getApiClientForClient from '../../../infrastructure/api'
 
 const MarkAsReadErrorMessage = '既読に失敗しました'
@@ -30,7 +30,7 @@ export default function useReadArticle() {
 
     setIsLoading(false)
 
-    if (isFailure(result)) {
+    if (result.isErr()) {
       toast.error(MarkAsReadErrorMessage)
       return false
     }
@@ -57,7 +57,7 @@ export default function useReadArticle() {
 
     setIsLoading(false)
 
-    if (isFailure(result)) {
+    if (result.isErr()) {
       toast.error(MarkAsUnreadErrorMessage)
       return false
     }

--- a/application/src/web/middleware/authenticator/authenticator.ts
+++ b/application/src/web/middleware/authenticator/authenticator.ts
@@ -1,6 +1,5 @@
 import { createMiddleware } from 'hono/factory'
 import { HTTPException } from 'hono/http-exception'
-import { isFailure } from '@/common/result'
 import { Env } from '../../env'
 import CONTEXT_KEY from '../context'
 import { validateSession } from './validate'
@@ -8,7 +7,7 @@ import { validateSession } from './validate'
 const authenticator = createMiddleware<Env>(async (c, next) => {
   const validationResult = await validateSession(c)
 
-  if (isFailure(validationResult)) {
+  if (validationResult.isErr()) {
     // ユーザーが見つからない場合は404、それ以外は401
     const statusCode = validationResult.error.reason === 'user_not_found' ? 404 : 401
     throw new HTTPException(statusCode, { message: 'login required' })

--- a/application/src/web/middleware/authenticator/authenticator.ts
+++ b/application/src/web/middleware/authenticator/authenticator.ts
@@ -14,7 +14,7 @@ const authenticator = createMiddleware<Env>(async (c, next) => {
     throw new HTTPException(statusCode, { message: 'login required' })
   }
 
-  c.set(CONTEXT_KEY.SESSION_USER, validationResult.data.sessionUser)
+  c.set(CONTEXT_KEY.SESSION_USER, validationResult.value.sessionUser)
   return next()
 })
 

--- a/application/src/web/middleware/authenticator/optional-authenticator.ts
+++ b/application/src/web/middleware/authenticator/optional-authenticator.ts
@@ -1,5 +1,4 @@
 import { createMiddleware } from 'hono/factory'
-import { isSuccess } from '@/common/result'
 import { Env } from '../../env'
 import CONTEXT_KEY from '../context'
 import { validateSession } from './validate'
@@ -12,7 +11,7 @@ import { validateSession } from './validate'
 const optionalAuthenticator = createMiddleware<Env>(async (c, next) => {
   const validationResult = await validateSession(c)
 
-  if (isSuccess(validationResult)) {
+  if (validationResult.isOk()) {
     c.set(CONTEXT_KEY.SESSION_USER, validationResult.value.sessionUser)
   }
 

--- a/application/src/web/middleware/authenticator/optional-authenticator.ts
+++ b/application/src/web/middleware/authenticator/optional-authenticator.ts
@@ -13,7 +13,7 @@ const optionalAuthenticator = createMiddleware<Env>(async (c, next) => {
   const validationResult = await validateSession(c)
 
   if (isSuccess(validationResult)) {
-    c.set(CONTEXT_KEY.SESSION_USER, validationResult.data.sessionUser)
+    c.set(CONTEXT_KEY.SESSION_USER, validationResult.value.sessionUser)
   }
 
   return next()

--- a/application/src/web/middleware/authenticator/validate.ts
+++ b/application/src/web/middleware/authenticator/validate.ts
@@ -1,7 +1,7 @@
 import type { Context } from 'hono'
+import { err, ok, type Result } from 'neverthrow'
 import { ClientError, ServerError } from '@/common/errors'
 import UnauthorizedError from '@/common/errors/client-error/unauthorized-error'
-import { failure, isFailure, type Result, success } from '@/common/result'
 import { createAuthUseCase } from '@/domain/user'
 import getRdbClient from '@/infrastructure/rdb'
 import { createSupabaseAuthClient } from '@/infrastructure/supabase'
@@ -43,20 +43,20 @@ export async function validateSession(
     const useCase = createAuthUseCase(supabaseClient, rdb)
 
     const result = await useCase.getCurrentActiveUser()
-    if (isFailure(result)) {
+    if (result.isErr()) {
       if (result.error instanceof UnauthorizedError) {
-        return failure(createAuthValidationError('no_session', 'No session found'))
+        return err(createAuthValidationError('no_session', 'No session found'))
       }
       if (result.error instanceof ClientError || result.error instanceof ServerError) {
         logger.warn('Session validation failed', { error: result.error })
       } else {
         logger.error('Unexpected error occurred', { error: result.error })
       }
-      return failure(createAuthValidationError('validation_failed', 'Session validation failed'))
+      return err(createAuthValidationError('validation_failed', 'Session validation failed'))
     }
 
     if (!result.value) {
-      return failure(createAuthValidationError('user_not_found', 'User not found'))
+      return err(createAuthValidationError('user_not_found', 'User not found'))
     }
 
     // 管理者権限をチェック
@@ -66,9 +66,9 @@ export async function validateSession(
       email: result.value.email,
     }
 
-    return success({ sessionUser })
+    return ok({ sessionUser })
   } catch (error) {
     logger.warn('Session validation setup failed', { error })
-    return failure(createAuthValidationError('validation_failed', 'Session validation failed'))
+    return err(createAuthValidationError('validation_failed', 'Session validation failed'))
   }
 }

--- a/application/src/web/middleware/authenticator/validate.ts
+++ b/application/src/web/middleware/authenticator/validate.ts
@@ -55,10 +55,6 @@ export async function validateSession(
       return err(createAuthValidationError('validation_failed', 'Session validation failed'))
     }
 
-    if (!result.value) {
-      return err(createAuthValidationError('user_not_found', 'User not found'))
-    }
-
     // 管理者権限をチェック
     const sessionUser: SessionUser = {
       activeUserId: result.value.activeUserId,

--- a/application/src/web/middleware/authenticator/validate.ts
+++ b/application/src/web/middleware/authenticator/validate.ts
@@ -55,15 +55,15 @@ export async function validateSession(
       return failure(createAuthValidationError('validation_failed', 'Session validation failed'))
     }
 
-    if (!result.data) {
+    if (!result.value) {
       return failure(createAuthValidationError('user_not_found', 'User not found'))
     }
 
     // 管理者権限をチェック
     const sessionUser: SessionUser = {
-      activeUserId: result.data.activeUserId,
-      displayName: result.data.displayName,
-      email: result.data.email,
+      activeUserId: result.value.activeUserId,
+      displayName: result.value.displayName,
+      email: result.value.email,
     }
 
     return success({ sessionUser })

--- a/application/src/web/server/article/handler/get-articles.ts
+++ b/application/src/web/server/article/handler/get-articles.ts
@@ -77,7 +77,7 @@ export default async function getArticles(c: ZodValidatedQueryContext<ApiQueryPa
     throw handleError(result.error, logger)
   }
 
-  const paginationResult = result.data
+  const paginationResult = result.value
   logger.info('articles retrieved successfully', { count: paginationResult.data.length })
   const response: ArticleListResponse = {
     data: paginationResult.data.map(convertToResponse),

--- a/application/src/web/server/article/handler/get-articles.ts
+++ b/application/src/web/server/article/handler/get-articles.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod'
 import { handleError } from '@/common/errors'
 import { OffsetPaginationResult, offsetPaginationSchema } from '@/common/pagination'
-import { isFailure } from '@/common/result'
 import { createArticleUseCase, QueryParams } from '@/domain/article'
 import { ARTICLE_MEDIA } from '@/domain/article/media'
 import type { ArticleWithOptionalReadStatus } from '@/domain/article/schema/article-schema'
@@ -73,7 +72,7 @@ export default async function getArticles(c: ZodValidatedQueryContext<ApiQueryPa
     convertApiQueryParams(transformedParams),
     activeUserId,
   )
-  if (isFailure(result)) {
+  if (result.isErr()) {
     throw handleError(result.error, logger)
   }
 

--- a/application/src/web/server/article/handler/get-diary.test.ts
+++ b/application/src/web/server/article/handler/get-diary.test.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod'
 import { addJstDays, toJstDateString } from '@/common/locale/date'
-import { isFailure } from '@/common/result'
 import TEST_ENV from '@/test/env'
 import * as articleHelper from '@/test/helper/article'
 import type { CleanUpIds } from '@/test/helper/user'
@@ -39,7 +38,7 @@ type DiaryRangeResponse = {
 
 const getTodayJst = () => {
   const result = toJstDateString(new Date())
-  if (isFailure(result)) throw result.error
+  if (result.isErr()) throw result.error
   return result.value
 }
 
@@ -202,7 +201,7 @@ describe('GET /api/articles/diary (単日詳細)', () => {
 
   it('7日範囲外の日付は422', async () => {
     const tooOldDateResult = addJstDays(todayJst, -7)
-    if (isFailure(tooOldDateResult)) throw tooOldDateResult.error
+    if (tooOldDateResult.isErr()) throw tooOldDateResult.error
 
     const response = await requestDiaryRange(
       `from=${tooOldDateResult.value}&to=${tooOldDateResult.value}&page=1`,
@@ -213,7 +212,7 @@ describe('GET /api/articles/diary (単日詳細)', () => {
 
   it('未来日付は422', async () => {
     const tomorrowResult = addJstDays(todayJst, 1)
-    if (isFailure(tomorrowResult)) throw tomorrowResult.error
+    if (tomorrowResult.isErr()) throw tomorrowResult.error
 
     const response = await requestDiaryRange(
       `from=${tomorrowResult.value}&to=${tomorrowResult.value}&page=1`,
@@ -224,7 +223,7 @@ describe('GET /api/articles/diary (単日詳細)', () => {
 
   it('page指定時にfromとtoが異なる場合は422', async () => {
     const yesterdayResult = addJstDays(todayJst, -1)
-    if (isFailure(yesterdayResult)) throw yesterdayResult.error
+    if (yesterdayResult.isErr()) throw yesterdayResult.error
 
     const response = await requestDiaryRange(
       `from=${yesterdayResult.value}&to=${todayJst}&page=1`,
@@ -291,7 +290,7 @@ describe('GET /api/articles/diary', () => {
 
   it('指定期間のダイアリー集計を取得できる', async () => {
     const fromResult = addJstDays(todayJst, -6)
-    if (isFailure(fromResult)) throw fromResult.error
+    if (fromResult.isErr()) throw fromResult.error
 
     const response = await requestDiaryRange(`from=${fromResult.value}&to=${todayJst}`, authCookies)
 
@@ -313,7 +312,7 @@ describe('GET /api/articles/diary', () => {
 
   it('from > to は422', async () => {
     const fromResult = addJstDays(todayJst, -1)
-    if (isFailure(fromResult)) throw fromResult.error
+    if (fromResult.isErr()) throw fromResult.error
 
     const response = await requestDiaryRange(`from=${todayJst}&to=${fromResult.value}`, authCookies)
     expect(response.status).toBe(422)
@@ -321,7 +320,7 @@ describe('GET /api/articles/diary', () => {
 
   it('7日範囲外の期間は422', async () => {
     const fromResult = addJstDays(todayJst, -7)
-    if (isFailure(fromResult)) throw fromResult.error
+    if (fromResult.isErr()) throw fromResult.error
 
     const response = await requestDiaryRange(`from=${fromResult.value}&to=${todayJst}`, authCookies)
     expect(response.status).toBe(422)
@@ -336,7 +335,7 @@ describe('GET /api/articles/diary', () => {
 
   it('未来日付を含む期間は422', async () => {
     const toResult = addJstDays(todayJst, 1)
-    if (isFailure(toResult)) throw toResult.error
+    if (toResult.isErr()) throw toResult.error
 
     const response = await requestDiaryRange(`from=${todayJst}&to=${toResult.value}`, authCookies)
     expect(response.status).toBe(422)
@@ -344,7 +343,7 @@ describe('GET /api/articles/diary', () => {
 
   it('未認証時は401', async () => {
     const fromResult = addJstDays(todayJst, -6)
-    if (isFailure(fromResult)) throw fromResult.error
+    if (fromResult.isErr()) throw fromResult.error
 
     const response = await requestDiaryRange(`from=${fromResult.value}&to=${todayJst}`)
     expect(response.status).toBe(401)

--- a/application/src/web/server/article/handler/get-diary.test.ts
+++ b/application/src/web/server/article/handler/get-diary.test.ts
@@ -40,7 +40,7 @@ type DiaryRangeResponse = {
 const getTodayJst = () => {
   const result = toJstDateString(new Date())
   if (isFailure(result)) throw result.error
-  return result.data
+  return result.value
 }
 
 function toJstDateTime(date: string, time: string) {
@@ -205,7 +205,7 @@ describe('GET /api/articles/diary (単日詳細)', () => {
     if (isFailure(tooOldDateResult)) throw tooOldDateResult.error
 
     const response = await requestDiaryRange(
-      `from=${tooOldDateResult.data}&to=${tooOldDateResult.data}&page=1`,
+      `from=${tooOldDateResult.value}&to=${tooOldDateResult.value}&page=1`,
       authCookies,
     )
     expect(response.status).toBe(422)
@@ -216,7 +216,7 @@ describe('GET /api/articles/diary (単日詳細)', () => {
     if (isFailure(tomorrowResult)) throw tomorrowResult.error
 
     const response = await requestDiaryRange(
-      `from=${tomorrowResult.data}&to=${tomorrowResult.data}&page=1`,
+      `from=${tomorrowResult.value}&to=${tomorrowResult.value}&page=1`,
       authCookies,
     )
     expect(response.status).toBe(422)
@@ -227,7 +227,7 @@ describe('GET /api/articles/diary (単日詳細)', () => {
     if (isFailure(yesterdayResult)) throw yesterdayResult.error
 
     const response = await requestDiaryRange(
-      `from=${yesterdayResult.data}&to=${todayJst}&page=1`,
+      `from=${yesterdayResult.value}&to=${todayJst}&page=1`,
       authCookies,
     )
     expect(response.status).toBe(422)
@@ -293,7 +293,7 @@ describe('GET /api/articles/diary', () => {
     const fromResult = addJstDays(todayJst, -6)
     if (isFailure(fromResult)) throw fromResult.error
 
-    const response = await requestDiaryRange(`from=${fromResult.data}&to=${todayJst}`, authCookies)
+    const response = await requestDiaryRange(`from=${fromResult.value}&to=${todayJst}`, authCookies)
 
     expect(response.status).toBe(200)
     const json = (await response.json()) as DiaryRangeResponse
@@ -315,7 +315,7 @@ describe('GET /api/articles/diary', () => {
     const fromResult = addJstDays(todayJst, -1)
     if (isFailure(fromResult)) throw fromResult.error
 
-    const response = await requestDiaryRange(`from=${todayJst}&to=${fromResult.data}`, authCookies)
+    const response = await requestDiaryRange(`from=${todayJst}&to=${fromResult.value}`, authCookies)
     expect(response.status).toBe(422)
   })
 
@@ -323,7 +323,7 @@ describe('GET /api/articles/diary', () => {
     const fromResult = addJstDays(todayJst, -7)
     if (isFailure(fromResult)) throw fromResult.error
 
-    const response = await requestDiaryRange(`from=${fromResult.data}&to=${todayJst}`, authCookies)
+    const response = await requestDiaryRange(`from=${fromResult.value}&to=${todayJst}`, authCookies)
     expect(response.status).toBe(422)
   })
 
@@ -338,7 +338,7 @@ describe('GET /api/articles/diary', () => {
     const toResult = addJstDays(todayJst, 1)
     if (isFailure(toResult)) throw toResult.error
 
-    const response = await requestDiaryRange(`from=${todayJst}&to=${toResult.data}`, authCookies)
+    const response = await requestDiaryRange(`from=${todayJst}&to=${toResult.value}`, authCookies)
     expect(response.status).toBe(422)
   })
 
@@ -346,7 +346,7 @@ describe('GET /api/articles/diary', () => {
     const fromResult = addJstDays(todayJst, -6)
     if (isFailure(fromResult)) throw fromResult.error
 
-    const response = await requestDiaryRange(`from=${fromResult.data}&to=${todayJst}`)
+    const response = await requestDiaryRange(`from=${fromResult.value}&to=${todayJst}`)
     expect(response.status).toBe(401)
   })
 })

--- a/application/src/web/server/article/handler/get-diary.ts
+++ b/application/src/web/server/article/handler/get-diary.ts
@@ -3,7 +3,6 @@ import { z } from 'zod'
 import { handleError } from '@/common/errors'
 import { addJstDays, toJstDate, toJstDateString, toTodayJstDateString } from '@/common/locale/date'
 import { MAX_PAGE } from '@/common/pagination'
-import { isFailure } from '@/common/result'
 import { createArticleUseCase } from '@/domain/article'
 import { DIARY_DAYS, DIARY_READ_LIMIT } from '@/domain/article/diary'
 import type { DailyDiary, DailyDiaryRangeItem } from '@/domain/article/schema/diary-schema'
@@ -21,7 +20,7 @@ const diaryDateSchema = z
     if (Number.isNaN(parsed.getTime())) return false
 
     const normalized = toJstDateString(parsed)
-    return !isFailure(normalized) && normalized.value === inputDate
+    return !normalized.isErr() && normalized.value === inputDate
   }, DIARY_DATE_MESSAGE)
 
 export const diaryQuerySchema = z
@@ -92,7 +91,7 @@ export default async function getDiary(c: ZodValidatedQueryContext<DiaryQuery>) 
       query.page,
       DIARY_READ_LIMIT,
     )
-    if (isFailure(detailResult)) {
+    if (detailResult.isErr()) {
       throw handleError(detailResult.error, logger)
     }
 
@@ -108,7 +107,7 @@ export default async function getDiary(c: ZodValidatedQueryContext<DiaryQuery>) 
   }
 
   const result = await useCase.getDailyDiaryRange(sessionUser.activeUserId, fromDate, toDate)
-  if (isFailure(result)) {
+  if (result.isErr()) {
     throw handleError(result.error, logger)
   }
   const response = toDiaryResponse(result.value)
@@ -124,7 +123,7 @@ export default async function getDiary(c: ZodValidatedQueryContext<DiaryQuery>) 
 
 function resolveTodayJst(): string {
   const todayResult = toTodayJstDateString()
-  if (isFailure(todayResult)) {
+  if (todayResult.isErr()) {
     throw new HTTPException(500, { message: 'Failed to resolve JST date' })
   }
   return todayResult.value
@@ -141,7 +140,7 @@ function validateDiaryDateRange(fromDate: string, toDate: string, todayJst: stri
   }
 
   const earliestResult = addJstDays(todayJst, -(DIARY_DAYS - 1))
-  if (isFailure(earliestResult)) {
+  if (earliestResult.isErr()) {
     throw new HTTPException(500, { message: 'Failed to resolve diary date range' })
   }
   const earliestDate = earliestResult.value

--- a/application/src/web/server/article/handler/get-diary.ts
+++ b/application/src/web/server/article/handler/get-diary.ts
@@ -21,7 +21,7 @@ const diaryDateSchema = z
     if (Number.isNaN(parsed.getTime())) return false
 
     const normalized = toJstDateString(parsed)
-    return !isFailure(normalized) && normalized.data === inputDate
+    return !isFailure(normalized) && normalized.value === inputDate
   }, DIARY_DATE_MESSAGE)
 
 export const diaryQuerySchema = z
@@ -96,13 +96,13 @@ export default async function getDiary(c: ZodValidatedQueryContext<DiaryQuery>) 
       throw handleError(detailResult.error, logger)
     }
 
-    const response = toDiaryDetailResponse(detailResult.data)
+    const response = toDiaryDetailResponse(detailResult.value)
     logger.info('daily diary detail retrieved successfully', {
       activeUserId: sessionUser.activeUserId,
       date: fromDate,
       page: query.page,
-      read: detailResult.data.summary.read,
-      skip: detailResult.data.summary.skip,
+      read: detailResult.value.summary.read,
+      skip: detailResult.value.summary.skip,
     })
     return c.json(response, 200)
   }
@@ -111,7 +111,7 @@ export default async function getDiary(c: ZodValidatedQueryContext<DiaryQuery>) 
   if (isFailure(result)) {
     throw handleError(result.error, logger)
   }
-  const response = toDiaryResponse(result.data)
+  const response = toDiaryResponse(result.value)
   logger.info('daily diary range retrieved successfully', {
     activeUserId: sessionUser.activeUserId,
     from: fromDate,
@@ -127,7 +127,7 @@ function resolveTodayJst(): string {
   if (isFailure(todayResult)) {
     throw new HTTPException(500, { message: 'Failed to resolve JST date' })
   }
-  return todayResult.data
+  return todayResult.value
 }
 
 function validateDiaryDateRange(fromDate: string, toDate: string, todayJst: string) {
@@ -144,7 +144,7 @@ function validateDiaryDateRange(fromDate: string, toDate: string, todayJst: stri
   if (isFailure(earliestResult)) {
     throw new HTTPException(500, { message: 'Failed to resolve diary date range' })
   }
-  const earliestDate = earliestResult.data
+  const earliestDate = earliestResult.value
 
   const causes: { from?: string[]; to?: string[] } = {}
   if (fromDate < earliestDate) {

--- a/application/src/web/server/article/handler/unread-digestion-articles.ts
+++ b/application/src/web/server/article/handler/unread-digestion-articles.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod'
 import { handleError } from '@/common/errors'
-import { isFailure } from '@/common/result'
 import { createArticleUseCase } from '@/domain/article'
 import { ARTICLE_MEDIA } from '@/domain/article/media'
 import type { ArticleOutput } from '@/domain/article/schema/article-schema'
@@ -34,7 +33,7 @@ export default async function unreadDigestionArticles(
   const rdb = getRdbClient({ db: c.env.DB, databaseUrl: c.env.DATABASE_URL })
   const useCase = createArticleUseCase(rdb)
   const result = await useCase.getUnreadDigestionArticles(sessionUser.activeUserId, query.media)
-  if (isFailure(result)) {
+  if (result.isErr()) {
     throw handleError(result.error, logger)
   }
 

--- a/application/src/web/server/article/handler/unread-digestion-articles.ts
+++ b/application/src/web/server/article/handler/unread-digestion-articles.ts
@@ -38,7 +38,7 @@ export default async function unreadDigestionArticles(
     throw handleError(result.error, logger)
   }
 
-  const response: UnreadDigestionArticlesResponse = { data: result.data.map(toArticleResponse) }
+  const response: UnreadDigestionArticlesResponse = { data: result.value.map(toArticleResponse) }
 
   logger.info('unread digestion articles retrieved successfully', { count: response.data.length })
   return c.json(response, 200)

--- a/application/src/web/server/auth/handler/login.ts
+++ b/application/src/web/server/auth/handler/login.ts
@@ -17,7 +17,7 @@ export default async function login(c: ZodValidatedContext<AuthInput>) {
   const result = await useCase.login(valid.email, valid.password)
   if (isFailure(result)) throw handleError(result.error, logger)
 
-  const { activeUser } = result.data
+  const { activeUser } = result.value
   logger.info('login success', { activeUserId: activeUser.activeUserId })
 
   return c.json(

--- a/application/src/web/server/auth/handler/login.ts
+++ b/application/src/web/server/auth/handler/login.ts
@@ -1,5 +1,4 @@
 import { handleError } from '@/common/errors'
-import { isFailure } from '@/common/result'
 import { type AuthInput, createAuthUseCase } from '@/domain/user'
 import getRdbClient from '@/infrastructure/rdb'
 import { createSupabaseAuthClient } from '@/infrastructure/supabase'
@@ -15,7 +14,7 @@ export default async function login(c: ZodValidatedContext<AuthInput>) {
   const useCase = createAuthUseCase(client, rdb)
 
   const result = await useCase.login(valid.email, valid.password)
-  if (isFailure(result)) throw handleError(result.error, logger)
+  if (result.isErr()) throw handleError(result.error, logger)
 
   const { activeUser } = result.value
   logger.info('login success', { activeUserId: activeUser.activeUserId })

--- a/application/src/web/server/auth/handler/logout.ts
+++ b/application/src/web/server/auth/handler/logout.ts
@@ -1,6 +1,5 @@
 import type { Context } from 'hono'
 import { handleError } from '@/common/errors'
-import { isFailure } from '@/common/result'
 import { createAuthUseCase } from '@/domain/user'
 import getRdbClient from '@/infrastructure/rdb'
 import { createSupabaseAuthClient } from '@/infrastructure/supabase'
@@ -19,7 +18,7 @@ export default async function logout(c: Context) {
   // エラーが発生した場合はログに記録し、エラーレスポンスを返す
   // 既にログアウト済みの場合でもSupabaseはエラーを返さないため、
   // エラーが返ってきた場合は実際の問題（ネットワークエラー、サーバーエラーなど）
-  if (isFailure(result)) {
+  if (result.isErr()) {
     logger.error('logout failed', { error: result.error })
     throw handleError(result.error, logger)
   }

--- a/application/src/web/server/auth/handler/me.ts
+++ b/application/src/web/server/auth/handler/me.ts
@@ -18,7 +18,7 @@ export default async function me(c: Context) {
     throw handleError(activeUserResult.error, logger)
   }
 
-  const activeUser = activeUserResult.data
+  const activeUser = activeUserResult.value
 
   logger.info('get current user success', { userId: activeUser.userId })
 

--- a/application/src/web/server/auth/handler/me.ts
+++ b/application/src/web/server/auth/handler/me.ts
@@ -1,6 +1,5 @@
 import type { Context } from 'hono'
 import { handleError } from '@/common/errors'
-import { isFailure } from '@/common/result'
 import { createAuthUseCase } from '@/domain/user'
 import getRdbClient from '@/infrastructure/rdb'
 import { createSupabaseAuthClient } from '@/infrastructure/supabase'
@@ -14,7 +13,7 @@ export default async function me(c: Context) {
   const useCase = createAuthUseCase(client, rdb)
 
   const activeUserResult = await useCase.getCurrentActiveUser()
-  if (isFailure(activeUserResult)) {
+  if (activeUserResult.isErr()) {
     throw handleError(activeUserResult.error, logger)
   }
 

--- a/application/src/web/server/auth/handler/signup.ts
+++ b/application/src/web/server/auth/handler/signup.ts
@@ -1,5 +1,4 @@
 import { ExternalServiceError, handleError } from '@/common/errors'
-import { isFailure } from '@/common/result'
 import { type AuthInput, createAuthUseCase } from '@/domain/user'
 import getRdbClient from '@/infrastructure/rdb'
 import { createSupabaseAuthClient } from '@/infrastructure/supabase'
@@ -15,7 +14,7 @@ export default async function signup(c: ZodValidatedContext<AuthInput>) {
   const useCase = createAuthUseCase(client, rdb)
 
   const result = await useCase.signup(valid.email, valid.password)
-  if (isFailure(result)) {
+  if (result.isErr()) {
     // 補償トランザクション失敗時のログ出力
     if (result.error instanceof ExternalServiceError) {
       logger.error(

--- a/application/src/web/server/auth/handler/signup.ts
+++ b/application/src/web/server/auth/handler/signup.ts
@@ -33,7 +33,7 @@ export default async function signup(c: ZodValidatedContext<AuthInput>) {
     throw handleError(result.error, logger)
   }
 
-  const { activeUser } = result.data
+  const { activeUser } = result.value
   logger.info('signup success', { activeUserId: activeUser.activeUserId })
 
   return c.json({}, 201)

--- a/application/src/web/server/handler/factory.ts
+++ b/application/src/web/server/handler/factory.ts
@@ -169,10 +169,10 @@ function executeHandlerLogic<
     if (config.logMessage) {
       const message =
         typeof config.logMessage === 'function'
-          ? config.logMessage(result.data, context)
+          ? config.logMessage(result.value, context)
           : config.logMessage
 
-      const payload = config.logPayload ? config.logPayload(result.data, context) : {}
+      const payload = config.logPayload ? config.logPayload(result.value, context) : {}
 
       context.logger.info({ msg: message, ...payload })
     }
@@ -185,7 +185,7 @@ function executeHandlerLogic<
       return c.body(null, 204)
     }
 
-    const responseData = config.transform ? config.transform(result.data) : result.data
+    const responseData = config.transform ? config.transform(result.value) : result.value
     return c.json(responseData, statusCode as ContentfulStatusCode)
   })()
 }

--- a/application/src/web/server/handler/factory.ts
+++ b/application/src/web/server/handler/factory.ts
@@ -32,7 +32,7 @@
  *   const { id } = c.req.valid('param')
  *   const parsedJson = c.req.valid('json')
  *   // ... UseCase実行とエラーハンドリング
- *   return c.json({ role: result.data })
+ *   return c.json({ role: result.value })
  * }
  * ```
  *
@@ -57,10 +57,9 @@
 import type { Context } from 'hono'
 import { HTTPException } from 'hono/http-exception'
 import type { ContentfulStatusCode, StatusCode } from 'hono/utils/http-status'
+import { type Result } from 'neverthrow'
 import { handleError } from '@/common/errors'
 import type { LoggerType } from '@/common/logger'
-import type { Result } from '@/common/result'
-import { isFailure } from '@/common/result'
 import getRdbClient, { type RdbClient } from '@/infrastructure/rdb'
 import type { Env, SessionUser } from '@/web/env'
 import CONTEXT_KEY from '@/web/middleware/context'
@@ -161,7 +160,7 @@ function executeHandlerLogic<
     const result = await config.execute(useCase, context)
 
     // 2. エラーハンドリング
-    if (isFailure(result)) {
+    if (result.isErr()) {
       throw handleError(result.error, context.logger)
     }
 


### PR DESCRIPTION
## 概要

`src/common/result` の独自 `Result` 実装を **neverthrow** へ移行しました。当初は互換レイヤー（`success`/`failure` 等のエイリアス）で導入しましたが、レビュー方針に従い、薄いラッパーは廃して呼び出し側で neverthrow を直接利用する形に変更しています。

## 変更内容

- `neverthrow@^8.2.0` を依存に追加
- 薄いエイリアス（`success` / `failure` / `isSuccess` / `isFailure` / `Result` / `AsyncResult`）を撤廃
  - `success(x)` → `ok(x)` / `failure(e)` → `err(e)`
  - `isSuccess(r)` → `r.isOk()` / `isFailure(r)` → `r.isErr()`
  - 値アクセス `.data` → `.value`（`.error` は据え置き）
  - 型は neverthrow の `Result<T, E>` を直接 import。`AsyncResult<T, E>` は `Promise<Result<T, E>>` に展開
  - エラー早期 return は `return err(x.error)`（`Ok`/`Err` の型引数が不変なため絞り込んだ `Err` を直接返せないケースに対応）
- `src/common/result` にはロジックを持つ `wrapAsyncCall` のみ残置（内部で `ok`/`err` を使用）

## 設計判断

- neverthrow の `Ok` は値プロパティが `.value`（`.data` ではない）、`Err` は `.error`。`.error` は従来と同名で変更不要です。
- `success`/`failure`/`isSuccess`/`isFailure` は neverthrow が同等機能を提供する「薄いラッパー」だったため、独自に再エクスポートせず直接利用に統一しました。

## 確認

- [x] `npm run typecheck`（tsgo）: エラー0
- [x] `biome ci .`: 254ファイル、指摘なし
- [x] `test:common` / `test:domain` / `test:client` / `test:cron`: すべてパス
- [x] `test:server`: 本ブランチ・mainともに同一結果（46 failed / 26 passed）。失敗はローカルSupabase未起動による既存の環境依存で、本変更による回帰はありません（CIではSupabaseが構成されており当該スイートはグリーン）

> 注: ローカル検証のため `prisma generate` と test.db へのスキーマ反映を実施しています（コミットには含まれません）。

https://claude.ai/code/session_015YS1d58cjGz9LGdmKXXMME