### PR TITLE
docs: READMEのバッジをCIワークフローに合わせて更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-[![Lint](https://github.com/geek-beyond/trend_diary/actions/workflows/lint.yaml/badge.svg)](https://github.com/geek-beyond/trend_diary/actions/workflows/lint.yaml)
-[![Test](https://github.com/geek-beyond/trend_diary/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/geek-beyond/trend_diary/actions/workflows/test.yaml)
+[![CI](https://github.com/geek-beyond/trend_diary/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/geek-beyond/trend_diary/actions/workflows/ci.yaml)
 [![CD](https://github.com/geek-beyond/trend_diary/actions/workflows/cd.yaml/badge.svg)](https://github.com/geek-beyond/trend_diary/actions/workflows/cd.yaml)
 
 ## 環境構築


### PR DESCRIPTION
## 概要

READMEのCIバッジを現在のワークフロー構成に合わせて更新しました。

## 背景

`lint.yaml`と`test.yaml`が`ci.yaml`に統合されていましたが、READMEのバッジは古いワークフロー（`lint.yaml` / `test.yaml`）を参照したままでした。存在しないワークフローを参照しているため、バッジが正しく表示されません。

## 変更内容

- `Lint`バッジと`Test`バッジを削除
- 統合先である`ci.yaml`を参照する単一の`CI`バッジを追加
- `CD`バッジは変更なし

https://claude.ai/code/session_01L9i9NpZiEEtoMqEB5BJxkj

---
_Generated by [Claude Code](https://claude.ai/code/session_01L9i9NpZiEEtoMqEB5BJxkj)_