### PR TITLE
chore: buildのwarningをすべて解消

### DIFF
--- a/application/package.json
+++ b/application/package.json
@@ -97,7 +97,6 @@
     "tailwindcss": "^4.3.0",
     "typescript": "^5.9.3",
     "vite": "^8.0.16",
-    "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.8",
     "vitest-mock-extended": "^4.0.0",
     "wrangler": "^4.95.0"

--- a/application/pnpm-lock.yaml
+++ b/application/pnpm-lock.yaml
@@ -206,9 +206,6 @@ importers:
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)
-      vite-tsconfig-paths:
-        specifier: ^6.1.1
-        version: 6.1.1(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))
@@ -3499,9 +3496,6 @@ packages:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
 
-  globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -4245,16 +4239,6 @@ packages:
       typescript:
         optional: true
 
-  tsconfck@3.1.6:
-    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
-    engines: {node: ^18 || >=20}
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
@@ -4355,11 +4339,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
       vite: ^2.7.0 || ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  vite-tsconfig-paths@6.1.1:
-    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
-    peerDependencies:
-      vite: '*'
 
   vite@7.3.2:
     resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
@@ -7229,8 +7208,6 @@ snapshots:
       minipass: 7.1.3
       path-scurry: 2.0.2
 
-  globrex@0.1.2: {}
-
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
@@ -8029,10 +8006,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  tsconfck@3.1.6(typescript@5.9.3):
-    optionalDependencies:
-      typescript: 5.9.3
-
   tsconfig-paths@4.2.0:
     dependencies:
       json5: 2.2.3
@@ -8150,16 +8123,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)
-
-  vite-tsconfig-paths@6.1.1(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)):
-    dependencies:
-      debug: 4.4.1
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@5.9.3)
-      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.4):
     dependencies:

--- a/application/react-router.config.ts
+++ b/application/react-router.config.ts
@@ -2,32 +2,18 @@ import type { Config } from '@react-router/dev/config'
 export default {
   appDirectory: 'src/web/client',
   future: {
-    // React Router v8 の future フラグ名は外部ライブラリ規約の `v8_` プレフィックス付きで固定であり
-    // 命名規則を変更できないため、各フラグで useNamingConvention を抑制する。
-    // ルートモジュール分割の最適化。コード変更不要。
     // biome-ignore lint/style/useNamingConvention: React Router v8 future フラグ名は固定
     v8_splitRouteModules: true,
-    // client/ssr 環境を分離する Vite Environment API。Vite 8 で要件を満たす。
     // biome-ignore lint/style/useNamingConvention: React Router v8 future フラグ名は固定
     v8_viteEnvironmentApi: true,
-    // 生の Request をそのまま渡す。loader/action は影響を受けない。
     // biome-ignore lint/style/useNamingConvention: React Router v8 future フラグ名は固定
     v8_passThroughRequests: true,
-    // データリクエストの URL 形式変更。Hono は api パスのみのため影響なし。
     // biome-ignore lint/style/useNamingConvention: React Router v8 future フラグ名は固定
     v8_trailingSlashAwareDataRequests: true,
-    // v8_middleware は明示的に false としてオプトアウトする。
-    // true にすると loader/action に渡る context が plain object から
-    // RouterContextProvider インスタンスへ変わるが、現状利用している
-    // hono-react-router-adapter@0.6.5（npm の最新版。middleware 未対応）は
-    // getLoadContext の返り値（plain object）をそのまま createRequestHandler に渡すため、
-    // React Router 本体が「context は RouterContextProvider であること」を要求して例外を投げる
-    // （node_modules の react-router ランタイムで該当の throw を確認済み）。
-    // さらにアプリ側の auth action は context.cloudflare.env を直接参照しており、
-    // RouterContextProvider 化すると undefined になって認証設定の解決に失敗する。
-    // よってアダプタが middleware 対応するまで本フラグは有効化できない。
-    // ただし未指定（undefined）のままだと react-router build が Future Flag Warning を出力するため、
-    // 既定値と同じ false を明示することで挙動を変えずに警告のみを抑制する。
+    // true にすると context が RouterContextProvider インスタンス必須になるが、
+    // hono-react-router-adapter@0.6.5 は plain object を渡すため全ルートが 500 になる。
+    // アダプタが middleware 対応するまで有効化できないため、
+    // 既定値と同じ false を明示して挙動を変えずに Future Flag Warning のみ抑制する。
     v8_middleware: false,
   },
 } satisfies Config

