### PR TITLE
fix: Storybookテスト・CIログの警告を解消

### DIFF
--- a/.github/actions/setup_e2e/action.yaml
+++ b/.github/actions/setup_e2e/action.yaml
@@ -15,7 +15,7 @@ runs:
         node-version-file: ${{ inputs.node-version-file }}
 
     - name: Playwrightブラウザのキャッシュ
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       id: playwright-cache
       with:
         path: ~/.cache/ms-playwright

--- a/.github/actions/setup_node/action.yaml
+++ b/.github/actions/setup_node/action.yaml
@@ -11,7 +11,7 @@ runs:
   using: 'composite'
   steps:
     - name: Node.jsの構築
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version-file: ${{ inputs.node-version-file }}
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -35,7 +35,7 @@ jobs:
     environment: production
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || github.event.inputs.deploy_type == 'web' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:
@@ -72,7 +72,7 @@ jobs:
     environment: production
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || github.event.inputs.deploy_type == 'database' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:

--- a/.github/workflows/cron-deploy.yaml
+++ b/.github/workflows/cron-deploy.yaml
@@ -24,7 +24,7 @@ jobs:
     environment: production
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
 

--- a/.github/workflows/cron-test.yaml
+++ b/.github/workflows/cron-test.yaml
@@ -44,7 +44,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: develop
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Supabaseのセットアップ
         uses: ./.github/actions/setup_supabase
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: develop
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,7 +21,7 @@ jobs:
   code-quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Setup Biome
         uses: biomejs/setup-biome@a05c02a1304287da45f13648675a70d5841acdbc # v2
         with:
@@ -34,7 +34,7 @@ jobs:
   ts-compile:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:
@@ -46,7 +46,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:

--- a/.github/workflows/prisma.yaml
+++ b/.github/workflows/prisma.yaml
@@ -24,7 +24,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,7 @@ jobs:
       run_common_test: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || steps.check-test-config.outputs.diff-count != 0 || steps.check-common.outputs.diff-count != 0 }}
       run_component_test: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || steps.check-test-config.outputs.diff-count != 0 || steps.check-client.outputs.diff-count != 0 || steps.check-storybook.outputs.diff-count != 0 }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: テスト設定ファイルの差分チェック
         id: check-test-config
