### PR TITLE
ci: テストジョブ名を単体/結合の観点で統一

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,7 +100,7 @@ jobs:
         run: pnpm run build
 
   client-test:
-    name: web client test
+    name: unit-test (web client)
     needs: changes
     if: ${{ needs.changes.outputs.web == 'true' }}
     runs-on: ubuntu-latest
@@ -119,7 +119,7 @@ jobs:
           target: client
 
   server-test:
-    name: web server test
+    name: integration-test (web server)
     needs: changes
     if: ${{ needs.changes.outputs.web == 'true' }}
     runs-on: ubuntu-latest
@@ -144,7 +144,7 @@ jobs:
           target: server
 
   component-test:
-    name: web component test
+    name: integration-test (web component)
     needs: changes
     if: ${{ needs.changes.outputs.web == 'true' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 概要

CIのテストジョブ名が揃っておらず、実態が結合テストのジョブが汎用名（`web server test` など）で結合テストと判別できなかった。`unit-test`（パッケージ）がマトリクスで `unit-test (domain)` のように表示される形式に揃え、`<種別>-test (詳細)` のkebab-case + かっこ形式で命名を統一する。

## 変更内容

| job id | 旧name | 新name | 根拠 |
|---|---|---|---|
| `client-test` | `web client test` | `unit-test (web client)` | jsdom・モックの単体テスト |
| `server-test` | `web server test` | `integration-test (web server)` | 実D1 + Supabase emulatorでHonoアプリ経由のためデータレイヤと結合 |
| `component-test` | `web component test` | `integration-test (web component)` | 実chromiumブラウザでコンポーネントを描画して検証。コード内でも「結合検証の対象」と表現されている |

- job id は内部参照（`gate` の `needs`）のため変更せず、表示名（`name:`）のみ変更。
- パッケージ単体テストの `unit-test` ジョブはフォーマットの基準のため変更なし。

## 補足

- ブランチ保護の required status checks が集約ジョブ `gate` ではなく個別ジョブ名を直接参照している場合、表示名の変更に追従が必要です（本リポジトリは `gate` 集約パターンのため不要の想定）。

---
_Generated by [Claude Code](https://claude.ai/code/session_016a94YjVUspM3P5dNarFXGC)_