### PR TITLE
ci: actions/checkoutのpersist-credentialsを無効化

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -36,6 +36,8 @@ jobs:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || github.event.inputs.deploy_type == 'web' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:
@@ -73,6 +75,8 @@ jobs:
     if: ${{ github.event.workflow_run && github.event.workflow_run.conclusion == 'success' || github.event.inputs.deploy_type == 'database' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:

--- a/.github/workflows/cron-deploy.yaml
+++ b/.github/workflows/cron-deploy.yaml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node

--- a/.github/workflows/cron-test.yaml
+++ b/.github/workflows/cron-test.yaml
@@ -49,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:

--- a/.github/workflows/db-schema.yaml
+++ b/.github/workflows/db-schema.yaml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -39,6 +39,8 @@ jobs:
     environment: develop
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Supabaseのセットアップ
         uses: ./.github/actions/setup_supabase
@@ -92,6 +94,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - id: setup-supabase
         name: Supabaseのセットアップ

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Setup Biome
         uses: biomejs/setup-biome@4c91541eaada48f67d7dbd7833600ce162b68f51 # v2
         with:
@@ -35,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:
@@ -47,6 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,6 +50,8 @@ jobs:
       run_package_test: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' || steps.check-test-config.outputs.diff-count != 0 || steps.check-packages.outputs.diff-count != 0 }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: テスト設定ファイルの差分チェック
         id: check-test-config
@@ -105,6 +107,8 @@ jobs:
     if: ${{ needs.setup.outputs.run_client_test == 'true' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:
@@ -121,6 +125,8 @@ jobs:
     if: ${{ needs.setup.outputs.run_server_test == 'true' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:
@@ -155,6 +161,8 @@ jobs:
           - notification
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:
@@ -173,6 +181,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - name: Node.jsの構築
         uses: ./.github/actions/setup_node
         with:


### PR DESCRIPTION
## 概要

`actions/checkout` のセキュリティ対策として、全ワークフローのcheckoutステップに `persist-credentials: false` を設定しました。

## 背景

`actions/checkout` はデフォルトで `persist-credentials: true` となっており、`GITHUB_TOKEN` がランナー上の `.git/config` に書き込まれます。この認証情報が残存すると、後続ステップ（サードパーティのactionや任意スクリプト）からトークンが読み取られ、悪用される脆弱性につながります。push等の認証付きgit操作を行わないジョブでは無効化するのが推奨されています。

## 変更内容

以下7ワークフローの全checkout（計15箇所）に `persist-credentials: false` を追加:

- `cd.yaml`（web / database）
- `cron-deploy.yaml`
- `e2e.yaml`（Main / Diff）
- `db-schema.yaml`
- `test.yaml`（setup / client / server / package / component）
- `lint.yaml`（code-quality / ts-compile / build）
- `cron-test.yaml`

## 安全性の確認

いずれのジョブもcheckout後にpush等の認証付きgit操作を行っていないことを確認済みです。
- `db-schema.yaml` の `git diff` / `git add -N` はローカル操作のみ
- `e2e.yaml` Diffの `--only-changed` はローカルのgit履歴（`fetch-depth: 0`）を参照するのみ

そのため認証情報の保持は不要で、無効化による影響はありません。

https://claude.ai/code/session_01ADgYRoDMX2Lf3UDTfPro4o

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADgYRoDMX2Lf3UDTfPro4o)_