### PR TITLE
fix(web): storybookカバレッジ用の @vitest/coverage-v8 依存を復活

### DIFF
--- a/application/packages/web/package.json
+++ b/application/packages/web/package.json
@@ -72,6 +72,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitest/browser-playwright": "^4.1.8",
     "@vitest/coverage-istanbul": "^4.1.8",
+    "@vitest/coverage-v8": "^4.1.8",
     "babel-plugin-react-compiler": "^1.0.0",
     "jsdom": "^26.1.0",
     "playwright": "^1.60.0",

--- a/application/pnpm-lock.yaml
+++ b/application/pnpm-lock.yaml
@@ -396,6 +396,9 @@ importers:
       '@vitest/coverage-istanbul':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.8
+        version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -5016,8 +5019,7 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@bcoe/v8-coverage@1.0.2':
-    optional: true
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@2.4.16':
     optionalDependencies:
@@ -7004,7 +7006,6 @@ snapshots:
       vitest: 4.1.8(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))
     optionalDependencies:
       '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))(vitest@4.1.8)
-    optional: true
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -7102,7 +7103,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
-    optional: true
 
   atomic-sleep@1.0.0: {}
 
@@ -7585,8 +7585,7 @@ snapshots:
   js-base64@3.7.8:
     optional: true
 
-  js-tokens@10.0.0:
-    optional: true
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION
## 概要

Test ワークフローの `component`（storybook）ジョブが失敗していたので修正します。

## 失敗内容

```
TypeError: Failed to fetch dynamically imported module:
  http://localhost:63315/@id/@vitest/coverage-v8/browser?import
```

ブラウザモードのカバレッジが `@vitest/coverage-v8/browser` を解決できず、計測が 0% になり閾値(75%)割れで落ちていました。

## 原因

コミット `086f0ca`（"ルートから未使用依存を除去…"）が `@vitest/coverage-v8` を**「完全未使用」と判断してルートから削除**しました。しかし storybook のカバレッジ設定は coverage provider を明示しておらず、**デフォルトの v8 に暗黙的に依存**していました。直接依存から外れたことで pnpm の node_modules 上で bare specifier が解決できなくなり、ブラウザからの動的importが失敗していました。

## 方針

provider ごとの本来の住み分けは以下のとおりで、istanbul はあくまで **workerd が v8 非対応**（コミット `7a96934` 参照）のための限定的な選択です。

| テスト | 実行環境 | provider |
|---|---|---|
| client | jsdom | v8（デフォルト）|
| server / cron | workerd | istanbul（v8非対応のため）|
| storybook | 実ブラウザ(chromium) | v8（デフォルト）|

storybook・client は本来どおり v8 を使うのが正しいため、storybook 設定には手を入れず、**誤って削除された `@vitest/coverage-v8` を実際に利用している `packages/web` へ宣言して復旧**します（`noUndeclaredDependencies` にも適合）。

## 確認

`pnpm --filter @trend-diary/web test-storybook --coverage` がローカルで成功することを確認:

- Test Files 16 passed / Tests 62 passed
- Coverage enabled with **v8**
- Statements 100% / Branches 94.11% / Functions 100% / Lines 100%（いずれも閾値75%以上）
- `biome ci` / `typecheck` パス

https://claude.ai/code/session_01SKmMnyjJ9cdBtbqEgJorpo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKmMnyjJ9cdBtbqEgJorpo)_