### PR TITLE
fix(ci): cron deployのwrangler未検出によるデプロイ失敗を修正

### DIFF
--- a/application/packages/cron/package.json
+++ b/application/packages/cron/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "catalog:",
     "@cloudflare/workers-types": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "wrangler": "catalog:"
   }
 }

--- a/application/pnpm-lock.yaml
+++ b/application/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.8)(jsdom@26.1.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))
+      wrangler:
+        specifier: 'catalog:'
+        version: 4.97.0(@cloudflare/workers-types@4.20260507.1)
 
   packages/datastore:
     dependencies:


### PR DESCRIPTION
## 概要

Cron Deployワークフローが以下のエラーで失敗していた問題を修正します。

```
npm error code EUNSUPPORTEDPROTOCOL
npm error Unsupported URL Type "workspace:": workspace:*
##[error]🚨 Action failed
```

## 原因

`cloudflare/wrangler-action` は `workingDirectory` で `npx --no-install wrangler --version` を実行し、wranglerが見つからない場合に `npm i wrangler@4` へフォールバックします。

- `web` パッケージは `wrangler: catalog:` を devDependency に持つため、`pnpm install` 後にwranglerが解決済みで、フォールバックが発生しない（CDは成功）
- `cron` パッケージには wrangler 依存が無いため `npx --no-install wrangler` が失敗し、`npm i` へフォールバック。npmは `workspace:` プロトコルを解釈できないためデプロイが失敗していた

## 変更内容

- `application/packages/cron/package.json` の devDependencies に `wrangler: catalog:` を追加
- `pnpm-lock.yaml` を更新（既に解決済みの 4.97.0 を cron からも参照）

これにより `pnpm install --frozen-lockfile` でwranglerが配置され、wrangler-actionがnpmフォールバックを行わなくなります。

## 確認

- [ ] mainマージ後、Cron Deployワークフローが成功すること

https://claude.ai/code/session_01EvoGGumP2nzZMVLNL7vduB

---
_Generated by [Claude Code](https://claude.ai/code/session_01EvoGGumP2nzZMVLNL7vduB)_