### PR TITLE
ci: CDのデプロイ対象なし時にジョブサマリへスキップ相当を明記

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -84,7 +84,7 @@ jobs:
           {
             echo "## CD デプロイ対象"
             if [[ "$web" == "false" && "$cron" == "false" && "$database" == "false" ]]; then
-              echo "デプロイ対象なし（実質スキップ）"
+              echo "デプロイ対象なし（スキップ）"
             else
               echo "| リソース | デプロイ |"
               echo "| --- | --- |"

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -81,6 +81,20 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "デプロイ対象: web=$web cron=$cron database=$database"
 
+          # ジョブサマリにデプロイ対象を記載(対象が無い場合はスキップ相当である旨を明記)
+          {
+            echo "## CD デプロイ対象"
+            if [[ "$web" == "false" && "$cron" == "false" && "$database" == "false" ]]; then
+              echo "デプロイ対象なし（実質スキップ）"
+            else
+              echo "| リソース | デプロイ |"
+              echo "| --- | --- |"
+              echo "| web | $web |"
+              echo "| cron | $cron |"
+              echo "| database | $database |"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
   web:
     needs: changes
     if: ${{ needs.changes.outputs.web == 'true' }}

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -81,7 +81,6 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "デプロイ対象: web=$web cron=$cron database=$database"
 
-          # ジョブサマリにデプロイ対象を記載(対象が無い場合はスキップ相当である旨を明記)
           {
             echo "## CD デプロイ対象"
             if [[ "$web" == "false" && "$cron" == "false" && "$database" == "false" ]]; then


### PR DESCRIPTION
## 概要

CD が `changes` ジョブのみで終わった（web/cron/database いずれもデプロイ対象なし）場合は実質スキップだが、`changes` ジョブが成功するため Actions の run ステータスは success（緑）のままで、no-op か実デプロイかが一見区別しづらかった。

## 方針

GitHub の仕様上、run が `skipped` 扱いになるのは「全ジョブが skipped」のときのみ。`changes` ジョブは差分検出のため必ず実行・成功する以上、`workflow_run` トリガーを維持したまま run 自体を `skipped` にはできない。

そのため、トリガー構成（`workflow_run` による CI ゲート）は変更せず、カバレッジ等と同様に **GitHub ジョブサマリ** へデプロイ対象を出力し、対象が無い場合は「実質スキップ」である旨を明記する方針とした。

## 変更内容

- `cd.yaml` の `detect` ステップで `$GITHUB_STEP_SUMMARY` にデプロイ対象を出力
  - 対象なし: 「デプロイ対象なし（実質スキップ）」
  - 対象あり: リソースごとのデプロイ可否をテーブル表示

https://claude.ai/code/session_0197bWjSBYgfotcSBSTmbqst

---
_Generated by [Claude Code](https://claude.ai/code/session_0197bWjSBYgfotcSBSTmbqst)_