### PR TITLE
fix(authenticate): authenticate-form の Story を表示用コンポーネントの責務に合わせて修正

### DIFF
--- a/application/src/web/client/features/authenticate/authenticate-form.stories.tsx
+++ b/application/src/web/client/features/authenticate/authenticate-form.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { expect, waitFor } from 'storybook/test'
+import { expect } from 'storybook/test'
 import { AuthenticateForm } from './authenticate-form'
 
 const meta: Meta<typeof AuthenticateForm> = {
@@ -12,11 +12,7 @@ type Story = StoryObj<typeof AuthenticateForm>
 const defaultArgs = {
   loadingSubmitButtonText: 'ログイン中...',
   submitButtonText: 'ログイン',
-  async handleSubmit() {
-    await new Promise((resolve) => {
-      setTimeout(resolve, 300)
-    })
-  },
+  isSubmitting: false,
 }
 
 export const EmptyForm: Story = {
@@ -49,40 +45,44 @@ export const EmptyForm: Story = {
   },
 }
 
+// 送信中（isSubmitting）の表示を検証する。
+// AuthenticateForm は表示専用コンポーネントのため、送信中状態は props で渡す。
 export const FilledForm: Story = {
-  args: defaultArgs,
-  play: async ({ canvas, userEvent }) => {
-    await userEvent.type(canvas.getByLabelText('メールアドレス'), 'email@provider.com')
+  args: {
+    ...defaultArgs,
+    isSubmitting: true,
+  },
+  play: async ({ canvas }) => {
+    // ローディング用のボタンテキストが表示されることを確認
+    await expect(canvas.getByRole('button')).toHaveTextContent('ログイン中...')
 
-    await userEvent.type(canvas.getByLabelText('パスワード'), 'Password1!')
-
-    await userEvent.click(canvas.getByRole('button'))
-
-    await waitFor(() => {
-      expect(canvas.getByRole('button')).toHaveTextContent('ログイン中...')
-    })
+    // 送信中はボタンと入力欄が disabled になることを確認
+    await expect(canvas.getByRole('button')).toBeDisabled()
+    await expect(canvas.getByLabelText('メールアドレス')).toBeDisabled()
+    await expect(canvas.getByLabelText('パスワード')).toBeDisabled()
   },
 }
 
+// バリデーションエラーの表示を検証する。
+// バリデーション結果（errors）は props で渡される設計のため、ここでは errors を直接与える。
 export const FormValidationError: Story = {
-  args: defaultArgs,
-  play: async ({ canvas, userEvent }) => {
-    // 有効なメールアドレスを入力
-    await userEvent.type(canvas.getByLabelText('メールアドレス'), 'user@example.com')
-
-    // 短すぎるパスワードを入力（7文字）
-    await userEvent.type(canvas.getByLabelText('パスワード'), '1234567')
-
-    // Submitしてバリデーションエラーを発生させる
-    await userEvent.click(canvas.getByRole('button'))
-
+  args: {
+    ...defaultArgs,
+    errors: {
+      password: ['パスワードは8文字以上必要です'],
+    },
+  },
+  play: async ({ canvas }) => {
     // バリデーションエラーメッセージが表示されることを確認
     await expect(canvas.getByText('パスワードは8文字以上必要です')).toBeInTheDocument()
 
-    // aria-invalid属性が正しく設定されることを確認
+    // エラーのあるフィールドに aria-invalid 属性が設定されることを確認
     await expect(canvas.getByLabelText('パスワード')).toHaveAttribute('aria-invalid', 'true')
 
-    // Submitボタンがローディング状態にならないことを確認（バリデーションエラーのため）
+    // エラーのないフィールドには aria-invalid が設定されないことを確認
+    await expect(canvas.getByLabelText('メールアドレス')).not.toHaveAttribute('aria-invalid')
+
+    // ローディング状態ではないため、通常のボタンテキストが表示されることを確認
     await expect(canvas.getByRole('button')).toHaveTextContent('ログイン')
   },
 }

--- a/application/src/web/client/features/authenticate/authenticate-form.stories.tsx
+++ b/application/src/web/client/features/authenticate/authenticate-form.stories.tsx
@@ -47,7 +47,7 @@ export const EmptyForm: Story = {
 
 // 送信中（isSubmitting）の表示を検証する。
 // AuthenticateForm は表示専用コンポーネントのため、送信中状態は props で渡す。
-export const FilledForm: Story = {
+export const Submitting: Story = {
   args: {
     ...defaultArgs,
     isSubmitting: true,


### PR DESCRIPTION
## 概要

#629 の修正。`authenticate-form.stories.tsx` の 2 つの story（`FilledForm` / `FormValidationError`）が現行の `AuthenticateForm` 実装と乖離しており、`test-storybook` で常に失敗していた問題を解消する。

## 原因

`AuthenticateForm` は `react-router` の `Form` をレンダリングするだけの**表示用コンポーネント**であり、クライアントバリデーションや送信ロジックを持たず、`errors` / `isSubmitting` / `formError` を props 経由で受け取る設計になっている。

一方、失敗していた story は存在しない `handleSubmit` を渡したうえで、実送信後のローディング表示やクライアントバリデーションのエラー表示を `play` で期待していた。コンポーネントにその機能がないため、action の無いルートへの送信で `405 Method Not Allowed` の error boundary が描画され、期待要素が見つからず失敗していた。

## 修正内容

表示用コンポーネントの責務に合わせて story を書き換え（issue の想定修正方針に準拠）:

- **`FilledForm`**: `isSubmitting: true` を props で渡し、ローディング表示（`ログイン中...`）とボタン・入力欄の `disabled` を検証（実送信させない）
- **`FormValidationError`**: `errors` を props で渡し、エラーメッセージ表示と `aria-invalid` を検証（実送信させない）
- 不要になった `handleSubmit` 引数および `waitFor` import を除去

実送信〜バリデーションのフローは、引き続きルート（action 側）およびドメイン層の単体/結合テストでカバーされる。

## 検証

```
$ npm run test-storybook
 Test Files  9 passed (9)
      Tests  44 passed (44)
```

- `npm run test-storybook`: 全 44 件 pass（修正前は 2 件失敗）
- `biome check`: クリーン
- `npm run typecheck`: クリーン

Closes #629

---
_Generated by [Claude Code](https://claude.ai/code/session_016srFGbqNuvrDmARacNqAHG)_