--- a/application/react-router.config.ts
+++ b/application/react-router.config.ts
@@ -1,4 +1,33 @@
 import type { Config } from '@react-router/dev/config'
 export default {
   appDirectory: 'src/web/client',
+  future: {
+    // React Router v8 の future フラグ名は外部ライブラリ規約の `v8_` プレフィックス付きで固定であり
+    // 命名規則を変更できないため、各フラグで useNamingConvention を抑制する。
+    // ルートモジュール分割の最適化。コード変更不要。
+    // biome-ignore lint/style/useNamingConvention: React Router v8 future フラグ名は固定
+    v8_splitRouteModules: true,
+    // client/ssr 環境を分離する Vite Environment API。Vite 8 で要件を満たす。
+    // biome-ignore lint/style/useNamingConvention: React Router v8 future フラグ名は固定
+    v8_viteEnvironmentApi: true,
+    // 生の Request をそのまま渡す。loader/action は影響を受けない。
+    // biome-ignore lint/style/useNamingConvention: React Router v8 future フラグ名は固定
+    v8_passThroughRequests: true,
+    // データリクエストの URL 形式変更。Hono は api パスのみのため影響なし。
+    // biome-ignore lint/style/useNamingConvention: React Router v8 future フラグ名は固定
+    v8_trailingSlashAwareDataRequests: true,
+    // v8_middleware は明示的に false としてオプトアウトする。
+    // true にすると loader/action に渡る context が plain object から
+    // RouterContextProvider インスタンスへ変わるが、現状利用している
+    // hono-react-router-adapter@0.6.5（npm の最新版。middleware 未対応）は
+    // getLoadContext の返り値（plain object）をそのまま createRequestHandler に渡すため、
+    // React Router 本体が「context は RouterContextProvider であること」を要求して例外を投げる
+    // （node_modules の react-router ランタイムで該当の throw を確認済み）。
+    // さらにアプリ側の auth action は context.cloudflare.env を直接参照しており、
+    // RouterContextProvider 化すると undefined になって認証設定の解決に失敗する。
+    // よってアダプタが middleware 対応するまで本フラグは有効化できない。
+    // ただし未指定（undefined）のままだと react-router build が Future Flag Warning を出力するため、
+    // 既定値と同じ false を明示することで挙動を変えずに警告のみを抑制する。
+    v8_middleware: false,
+  },
 } satisfies Config

--- a/application/src/test/vitest/client/config.ts
+++ b/application/src/test/vitest/client/config.ts
@@ -1,6 +1,5 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vite'
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { coverageReporter } from '../generate'
 
 const testInclude = ['src/web/client/**/*.test.ts']
