### PR TITLE
fix(emulator): setup_emulator action のレビュー指摘対応 (PR #632 follow-up)

### DIFF
--- a/.github/actions/setup_emulator/action.yaml
+++ b/.github/actions/setup_emulator/action.yaml
@@ -35,6 +35,8 @@ runs:
         esac
 
         work="$RUNNER_TEMP/supa-emu"
+        # セルフホストランナーでの前回ジョブの残骸を排除して状態を初期化する
+        rm -rf "$work"
         mkdir -p "$work"
         # GoReleaser のアセット名: supabase-emulator_<version>_<os>_<arch>.tar.gz
         # バージョンを問わず glob で一致させる
@@ -43,7 +45,8 @@ runs:
           --pattern "supabase-emulator_*_${os}_${arch}.tar.gz" \
           --dir "$work" --clobber
 
-        tar -xzf "$work"/supabase-emulator_*_"${os}"_"${arch}".tar.gz -C "$work"
+        # pattern で 1 ファイルだけ DL されるため glob は *.tar.gz で十分
+        tar -xzf "$work"/*.tar.gz -C "$work"
         chmod +x "$work/supabase-emulator"
         echo "EMULATOR_BIN=$work/supabase-emulator" >> "$GITHUB_ENV"
 
@@ -52,7 +55,7 @@ runs:
       run: |
         set -euo pipefail
         "$EMULATOR_BIN" -addr 127.0.0.1:54321 > "$RUNNER_TEMP/emulator.log" 2>&1 &
-        for _ in $(seq 1 200); do
+        for _ in {1..200}; do
           curl -sf http://127.0.0.1:54321/auth/v1/health > /dev/null && exit 0
           sleep 0.05
         done

--- a/.github/actions/setup_emulator/action.yaml
+++ b/.github/actions/setup_emulator/action.yaml
@@ -57,7 +57,7 @@ runs:
       run: |
         set -euo pipefail
         "$EMULATOR_BIN" -addr 127.0.0.1:54321 > "$RUNNER_TEMP/emulator.log" 2>&1 &
-        for _ in {1..200}; do
+        for i in {1..200}; do
           curl -sf http://127.0.0.1:54321/auth/v1/health > /dev/null && exit 0
           sleep 0.05
         done

--- a/.github/actions/setup_emulator/action.yaml
+++ b/.github/actions/setup_emulator/action.yaml
@@ -34,6 +34,8 @@ runs:
           *) echo "::error::unsupported arch: $arch"; exit 1 ;;
         esac
 
+        # RUNNER_TEMP が空だと work が /supa-emu になり rm -rf が危険なため事前にガードする
+        : "${RUNNER_TEMP:?RUNNER_TEMP is empty or unset}"
         work="$RUNNER_TEMP/supa-emu"
         # セルフホストランナーでの前回ジョブの残骸を排除して状態を初期化する
         rm -rf "$work"

--- a/.github/actions/setup_emulator/action.yaml
+++ b/.github/actions/setup_emulator/action.yaml
@@ -57,7 +57,7 @@ runs:
       run: |
         set -euo pipefail
         "$EMULATOR_BIN" -addr 127.0.0.1:54321 > "$RUNNER_TEMP/emulator.log" 2>&1 &
-        for i in {1..200}; do
+        for _ in {1..200}; do
           curl -sf http://127.0.0.1:54321/auth/v1/health > /dev/null && exit 0
           sleep 0.05
         done


### PR DESCRIPTION
## 概要

PR #632 で gemini-code-assist から受けたレビュー指摘が、修正 push とマージのタイミング差により main に取り込まれなかったため、follow-up として反映する。

## 変更内容（`.github/actions/setup_emulator/action.yaml`）

- **[medium]** DL 前に `rm -rf "$work"` を追加し、セルフホストランナーでの前回ジョブの残骸を排除して状態を初期化。
- **[low]** tar 展開を `tar -xzf "$work"/*.tar.gz` に簡略化（`--pattern` で 1 ファイルのみ DL されるため）。
- **[low]** ヘルスチェックのループを `for _ in {1..200}` のブレース展開に変更（`seq` のプロセス起動を排除）。

## 動作確認

- 実機 (darwin/arm64) で新ロジック（`rm -rf` 初期化 → DL → `*.tar.gz` 展開 → 起動 → `/auth/v1/health` 200）を確認済み。
- YAML パース OK。

## 関連

- #632