### PR TITLE
fix(ci): cron deployのsecretアップロード失敗を修正

### DIFF
--- a/.github/workflows/cron-deploy.yaml
+++ b/.github/workflows/cron-deploy.yaml
@@ -39,8 +39,8 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: ./application
-          command: deploy --config packages/cron/wrangler.toml
+          workingDirectory: ./application/packages/cron
+          command: deploy
           secrets: |
             DISCORD_WEBHOOK_URL
         env:


### PR DESCRIPTION
## 概要

Cron Deploy Actionが失敗していたため、エラーログを確認し修正しました。

## 原因

直近の「cron worker を `@trend-diary/cron` パッケージへ切り出す」(cb85482) によるリグレッションです。

エラーログ（run 27086240700）:

```
🔑 Uploading secrets...
[command] pnpm exec wrangler secret bulk
✘ [ERROR] Required Worker name missing. Please specify the Worker name in your
  Wrangler configuration file, or pass it as an argument with `--name <worker-name>`
##[error]Failed to upload secrets.
```

`cron-deploy.yaml` では `workingDirectory: ./application` のまま `command: deploy --config packages/cron/wrangler.toml` で設定ファイルを指定していました。`deploy` 自体は `--config` で動作しますが、wrangler-action の secrets アップロード処理（`wrangler secret bulk`）には `--config` が引き継がれず、`./application` 直下の wrangler.toml を探して **Worker 名を解決できず失敗** していました。

## 修正

正常動作している `cd.yaml` の web deploy と同じパターンに揃え、`workingDirectory` を `./application/packages/cron` に変更して `command: deploy` で設定ファイルを自動検出させます。

- `wrangler.toml` 内のパス（`main`, `migrations_dir`）は設定ファイルの位置基準で解決されるため、ワーキングディレクトリ変更による影響はありません。

## 確認方法

mainマージ後の次回 Cron Test 成功時に Cron Deploy がトリガーされ、secret アップロード〜デプロイが成功することを確認する。

https://claude.ai/code/session_01JYmNRXCuSqm8WrXdd1oG9m

---
_Generated by [Claude Code](https://claude.ai/code/session_01JYmNRXCuSqm8WrXdd1oG9m)_