@@ -14,7 +13,10 @@ const exclude = [
 ]
 
 export default defineConfig({
-  plugins: [tsconfigPaths()],
+  // Vite 8 ネイティブの tsconfig paths 解決（vite-tsconfig-paths プラグインの代替）
+  resolve: {
+    tsconfigPaths: true,
+  },
   test: {
     globals: true,
     environment: 'jsdom',

--- a/application/src/test/vitest/client/config.ts
+++ b/application/src/test/vitest/client/config.ts
@@ -13,7 +13,6 @@ const exclude = [
 ]
 
 export default defineConfig({
-  // Vite 8 ネイティブの tsconfig paths 解決（vite-tsconfig-paths プラグインの代替）
   resolve: {
     tsconfigPaths: true,
   },

--- a/application/src/test/vitest/common/config.ts
+++ b/application/src/test/vitest/common/config.ts
@@ -5,7 +5,6 @@ import { coverageReporter, generateIncludes } from '../generate'
 const { testInclude, coverageInclude } = generateIncludes('src/common')
 
 export default defineConfig({
-  // Vite 8 ネイティブの tsconfig paths 解決（vite-tsconfig-paths プラグインの代替）
   resolve: {
     tsconfigPaths: true,
   },

--- a/application/src/test/vitest/common/config.ts
+++ b/application/src/test/vitest/common/config.ts
@@ -1,12 +1,14 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vite'
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { coverageReporter, generateIncludes } from '../generate'
 
 const { testInclude, coverageInclude } = generateIncludes('src/common')
 
 export default defineConfig({
-  plugins: [tsconfigPaths()],
+  // Vite 8 ネイティブの tsconfig paths 解決（vite-tsconfig-paths プラグインの代替）
+  resolve: {
+    tsconfigPaths: true,
+  },
   test: {
     globals: true,
     include: testInclude,

--- a/application/src/test/vitest/cron/config.ts
+++ b/application/src/test/vitest/cron/config.ts
@@ -1,10 +1,12 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vite'
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { TEST_DATABASE_URL } from '../../env'
 
 export default defineConfig({
-  plugins: [tsconfigPaths()],
+  // Vite 8 ネイティブの tsconfig paths 解決（vite-tsconfig-paths プラグインの代替）
+  resolve: {
+    tsconfigPaths: true,
+  },
   test: {
     globals: true,
     globalSetup: ['src/test/setup/apply-migrations.ts'],

--- a/application/src/test/vitest/cron/config.ts
+++ b/application/src/test/vitest/cron/config.ts
@@ -3,7 +3,6 @@ import { defineConfig } from 'vite'
 import { TEST_DATABASE_URL } from '../../env'
 
 export default defineConfig({
-  // Vite 8 ネイティブの tsconfig paths 解決（vite-tsconfig-paths プラグインの代替）
   resolve: {
     tsconfigPaths: true,
   },

--- a/application/src/test/vitest/domain/config.ts
+++ b/application/src/test/vitest/domain/config.ts
@@ -1,12 +1,14 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vite'
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { coverageReporter, generateIncludes } from '../generate'
 
 const { testInclude, coverageInclude } = generateIncludes('src/domain')
 
 export default defineConfig({
-  plugins: [tsconfigPaths()],
+  // Vite 8 ネイティブの tsconfig paths 解決（vite-tsconfig-paths プラグインの代替）
+  resolve: {
+    tsconfigPaths: true,
+  },
   test: {
     globals: true,
     include: testInclude,

--- a/application/src/test/vitest/domain/config.ts
+++ b/application/src/test/vitest/domain/config.ts
@@ -5,7 +5,6 @@ import { coverageReporter, generateIncludes } from '../generate'
 const { testInclude, coverageInclude } = generateIncludes('src/domain')
 
 export default defineConfig({
-  // Vite 8 ネイティブの tsconfig paths 解決（vite-tsconfig-paths プラグインの代替）
   resolve: {
     tsconfigPaths: true,
   },

--- a/application/src/test/vitest/server/config.ts
+++ b/application/src/test/vitest/server/config.ts
@@ -1,13 +1,15 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vite'
-import tsconfigPaths from 'vite-tsconfig-paths'
 import { TEST_DATABASE_URL } from '../../env'
 import { coverageReporter, generateIncludes } from '../generate'
 
 const { testInclude, coverageInclude } = generateIncludes('src/web/server')
 
 export default defineConfig({
-  plugins: [tsconfigPaths()],
+  // Vite 8 ネイティブの tsconfig paths 解決（vite-tsconfig-paths プラグインの代替）
+  resolve: {
+    tsconfigPaths: true,
+  },
   test: {
     globals: true,
     globalSetup: ['src/test/setup/apply-migrations.ts'],

--- a/application/src/test/vitest/server/config.ts
+++ b/application/src/test/vitest/server/config.ts
@@ -6,7 +6,6 @@ import { coverageReporter, generateIncludes } from '../generate'
 const { testInclude, coverageInclude } = generateIncludes('src/web/server')
 
 export default defineConfig({
-  // Vite 8 ネイティブの tsconfig paths 解決（vite-tsconfig-paths プラグインの代替）
   resolve: {
     tsconfigPaths: true,
   },

--- a/application/src/test/vitest/storybook/config.ts
+++ b/application/src/test/vitest/storybook/config.ts
@@ -7,7 +7,6 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
   process.env = { ...process.env, ...env }
   return {
-    // Vite 8 ネイティブの tsconfig paths 解決（vite-tsconfig-paths プラグインの代替）
     resolve: {
       tsconfigPaths: true,
     },

--- a/application/src/test/vitest/storybook/config.ts
+++ b/application/src/test/vitest/storybook/config.ts
@@ -2,13 +2,16 @@ import storybookTest from '@storybook/addon-vitest/vitest-plugin'
 import tailwindcss from '@tailwindcss/vite'
 import { playwright } from '@vitest/browser-playwright'
 import { defineConfig, loadEnv } from 'vite'
-import tsconfigPaths from 'vite-tsconfig-paths'
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '')
   process.env = { ...process.env, ...env }
   return {
-    plugins: [tailwindcss(), tsconfigPaths(), storybookTest()],
+    // Vite 8 ネイティブの tsconfig paths 解決（vite-tsconfig-paths プラグインの代替）
+    resolve: {
+      tsconfigPaths: true,
+    },
+    plugins: [tailwindcss(), storybookTest()],
     optimizeDeps: {
       noDiscovery: true,
       include: [

--- a/application/vite.config.ts
+++ b/application/vite.config.ts
@@ -1,15 +1,26 @@
 /// <reference types="vitest/config" />
 /// <reference types="vitest" />
 
+import { defaultOptions } from '@hono/vite-dev-server'
+import adapter from '@hono/vite-dev-server/cloudflare'
 import { reactRouter } from '@react-router/dev/vite'
 import tailwindcss from '@tailwindcss/vite'
+import serverAdapter from 'hono-react-router-adapter/vite'
 import { defineConfig } from 'vite'
 import babel from 'vite-plugin-babel'
 
 const ReactCompilerConfig = {}
 
-export default defineConfig(async ({ command }) => {
-  const plugins = [
+export default defineConfig({
+  resolve: {
+    tsconfigPaths: true,
+  },
+  ssr: {
+    resolve: {
+      externalConditions: ['workerd', 'worker'],
+    },
+  },
+  plugins: [
     tailwindcss(),
     reactRouter(),
     babel({
@@ -20,56 +31,32 @@ export default defineConfig(async ({ command }) => {
         plugins: [['babel-plugin-react-compiler', ReactCompilerConfig]],
       },
     }),
-  ]
-
-  // Cloudflare 用の dev サーバアダプタは wrangler（および内部にバンドルされた
-  // whatwg-url@5.0.0 が非推奨の punycode 組み込みを require する）を読み込む。
-  // これは `react-router dev` でのみ必要なため、serve 時だけ動的に読み込む。
-  // build 時に wrangler バンドルを評価させないことで DEP0040 警告を根本から防ぐ。
-  if (command === 'serve') {
-    const { defaultOptions } = await import('@hono/vite-dev-server')
-    const { default: adapter } = await import('@hono/vite-dev-server/cloudflare')
-    const { default: serverAdapter } = await import('hono-react-router-adapter/vite')
-    plugins.push(
-      serverAdapter({
-        adapter,
-        entry: 'src/web/server.ts',
-        exclude: [...defaultOptions.exclude, '/assets/**', '/src/web/client/**'],
-      }),
-    )
-  }
-
-  return {
-    resolve: {
-      tsconfigPaths: true,
-    },
-    ssr: {
-      resolve: {
-        externalConditions: ['workerd', 'worker'],
-      },
-    },
-    plugins,
-    optimizeDeps: {
-      entries: [],
-      include: [
-        '@radix-ui/react-checkbox',
-        '@radix-ui/react-dialog',
-        '@radix-ui/react-dropdown-menu',
-        '@radix-ui/react-label',
-        '@radix-ui/react-scroll-area',
-        '@radix-ui/react-select',
-        '@radix-ui/react-separator',
-        '@radix-ui/react-slot',
-        '@radix-ui/react-tooltip',
-        'next-themes',
-        'sonner',
-        'swr',
-        'swr/mutation',
-        'vaul',
-      ],
-    },
-    test: {
-      globals: true,
-    },
-  }
+    serverAdapter({
+      adapter,
+      entry: 'src/web/server.ts',
+      exclude: [...defaultOptions.exclude, '/assets/**', '/src/web/client/**'],
+    }),
+  ],
+  optimizeDeps: {
+    entries: [],
+    include: [
+      '@radix-ui/react-checkbox',
+      '@radix-ui/react-dialog',
+      '@radix-ui/react-dropdown-menu',
+      '@radix-ui/react-label',
+      '@radix-ui/react-scroll-area',
+      '@radix-ui/react-select',
+      '@radix-ui/react-separator',
+      '@radix-ui/react-slot',
+      '@radix-ui/react-tooltip',
+      'next-themes',
+      'sonner',
+      'swr',
+      'swr/mutation',
+      'vaul',
+    ],
+  },
+  test: {
+    globals: true,
+  },
 })

--- a/application/vite.config.ts
+++ b/application/vite.config.ts
@@ -1,60 +1,79 @@
 /// <reference types="vitest/config" />
 /// <reference types="vitest" />
 
-import { defaultOptions } from '@hono/vite-dev-server'
-import adapter from '@hono/vite-dev-server/cloudflare'
 import { reactRouter } from '@react-router/dev/vite'
 import tailwindcss from '@tailwindcss/vite'
-import serverAdapter from 'hono-react-router-adapter/vite'
 import { defineConfig } from 'vite'
 import babel from 'vite-plugin-babel'
-import tsconfigPaths from 'vite-tsconfig-paths'
 
 const ReactCompilerConfig = {}
 
-export default defineConfig({
-  ssr: {
-    resolve: {
-      externalConditions: ['workerd', 'worker'],
-    },
-  },
-  plugins: [
-    tsconfigPaths(),
+export default defineConfig(async ({ command }) => {
+  const plugins = [
     tailwindcss(),
     reactRouter(),
     babel({
-      filter: /\.[jt]sx?$/,
+      // filter は include と AND 結合される非推奨オプションのため、
+      // include/exclude へ移行する。node_modules を除外することで
+      // react-dom などの大きなファイルを babel 変換対象から外す。
+      include: [/\.[jt]sx?$/],
+      exclude: [/node_modules/],
       babelConfig: {
         presets: ['@babel/preset-typescript'],
         plugins: [['babel-plugin-react-compiler', ReactCompilerConfig]],
       },
     }),
-    serverAdapter({
-      adapter,
-      entry: 'src/web/server.ts',
-      exclude: [...defaultOptions.exclude, '/assets/**', '/src/web/client/**'],
-    }),
-  ],
-  optimizeDeps: {
-    entries: [],
-    include: [
-      '@radix-ui/react-checkbox',
-      '@radix-ui/react-dialog',
-      '@radix-ui/react-dropdown-menu',
-      '@radix-ui/react-label',
-      '@radix-ui/react-scroll-area',
-      '@radix-ui/react-select',
-      '@radix-ui/react-separator',
-      '@radix-ui/react-slot',
-      '@radix-ui/react-tooltip',
-      'next-themes',
-      'sonner',
-      'swr',
-      'swr/mutation',
-      'vaul',
-    ],
-  },
-  test: {
-    globals: true,
-  },
+  ]
+
+  // Cloudflare 用の dev サーバアダプタは wrangler（および内部にバンドルされた
+  // whatwg-url@5.0.0 が非推奨の punycode 組み込みを require する）を読み込む。
+  // これは `react-router dev` でのみ必要なため、serve 時だけ動的に読み込む。
+  // build 時に wrangler バンドルを評価させないことで DEP0040 警告を根本から防ぐ。
+  if (command === 'serve') {
+    const { defaultOptions } = await import('@hono/vite-dev-server')
+    const { default: adapter } = await import('@hono/vite-dev-server/cloudflare')
+    const { default: serverAdapter } = await import('hono-react-router-adapter/vite')
+    plugins.push(
+      serverAdapter({
+        adapter,
+        entry: 'src/web/server.ts',
+        exclude: [...defaultOptions.exclude, '/assets/**', '/src/web/client/**'],
+      }),
+    )
+  }
+
+  return {
+    resolve: {
+      // Vite 8 ネイティブの tsconfig paths 解決（vite-tsconfig-paths の代替）
+      tsconfigPaths: true,
+    },
+    ssr: {
+      resolve: {
+        externalConditions: ['workerd', 'worker'],
+      },
+    },
+    plugins,
+    optimizeDeps: {
+      entries: [],
+      include: [
+        '@radix-ui/react-checkbox',
+        '@radix-ui/react-dialog',
+        '@radix-ui/react-dropdown-menu',
+        '@radix-ui/react-label',
+        '@radix-ui/react-scroll-area',
+        '@radix-ui/react-select',
+        '@radix-ui/react-separator',
+        '@radix-ui/react-slot',
+        '@radix-ui/react-tooltip',
+        'next-themes',
+        'sonner',
+        'swr',
+        'swr/mutation',
+        'vaul',
+      ],
+    },
+    test: {
+      globals: true,
+    },
+  }
 })

--- a/application/vite.config.ts
+++ b/application/vite.config.ts
@@ -13,9 +13,6 @@ export default defineConfig(async ({ command }) => {
     tailwindcss(),
     reactRouter(),
     babel({
-      // filter は include と AND 結合される非推奨オプションのため、
-      // include/exclude へ移行する。node_modules を除外することで
-      // react-dom などの大きなファイルを babel 変換対象から外す。
       include: [/\.[jt]sx?$/],
       exclude: [/node_modules/],
       babelConfig: {
@@ -44,7 +41,6 @@ export default defineConfig(async ({ command }) => {
 
   return {
     resolve: {
-      // Vite 8 ネイティブの tsconfig paths 解決（vite-tsconfig-paths の代替）
       tsconfigPaths: true,
     },
     ssr: {


### PR DESCRIPTION
## 概要

`pnpm run build` (react-router build) 時に出力されていたwarningを解消します。

## 対応したwarning

| warning | 対応 |
|---|---|
| React Router v8 Future Flag Warning ×5種 | 4フラグ有効化 + `v8_middleware: false` 明示 |
| `[vite-plugin-babel] filter option ... deprecation` | `include`/`exclude` へ移行 |
| `The plugin "vite-tsconfig-paths" is detected` | Vite 8 ネイティブ `resolve.tsconfigPaths` へ移行 |
| `[BABEL] Note: ... deoptimised (react-dom 500KB超)` | babel から `node_modules` を除外 |

`(node) [DEP0040] punycode is deprecated` はdevツール(wrangler内部にバンドルされたwhatwg-url@5.0.0)由来かつアップストリーム未修正のため対応せず、許容します。

## 変更内容

### react-router.config.ts
- worktree上で実際にフラグを有効化し build / typecheck / 全テスト / dev runtime (全ルートHTTP 200) を実証した上で、安全な4フラグを有効化
- `v8_middleware` は有効化すると全ルートHTTP 500になることを実証済み（context が `RouterContextProvider` インスタンスを要求するが、hono-react-router-adapter@0.6.5 は plain object を渡すため非互換）。既定値と同じ `false` を明示することで挙動を変えずに警告のみ抑制

### vite.config.ts
- babel の非推奨 `filter` を `include: [/\.[jt]sx?$/]` + `exclude: [/node_modules/]` へ移行
- `vite-tsconfig-paths` プラグインを Vite 8 ネイティブの `resolve.tsconfigPaths: true` へ置換

### vitest config ×6 + package.json
- vitest 側の config も `resolve.tsconfigPaths: true` へ統一し、`vite-tsconfig-paths` を devDependencies から完全撤去

## 副次的な改善

旧 `filter: /\.[jt]sx?$/` 設定は vite-plugin-babel のデフォルト `include` (`/\.jsx?$/`) と AND 結合されるため、**React Compiler が .ts/.tsx に適用されていませんでした**。本変更で .tsx が正しく対象になり、`compiler-runtime` チャンクが各appチャンクからimportされることを確認済みです。

## 検証

- ✅ `pnpm run build`: 残存warningはDEP0040(許容)のみ、client/ssr とも正常出力
- ✅ `pnpm run lint`: biome ci (262ファイル) + tsgo --noEmit パス
- ✅ 全テスト: domain 285 / common 91 / client 135 / server 72 / cron 9 すべてパス

## 補足

- `resolve.tsconfigPaths` は Vite で experimental 扱いですが、`@/` import 86箇所の解決をビルドで実証済みです
- `v8_middleware` の有効化は hono-react-router-adapter の middleware 対応後に別タスクで対応します