### PR TITLE
fix(e2e): ハンバーガーメニューのハイドレーション競合によるflakyを解消

### DIFF
--- a/application/src/test/e2e/page/trends._index.mobile.test.ts
+++ b/application/src/test/e2e/page/trends._index.mobile.test.ts
@@ -43,7 +43,7 @@ test.describe('記事一覧ページ(モバイル)', () => {
         if (!(await sheet.isVisible())) {
           await menuButton.click()
         }
-        await expect(sheet).toBeVisible({ timeout: 2_000 })
+        await expect(sheet).toBeVisible({ timeout: 1_000 })
       }).toPass({ timeout: TIMEOUT })
 
       // Applicationラベルが表示されていること

--- a/application/src/test/e2e/page/trends._index.mobile.test.ts
+++ b/application/src/test/e2e/page/trends._index.mobile.test.ts
@@ -34,13 +34,17 @@ test.describe('記事一覧ページ(モバイル)', () => {
     })
 
     test('ハンバーガーメニューを開いてメニュー項目が表示されること', async ({ page }) => {
-      // ハンバーガーメニューを開く
       const menuButton = page.getByRole('button', { name: 'メニューを開く' })
-      await menuButton.click()
-
-      // Sheetが開くのを待機
       const sheet = page.getByRole('dialog', { name: 'メニュー' })
-      await expect(sheet).toBeVisible({ timeout: TIMEOUT })
+
+      // INFO: ハイドレーション完了前のクリックはハンドラ未アタッチで失われるため、
+      // Sheetが開くまでクリックを再試行する
+      await expect(async () => {
+        if (!(await sheet.isVisible())) {
+          await menuButton.click()
+        }
+        await expect(sheet).toBeVisible({ timeout: 2_000 })
+      }).toPass({ timeout: TIMEOUT })
 
       // Applicationラベルが表示されていること
       await expect(sheet.getByText('Application')).toBeVisible()


### PR DESCRIPTION
## 背景

`main` への push で実行される E2E フルスイートが失敗していた（[run 27019677623](https://github.com/geek-beyond/trend_diary/actions/runs/27019677623)）。

```
1) [chromium] › src/test/e2e/page/trends._index.mobile.test.ts:36:5
   › 記事一覧ページ(モバイル) › レイアウト確認
   › ハンバーガーメニューを開いてメニュー項目が表示されること
   Error: expect(locator).toBeVisible() failed
   Locator: getByRole('dialog', { name: 'メニュー' })
   Error: element(s) not found
1 flaky
26 passed
```

`--fail-on-flaky-tests` 指定のため、1 回目失敗 → リトライ成功（flaky）でもジョブが失敗扱いになっていた。PR の Diff 実行（`--only-changed`）では当該テストが変更対象外だったため検知されず、main へマージ後にフルスイートで顕在化した。

## 原因

- `レイアウト確認` の各テストは `beforeEach` の `goto()` 直後に実行され、他のフィルター系テストのような `waitForArticleCards()`（ハイドレーションの猶予になる待機）を挟まない。
- そのため SSR で描画済みのメニューボタンを **ハイドレーション完了前** にクリックしてしまい、Radix(`Sheet`) の `onClick` ハンドラが未アタッチでクリックが失われ、`dialog` が開かない。
- リトライ時にはハイドレーション済みで成功するため flaky として表面化していた。

## 対応

Sheet が開くまでクリックを再試行する Playwright 推奨の `toPass` パターンへ変更。既に開いている場合は再クリックしないようガードし、トグルで閉じる事故を防いでいる。

```ts
await expect(async () => {
  if (!(await sheet.isVisible())) {
    await menuButton.click()
  }
  await expect(sheet).toBeVisible({ timeout: 2_000 })
}).toPass({ timeout: TIMEOUT })
```

## 確認

- `pnpm run check` / `pnpm run lint`（biome + typecheck）パス
- E2E 実体の検証は CI に委譲（本環境では Playwright ブラウザの取得がネットワークポリシーで不可）。変更したテストは PR の Diff ジョブが `--only-changed` で実行する。


---
_Generated by [Claude Code](https://claude.ai/code/session_01NUuu4zUmcrRqQb8ZNGPXhj)_