@@ -107,7 +107,7 @@ jobs:
     runs-on: ${{ needs.setup.outputs.test_runner }}
     if: ${{ needs.setup.outputs.run_client_test == 'true' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:
@@ -123,7 +123,7 @@ jobs:
     runs-on: ${{ needs.setup.outputs.test_runner }}
     if: ${{ needs.setup.outputs.run_domain_test == 'true' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:
@@ -139,7 +139,7 @@ jobs:
     runs-on: ${{ needs.setup.outputs.test_runner }}
     if: ${{ needs.setup.outputs.run_server_test == 'true' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:
@@ -164,7 +164,7 @@ jobs:
     runs-on: ${{ needs.setup.outputs.test_runner }}
     if: ${{ needs.setup.outputs.run_common_test == 'true' }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:
@@ -181,14 +181,14 @@ jobs:
     if: ${{ needs.setup.outputs.run_component_test == 'true' }}
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:
           node-version-file: ${{ env.NODE_VERSION_FILE }}
 
       - name: Playwrightブラウザのキャッシュ
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright

--- a/application/.storybook/vitest.setup.ts
+++ b/application/.storybook/vitest.setup.ts
@@ -1,7 +1,0 @@
-import * as a11yAddonAnnotations from '@storybook/addon-a11y/preview'
-import { setProjectAnnotations } from '@storybook/react-vite'
-import * as projectAnnotations from './preview'
-
-// This is an important step to apply the right configuration when testing your stories.
-// More info at: https://storybook.js.org/docs/api/portable-stories/portable-stories-vitest#setprojectannotations
-setProjectAnnotations([a11yAddonAnnotations, projectAnnotations])

--- a/application/package-lock.json
+++ b/application/package-lock.json
@@ -50,7 +50,7 @@
         "@cloudflare/workers-types": "^4.20260507.1",
         "@faker-js/faker": "^10.4.0",
         "@hono/vite-dev-server": "^0.25.0",
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "^1.60.0",
         "@react-router/dev": "^7.12.0",
         "@storybook/addon-a11y": "^10.4.1",
         "@storybook/addon-docs": "^10.4.1",
@@ -2832,48 +2832,16 @@
       "license": "MIT"
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.57.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/@playwright/test/node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
       },
       "engines": {
         "node": ">=18"

--- a/application/package.json
+++ b/application/package.json
@@ -80,7 +80,7 @@
     "@cloudflare/workers-types": "^4.20260507.1",
     "@faker-js/faker": "^10.4.0",
     "@hono/vite-dev-server": "^0.25.0",
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "^1.60.0",
     "@react-router/dev": "^7.12.0",
     "@storybook/addon-a11y": "^10.4.1",
     "@storybook/addon-docs": "^10.4.1",

--- a/application/src/test/vitest/storybook/config.ts
+++ b/application/src/test/vitest/storybook/config.ts
@@ -51,7 +51,6 @@ export default defineConfig(({ mode }) => {
           },
         ],
       },
-      setupFiles: ['.storybook/vitest.setup.ts'],
       coverage: {
         include: ['src/web/client/components/**/*.tsx', 'src/web/client/features/**/*.tsx'],
         exclude: ['src/web/client/components/shadcn'],

--- a/application/src/web/client/routes/trends._index/components/article-drawer.tsx
+++ b/application/src/web/client/routes/trends._index/components/article-drawer.tsx
@@ -7,6 +7,7 @@ import {
   Drawer,
   DrawerClose,
   DrawerContent,
+  DrawerDescription,
   DrawerHeader,
   DrawerTitle,
 } from '@/web/client/components/shadcn/drawer'
@@ -78,6 +79,10 @@ export default function ArticleDrawer({
             <DrawerTitle className='text-xl leading-relaxed font-bold text-gray-900'>
               {article.title}
             </DrawerTitle>
+            {/* スクリーンリーダー向けの説明。Radix Dialog の aria-describedby 警告も解消する */}
+            <DrawerDescription className='sr-only'>
+              {`${article.author}による記事「${article.title}」の概要`}
+            </DrawerDescription>
             {isRead && (
               <span
                 data-testid='drawer-read-indicator'

--- a/application/src/web/client/routes/trends._index/components/article-drawer.tsx
+++ b/application/src/web/client/routes/trends._index/components/article-drawer.tsx
@@ -81,7 +81,9 @@ export default function ArticleDrawer({
             </DrawerTitle>
             {/* スクリーンリーダー向けの説明。Radix Dialog の aria-describedby 警告も解消する */}
             <DrawerDescription className='sr-only'>
-              {`${article.author}による記事「${article.title}」の概要`}
+              {article.author
+                ? `${article.author}による記事「${article.title}」の概要`
+                : `記事「${article.title}」の概要`}
             </DrawerDescription>
             {isRead && (
               <span


### PR DESCRIPTION
## 概要

Closes #634

Storybook テスト実行ログおよび GitHub Actions ログに出ていた複数の警告を解消する。

## 対応内容

### 1. Storybook `setProjectAnnotations` の重複適用警告
- Storybook 10.3 以降は `@storybook/addon-vitest` が preview annotations を自動適用するため、`.storybook/vitest.setup.ts` の `setProjectAnnotations([...])` 呼び出しが重複警告を出していた。
- `vitest.setup.ts` を削除し、`config.ts` の `setupFiles` 参照も除去した。
- preview のデコレーター（React Router の `RouterProvider` ラップ）と a11y addon の annotations は addon-vitest により自動適用される。

### 2. Radix Dialog (DialogContent) の `aria-describedby` 警告
- `article-drawer.tsx` の `DrawerContent` に `Description` が無く警告が出ていた。
- スクリーンリーダー向けの `DrawerDescription`（`sr-only`）を追加し、アクセシビリティ警告を解消した。

### 3. GitHub Actions の Node.js 20 非推奨警告
- 2026/6/2 以降 Node.js 20 ベースの Actions が強制的に Node.js 24 実行になるため、警告が出ていた。
- SHA ピン留めを維持したまま、Node.js 24 対応の v5 系へ更新:
  - `actions/checkout` → v5.0.1 (`93cb6ef`)
  - `actions/cache` → v5.0.5 (`27d5ce7`)
  - `actions/setup-node` → v5.0.0 (`a0853c2`)
- 対象: `.github/workflows/*` および `.github/actions/setup_node` / `setup_e2e` の composite action。

### 4. Playwright のバージョンドリフト
- `@playwright/test`(^1.57 / ブラウザビルド 1200) と `playwright`(^1.60 / ビルド 1223) がずれていた根因を解消。
- `@playwright/test` を `^1.60.0` に揃え、lockfile の重複していた `playwright@1.57` / `playwright-core@1.57` のネストエントリを除去。これで両者ともビルド 1223 に統一される。

## 検証

- `npm run lint`（biome ci + `tsgo --noEmit`）✅ パス
- `npm run check`（biome）✅ パス
- ⚠️ Storybook ブラウザテスト（`npm run test-storybook`）は本実行環境のネットワーク制約により Playwright のブラウザ（chromium v1223）をダウンロードできず未実行。CI（`test.yaml` の `component` ジョブ）での確認に委ねる。なおダウンロード試行時に要求されたビルドが `chromium v1223` であり、項目4のビルド統一が裏付けられた。

## 補足

- 項目4のバージョン統一により e2e と Storybook でブラウザキャッシュを共有できるようになるが、ワークフロー（`test.yaml` の Playwright キャッシュ／インストール手順）の簡素化はスコープ外の最適化として別途対応とする。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pe7H8v7g73yuw7JfQxQUNB)_