### PR TITLE
chore(dependabot): Prisma のメジャー更新を抑止する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,15 @@ updates:
     directory: "/application" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      # Prisma 7 は workerd(Cloudflare Workers) 上で実行時 WASM コンパイルが
+      # ブロックされクラッシュする未解決の不具合があるため、メジャー更新を抑止する。
+      # 解消されたら本 ignore を外して 7 系へ協調アップグレードする。
+      # 参考: https://github.com/prisma/prisma/issues/28657
+      - dependency-name: "prisma"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@prisma/*"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## 背景

Dependabot の #647（`@prisma/adapter-d1` 6→7 の単独昇格）の対応可否を調査した結果、**現時点で Prisma 7 へは上げられない**ことが判明しました。

### Prisma 7 が上げられない理由

1. **workerd 上の未解決クリティカルバグ**: Prisma 7.0.0 以降、Cloudflare Workers(workerd) 上で初回リクエスト時に `Wasm code generation disallowed by embedder` でクラッシュする（実行時 WASM コンパイルが CF にブロックされる）。**D1 アダプタでも回避不可**で、唯一の回避策は Prisma 6 系への据え置き。
   - 参考: https://github.com/prisma/prisma/issues/28657 （OPEN・critical）
2. **メジャー不整合**: #647 は `@prisma/adapter-d1` だけを v7 に上げるもので、`@prisma/client` / `prisma` は v6 のまま。ドライバアダプタは client とメジャーを揃える必要がある。
3. **CI で検証不能**: D1 本番経路（`PrismaD1`）はユニットテスト（mock）でも E2E（`file:` SQLite 経路）でも実行されず、CI が緑でも本番クラッシュを検知できない。

## 変更内容

`.github/dependabot.yml` に、`prisma` および `@prisma/*` の **メジャー更新を ignore** する設定を追加。これにより #647 のような単独メジャー昇格 PR が再生成されないようにする。6 系のマイナー/パッチ更新は引き続き受け取る。

## 今後

prisma/prisma#28657 が解消されたら、本 ignore を外し、`@prisma/client` + `prisma` + `@prisma/adapter-d1` を揃えて 7 系へ協調アップグレードする（実 D1 での動作確認込み）。

なお #647 は本方針に伴いクローズします。

https://claude.ai/code/session_019CA3uBFfwFfNhTbmVnow5d

---
_Generated by [Claude Code](https://claude.ai/code/session_019CA3uBFfwFfNhTbmVnow5d)_