### PR TITLE
test(cron): テスト構造を結合テストとe2eの2層へ再編する

### DIFF
--- a/application/packages/cron/src/fetch-articles.test.ts
+++ b/application/packages/cron/src/fetch-articles.test.ts
@@ -1,31 +1,25 @@
+import { env } from 'cloudflare:test'
 import { articles } from '@trend-diary/datastore/drizzle-orm/schema'
 import { eq } from 'drizzle-orm'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
-
-const fetchMock = vi.hoisted(() => vi.fn())
-const parseStringMock = vi.hoisted(() => vi.fn())
-
-vi.stubGlobal('fetch', fetchMock)
-
-// rss-parser はモックし、パース結果（item オブジェクト）を直接注入する。
-// 実XMLのパースは worker.test.ts（e2e）が実 rss-parser で担保する。
-vi.mock('rss-parser', () => ({
-  default: class MockParser {
-    parseString(xml: string) {
-      return parseStringMock(xml)
-    }
-  },
-}))
-
-import { env } from 'cloudflare:test'
 import { fetchHatenaArticles, fetchQiitaArticles, fetchZennArticles } from './fetch-articles'
+import {
+  buildHatenaRdf,
+  buildQiitaAtom,
+  buildZennRss,
+  type FeedItem,
+  rssResponse,
+} from './test-helper/feed'
 import { testRdb as db } from './test-helper/rdb'
+
+const fetchMock = vi.fn()
+vi.stubGlobal('fetch', fetchMock)
 
 const cronEnv = { DB: env.DB }
 
-const QIITA_FEED_URL = 'https://qiita.com/popular-items/feed.atom'
-const ZENN_FEED_URL = 'https://zenn.dev/feed'
-const HATENA_FEED_URL = 'https://b.hatena.ne.jp/hotentry/it.rss'
+function stubFeed(xml: string): void {
+  fetchMock.mockResolvedValue(rssResponse(xml))
+}
 
 async function countArticles(): Promise<number> {
   const rows = await db.select({ url: articles.url }).from(articles)
@@ -37,79 +31,82 @@ async function findByUrl(url: string) {
   return row
 }
 
-// rss-parser のパース結果を1回分注入する。
-function mockParsedItems(items: unknown[]): void {
-  parseStringMock.mockResolvedValue({ items })
-}
+beforeEach(async () => {
+  await db.delete(articles)
+  fetchMock.mockReset()
+})
 
-describe('記事取得（公開API越し結合テスト）', () => {
-  beforeEach(async () => {
-    await db.delete(articles)
+afterAll(async () => {
+  await db.delete(articles)
+  vi.unstubAllGlobals()
+})
 
-    fetchMock.mockReset()
-    parseStringMock.mockReset()
-
-    fetchMock.mockResolvedValue({
-      ok: true,
-      text: vi.fn().mockResolvedValue('<rss />'),
-    })
-  })
-
-  afterAll(async () => {
-    await db.delete(articles)
-  })
-
-  describe('メディア別マッピング', () => {
-    it('fetchQiitaArticles: author/content/link を記事へマッピングする', async () => {
-      mockParsedItems([
-        {
-          title: 'Qiita記事',
-          author: 'qiita_author',
-          content: 'Qiita本文',
-          link: 'https://qiita.com/u/items/q1',
-        },
-      ])
+describe('fetchQiitaArticles', () => {
+  describe('正常系', () => {
+    it('author を author、content を description にマッピングして保存する', async () => {
+      stubFeed(
+        buildQiitaAtom([
+          {
+            title: 'Qiita記事',
+            author: 'qiita_author',
+            content: 'Qiita本文',
+            url: 'https://qiita.com/u/items/q1',
+          },
+        ]),
+      )
 
       const result = await fetchQiitaArticles(cronEnv)
 
       expect(result.isOk()).toBe(true)
       if (result.isOk()) expect(result.value).toBe(1)
-      expect(fetchMock).toHaveBeenCalledWith(QIITA_FEED_URL)
       const saved = await findByUrl('https://qiita.com/u/items/q1')
       expect(saved.media).toBe('qiita')
       expect(saved.title).toBe('Qiita記事')
       expect(saved.author).toBe('qiita_author')
       expect(saved.description).toBe('Qiita本文')
     })
+  })
+})
 
-    it('fetchZennArticles: creator を author、content を description へマッピングする', async () => {
-      mockParsedItems([
-        {
-          title: 'Zenn記事',
-          creator: 'zenn_creator',
-          content: 'Zenn本文',
-          link: 'https://zenn.dev/u/articles/z1',
-        },
-      ])
+describe('fetchZennArticles', () => {
+  describe('正常系', () => {
+    it('creator を author、content を description にマッピングして保存する', async () => {
+      stubFeed(
+        buildZennRss([
+          {
+            title: 'Zenn記事',
+            author: 'zenn_creator',
+            content: 'Zenn本文',
+            url: 'https://zenn.dev/u/articles/z1',
+          },
+        ]),
+      )
 
       const result = await fetchZennArticles(cronEnv)
 
       expect(result.isOk()).toBe(true)
       if (result.isOk()) expect(result.value).toBe(1)
-      expect(fetchMock).toHaveBeenCalledWith(ZENN_FEED_URL)
       const saved = await findByUrl('https://zenn.dev/u/articles/z1')
       expect(saved.media).toBe('zenn')
       expect(saved.author).toBe('zenn_creator')
       expect(saved.description).toBe('Zenn本文')
     })
+  })
+})
 
-    it('fetchHatenaArticles: creator を author、content を description へマッピングする', async () => {
-      mockParsedItems([
+describe('fetchHatenaArticles', () => {
+  function stubHatena(items: FeedItem[]): void {
+    stubFeed(buildHatenaRdf(items))
+  }
+
+  describe('正常系', () => {
+    it('creator を author、content を description にマッピングして保存する', async () => {
+      stubHatena([
         {
           title: 'はてな記事',
-          creator: 'hatena_creator',
+          author: 'hatena_creator',
           content: 'はてな本文',
-          link: 'https://example.com/h1',
+          url: 'https://example.com/h1',
         },
       ])
 
@@ -117,145 +114,16 @@ describe('記事取得（公開API越し結合テスト）', () => {
 
       expect(result.isOk()).toBe(true)
       if (result.isOk()) expect(result.value).toBe(1)
-      expect(fetchMock).toHaveBeenCalledWith(HATENA_FEED_URL)
       const saved = await findByUrl('https://example.com/h1')
       expect(saved.media).toBe('hatena')
       expect(saved.author).toBe('hatena_creator')
       expect(saved.description).toBe('はてな本文')
     })
-  })
 
-  describe('hatena のフォールバック補完', () => {
-    it('creator が欠損した記事は author をはてなブックマークで補完する', async () => {
-      mockParsedItems([
-        {
-          title: 'はてな記事',
-          content: 'はてな本文',
-          link: 'https://example.com/h1',
-        },
-      ])
-
-      const result = await fetchHatenaArticles(cronEnv)
-
-      expect(result.isOk()).toBe(true)
-      const saved = await findByUrl('https://example.com/h1')
-      expect(saved.author).toBe('はてなブックマーク')
-    })
-
-    it('description は content > content:encoded > contentSnippet の優先順位で補完する', async () => {
-      mockParsedItems([
-        {
-          title: '記事1',
-          creator: '投稿者1',
-          content: 'content本文',
-          'content:encoded': 'encoded本文',
-          contentSnippet: 'snippet本文',
-          link: 'https://example.com/1',
-        },
-        {
-          title: '記事2',
-          creator: '投稿者2',
-          'content:encoded': 'encoded本文',
-          contentSnippet: 'snippet本文',
-          link: 'https://example.com/2',
-        },
-        {
-          title: '記事3',
-          creator: '投稿者3',
-          contentSnippet: 'snippet本文',
-          link: 'https://example.com/3',
-        },
-        {
-          title: '記事4',
-          creator: '投稿者4',
-          link: 'https://example.com/4',
-        },
-      ])
-
-      const result = await fetchHatenaArticles(cronEnv)
-
-      expect(result.isOk()).toBe(true)
-      if (result.isOk()) expect(result.value).toBe(4)
-      expect((await findByUrl('https://example.com/1')).description).toBe('content本文')
-      expect((await findByUrl('https://example.com/2')).description).toBe('encoded本文')
-      expect((await findByUrl('https://example.com/3')).description).toBe('snippet本文')
-      expect((await findByUrl('https://example.com/4')).description).toBe('')
-    })
-  })
-
-  describe('正規化（truncate）', () => {
-    it('各フィールドを最大長で切り詰める', async () => {
-      mockParsedItems([
-        {
-          title: 'あ'.repeat(150),
-          creator: 'い'.repeat(40),
-          content: 'う'.repeat(1100),
-          link: 'https://example.com/long',
-        },
-      ])
-
-      const result = await fetchHatenaArticles(cronEnv)
-
-      expect(result.isOk()).toBe(true)
-      const saved = await findByUrl('https://example.com/long')
-      expect([...saved.title].length).toBe(100)
-      expect([...saved.author].length).toBe(30)
-      expect([...saved.description].length).toBe(1024)
-    })
-
-    it('コードポイント単位で切り詰めサロゲートペア（絵文字）を壊さない', async () => {
-      mockParsedItems([
-        {
-          title: '記事',
-          creator: '😀'.repeat(40),
-          content: '本文',
-          link: 'https://example.com/emoji',
-        },
-      ])
-
-      const result = await fetchHatenaArticles(cronEnv)
-
-      expect(result.isOk()).toBe(true)
-      const saved = await findByUrl('https://example.com/emoji')
-      // 30コードポイント＝絵文字30個。UTF-16長は60だが文字化け（U+FFFD）しない。
-      expect([...saved.author].length).toBe(30)
-      expect(saved.author).toBe('😀'.repeat(30))
-      expect(saved.author).not.toContain('�')
-    })
-
-    it('description は 255 超〜1024 文字まで保存される（domain schema との不整合は別タスクで対応）', async () => {
-      mockParsedItems([
-        {
-          title: '記事',
-          creator: '投稿者',
-          content: 'え'.repeat(600),
-          link: 'https://example.com/desc',
-        },
-      ])
-
-      const result = await fetchHatenaArticles(cronEnv)
-
-      expect(result.isOk()).toBe(true)
-      const saved = await findByUrl('https://example.com/desc')
-      expect([...saved.description].length).toBe(600)
-    })
-  })
-
-  describe('永続化挙動', () => {
-    it('空フィードは ok(0) を返し何も保存しない', async () => {
-      mockParsedItems([])
-
-      const result = await fetchHatenaArticles(cronEnv)
-
-      expect(result.isOk()).toBe(true)
-      if (result.isOk()) expect(result.value).toBe(0)
-      expect(await countArticles()).toBe(0)
-    })
-
-    it('新規記事は全件保存される（D1互換のため1件ずつ）', async () => {
-      mockParsedItems([
-        { title: '記事A', creator: '投稿者A', content: '本文A', link: 'https://example.com/a' },
-        { title: '記事B', creator: '投稿者B', content: '本文B', link: 'https://example.com/b' },
+    it('新規記事を全件保存する', async () => {
+      stubHatena([
+        { title: '記事A', author: '投稿者A', content: '本文A', url: 'https://example.com/a' },
+        { title: '記事B', author: '投稿者B', content: '本文B', url: 'https://example.com/b' },
       ])
 
       const result = await fetchHatenaArticles(cronEnv)
@@ -265,14 +133,105 @@ describe('記事取得（公開API越し結合テスト）', () => {
       expect(await countArticles()).toBe(2)
     })
 
+    it('description は content を content:encoded より優先する', async () => {
+      stubHatena([
+        {
+          title: '記事',
+          author: '投稿者',
+          content: 'content本文',
+          contentEncoded: 'encoded本文',
+          url: 'https://example.com/priority',
+        },
+      ])
+
+      const result = await fetchHatenaArticles(cronEnv)
+
+      expect(result.isOk()).toBe(true)
+      expect((await findByUrl('https://example.com/priority')).description).toBe('content本文')
+    })
+  })
+
+  describe('準正常系', () => {
+    it('creator が欠損した記事は author をはてなブックマークで補完する', async () => {
+      stubHatena([{ title: 'はてな記事', content: 'はてな本文', url: 'https://example.com/h1' }])
+
+      const result = await fetchHatenaArticles(cronEnv)
+
+      expect(result.isOk()).toBe(true)
+      expect((await findByUrl('https://example.com/h1')).author).toBe('はてなブックマーク')
+    })
+
+    it('content が欠損した記事は content:encoded で補完する', async () => {
+      stubHatena([
+        {
+          title: '記事',
+          author: '投稿者',
+          contentEncoded: 'encoded本文',
+          url: 'https://example.com/encoded',
+        },
+      ])
+
+      const result = await fetchHatenaArticles(cronEnv)
+
+      expect(result.isOk()).toBe(true)
+      expect((await findByUrl('https://example.com/encoded')).description).toBe('encoded本文')
+    })
+
+    it('content 系がすべて欠損した記事は description を空にする', async () => {
+      stubHatena([{ title: '記事', author: '投稿者', url: 'https://example.com/empty-desc' }])
+
+      const result = await fetchHatenaArticles(cronEnv)
+
+      expect(result.isOk()).toBe(true)
+      expect((await findByUrl('https://example.com/empty-desc')).description).toBe('')
+    })
+
+    it('各フィールドを最大長で切り詰める', async () => {
+      stubHatena([
+        {
+          title: 'あ'.repeat(150),
+          author: 'い'.repeat(40),
+          content: 'う'.repeat(1100),
+          url: 'https://example.com/long',
+        },
+      ])
+
+      const result = await fetchHatenaArticles(cronEnv)
+
+      expect(result.isOk()).toBe(true)
+      const saved = await findByUrl('https://example.com/long')
+      expect([...saved.title].length).toBe(100)
+      expect([...saved.author].length).toBe(30)
+      // description は domain schema(255) と不整合だが現状は 1024 まで保存される（別タスクで対応）
+      expect([...saved.description].length).toBe(1024)
+    })
+
+    it('絵文字をコードポイント単位で切り詰めサロゲートペアを壊さない', async () => {
+      stubHatena([
+        {
+          title: '記事',
+          author: '😀'.repeat(40),
+          content: '本文',
+          url: 'https://example.com/emoji',
+        },
+      ])
+
+      const result = await fetchHatenaArticles(cronEnv)
+
+      expect(result.isOk()).toBe(true)
+      const saved = await findByUrl('https://example.com/emoji')
+      expect(saved.author).toBe('😀'.repeat(30))
+      expect(saved.author).not.toContain('�')
+    })
+
     it('フィード内で同一URLが重複する場合は1件だけ保存する', async () => {
-      mockParsedItems([
-        { title: '記事A', creator: '投稿者A', content: '本文A', link: 'https://example.com/a' },
+      stubHatena([
+        { title: '記事A', author: '投稿者A', content: '本文A', url: 'https://example.com/a' },
         {
           title: '記事A重複',
-          creator: '投稿者A',
+          author: '投稿者A',
           content: '本文A重複',
-          link: 'https://example.com/a',
+          url: 'https://example.com/a',
         },
       ])
 
@@ -283,17 +242,16 @@ describe('記事取得（公開API越し結合テスト）', () => {
       expect(await countArticles()).toBe(1)
     })
 
-    it('既にDBへ保存済みのURLはスキップし、新規分のみ保存する', async () => {
-      mockParsedItems([
-        { title: '記事A', creator: '投稿者A', content: '本文A', link: 'https://example.com/a' },
+    it('既にDBへ保存済みのURLはスキップし新規分のみ保存する', async () => {
+      stubHatena([
+        { title: '記事A', author: '投稿者A', content: '本文A', url: 'https://example.com/a' },
       ])
       const firstResult = await fetchHatenaArticles(cronEnv)
       expect(firstResult.isOk()).toBe(true)
-      if (firstResult.isOk()) expect(firstResult.value).toBe(1)
 
-      mockParsedItems([
-        { title: '記事A', creator: '投稿者A', content: '本文A', link: 'https://example.com/a' },
-        { title: '記事B', creator: '投稿者B', content: '本文B', link: 'https://example.com/b' },
+      stubHatena([
+        { title: '記事A', author: '投稿者A', content: '本文A', url: 'https://example.com/a' },
+        { title: '記事B', author: '投稿者B', content: '本文B', url: 'https://example.com/b' },
       ])
       const secondResult = await fetchHatenaArticles(cronEnv)
 
@@ -303,6 +261,18 @@ describe('記事取得（公開API越し結合テスト）', () => {
       expect((await findByUrl('https://example.com/b')).author).toBe('投稿者B')
     })
 
+    it('空フィードは何も保存しない', async () => {
+      stubHatena([])
+
+      const result = await fetchHatenaArticles(cronEnv)
+
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) expect(result.value).toBe(0)
+      expect(await countArticles()).toBe(0)
+    })
+  })
+
+  describe('異常系', () => {
     it('RSS取得に失敗した場合は err を返し何も保存しない', async () => {
       fetchMock.mockResolvedValue({ ok: false, status: 500 })
 

--- a/application/packages/cron/src/fetch-articles.test.ts
+++ b/application/packages/cron/src/fetch-articles.test.ts
@@ -1,3 +1,4 @@
+import { articles } from '@trend-diary/datastore/drizzle-orm/schema'
 import { eq } from 'drizzle-orm'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -6,6 +7,8 @@ const parseStringMock = vi.hoisted(() => vi.fn())
 
 vi.stubGlobal('fetch', fetchMock)
 
+// rss-parser はモックし、パース結果（item オブジェクト）を直接注入する。
+// 実XMLのパースは worker.test.ts（e2e）が実 rss-parser で担保する。
 vi.mock('rss-parser', () => ({
   default: class MockParser {
     parseString(xml: string) {
@@ -15,11 +18,14 @@ vi.mock('rss-parser', () => ({
 }))
 
 import { env } from 'cloudflare:test'
-import { articles } from '@trend-diary/datastore/drizzle-orm/schema'
-import { fetchHatenaArticles } from './fetch-articles'
+import { fetchHatenaArticles, fetchQiitaArticles, fetchZennArticles } from './fetch-articles'
 import { testRdb as db } from './test-helper/rdb'
 
 const cronEnv = { DB: env.DB }
+
+const QIITA_FEED_URL = 'https://qiita.com/popular-items/feed.atom'
+const ZENN_FEED_URL = 'https://zenn.dev/feed'
+const HATENA_FEED_URL = 'https://b.hatena.ne.jp/hotentry/it.rss'
 
 async function countArticles(): Promise<number> {
   const rows = await db.select({ url: articles.url }).from(articles)
@@ -31,7 +37,12 @@ async function findByUrl(url: string) {
   return row
 }
 
-describe('fetchHatenaArticles', () => {
+// rss-parser のパース結果を1回分注入する。
+function mockParsedItems(items: unknown[]): void {
+  parseStringMock.mockResolvedValue({ items })
+}
+
+describe('記事取得（公開API越し結合テスト）', () => {
   beforeEach(async () => {
     await db.delete(articles)
 
@@ -48,199 +59,258 @@ describe('fetchHatenaArticles', () => {
     await db.delete(articles)
   })
 
-  it('creatorが欠損した記事はauthorをフォールバック値で補完する', async () => {
-    parseStringMock.mockResolvedValue({
-      items: [
+  describe('メディア別マッピング', () => {
+    it('fetchQiitaArticles: author/content/link を記事へマッピングする', async () => {
+      mockParsedItems([
         {
-          title: '記事タイトル',
-          content: '本文',
-          link: 'https://example.com/1',
+          title: 'Qiita記事',
+          author: 'qiita_author',
+          content: 'Qiita本文',
+          link: 'https://qiita.com/u/items/q1',
         },
-      ],
+      ])
+
+      const result = await fetchQiitaArticles(cronEnv)
+
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) expect(result.value).toBe(1)
+      expect(fetchMock).toHaveBeenCalledWith(QIITA_FEED_URL)
+      const saved = await findByUrl('https://qiita.com/u/items/q1')
+      expect(saved.media).toBe('qiita')
+      expect(saved.title).toBe('Qiita記事')
+      expect(saved.author).toBe('qiita_author')
+      expect(saved.description).toBe('Qiita本文')
     })
 
-    const result = await fetchHatenaArticles(cronEnv)
+    it('fetchZennArticles: creator を author、content を description へマッピングする', async () => {
+      mockParsedItems([
+        {
+          title: 'Zenn記事',
+          creator: 'zenn_creator',
+          content: 'Zenn本文',
+          link: 'https://zenn.dev/u/articles/z1',
+        },
+      ])
 
-    expect(result.isOk()).toBe(true)
-    if (result.isOk()) {
-      expect(result.value).toBe(1)
-    }
-    expect(fetchMock).toHaveBeenCalledWith('https://b.hatena.ne.jp/hotentry/it.rss')
-    const saved = await findByUrl('https://example.com/1')
-    expect(saved.author).toBe('はてなブックマーク')
-    expect(saved.description).toBe('本文')
-    expect(saved.media).toBe('hatena')
+      const result = await fetchZennArticles(cronEnv)
+
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) expect(result.value).toBe(1)
+      expect(fetchMock).toHaveBeenCalledWith(ZENN_FEED_URL)
+      const saved = await findByUrl('https://zenn.dev/u/articles/z1')
+      expect(saved.media).toBe('zenn')
+      expect(saved.author).toBe('zenn_creator')
+      expect(saved.description).toBe('Zenn本文')
+    })
+
+    it('fetchHatenaArticles: creator を author、content を description へマッピングする', async () => {
+      mockParsedItems([
+        {
+          title: 'はてな記事',
+          creator: 'hatena_creator',
+          content: 'はてな本文',
+          link: 'https://example.com/h1',
+        },
+      ])
+
+      const result = await fetchHatenaArticles(cronEnv)
+
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) expect(result.value).toBe(1)
+      expect(fetchMock).toHaveBeenCalledWith(HATENA_FEED_URL)
+      const saved = await findByUrl('https://example.com/h1')
+      expect(saved.media).toBe('hatena')
+      expect(saved.author).toBe('hatena_creator')
+      expect(saved.description).toBe('はてな本文')
+    })
   })
 
-  it('D1互換のため記事は1件ずつ保存する', async () => {
-    parseStringMock.mockResolvedValue({
-      items: [
+  describe('hatena のフォールバック補完', () => {
+    it('creator が欠損した記事は author をはてなブックマークで補完する', async () => {
+      mockParsedItems([
         {
-          title: '記事A',
-          creator: '投稿者A',
-          content: '本文A',
-          link: 'https://example.com/a',
+          title: 'はてな記事',
+          content: 'はてな本文',
+          link: 'https://example.com/h1',
         },
-        {
-          title: '記事B',
-          creator: '投稿者B',
-          content: '本文B',
-          link: 'https://example.com/b',
-        },
-      ],
+      ])
+
+      const result = await fetchHatenaArticles(cronEnv)
+
+      expect(result.isOk()).toBe(true)
+      const saved = await findByUrl('https://example.com/h1')
+      expect(saved.author).toBe('はてなブックマーク')
     })
 
-    const result = await fetchHatenaArticles(cronEnv)
-
-    expect(result.isOk()).toBe(true)
-    if (result.isOk()) {
-      expect(result.value).toBe(2)
-    }
-    expect(await countArticles()).toBe(2)
-    expect((await findByUrl('https://example.com/a')).author).toBe('投稿者A')
-    expect((await findByUrl('https://example.com/b')).author).toBe('投稿者B')
-  })
-
-  it('同一URLの重複記事は1件だけ保存する', async () => {
-    parseStringMock.mockResolvedValue({
-      items: [
-        {
-          title: '記事A',
-          creator: '投稿者A',
-          content: '本文A',
-          link: 'https://example.com/a',
-        },
-        {
-          title: '記事A重複',
-          creator: '投稿者A',
-          content: '本文A重複',
-          link: 'https://example.com/a',
-        },
-      ],
-    })
-
-    const result = await fetchHatenaArticles(cronEnv)
-
-    expect(result.isOk()).toBe(true)
-    if (result.isOk()) {
-      expect(result.value).toBe(1)
-    }
-    expect(await countArticles()).toBe(1)
-  })
-
-  it('既にDBへ保存済みのURLは一意制約により再保存されない', async () => {
-    parseStringMock.mockResolvedValue({
-      items: [
-        {
-          title: '記事A',
-          creator: '投稿者A',
-          content: '本文A',
-          link: 'https://example.com/a',
-        },
-      ],
-    })
-
-    const firstResult = await fetchHatenaArticles(cronEnv)
-    expect(firstResult.isOk()).toBe(true)
-    if (firstResult.isOk()) {
-      expect(firstResult.value).toBe(1)
-    }
-    expect(await countArticles()).toBe(1)
-
-    const secondResult = await fetchHatenaArticles(cronEnv)
-    expect(secondResult.isOk()).toBe(true)
-    if (secondResult.isOk()) {
-      expect(secondResult.value).toBe(0)
-    }
-    expect(await countArticles()).toBe(1)
-  })
-
-  it('保存済みURLと新規URLが混在する場合は新規分のみ保存する', async () => {
-    parseStringMock.mockResolvedValueOnce({
-      items: [
-        {
-          title: '記事A',
-          creator: '投稿者A',
-          content: '本文A',
-          link: 'https://example.com/a',
-        },
-      ],
-    })
-    await fetchHatenaArticles(cronEnv)
-
-    parseStringMock.mockResolvedValueOnce({
-      items: [
-        {
-          title: '記事A',
-          creator: '投稿者A',
-          content: '本文A',
-          link: 'https://example.com/a',
-        },
-        {
-          title: '記事B',
-          creator: '投稿者B',
-          content: '本文B',
-          link: 'https://example.com/b',
-        },
-      ],
-    })
-
-    const result = await fetchHatenaArticles(cronEnv)
-
-    expect(result.isOk()).toBe(true)
-    if (result.isOk()) {
-      expect(result.value).toBe(1)
-    }
-    expect(await countArticles()).toBe(2)
-    expect((await findByUrl('https://example.com/b')).author).toBe('投稿者B')
-  })
-
-  it('RSS取得に失敗した場合はerrを返す', async () => {
-    fetchMock.mockResolvedValue({
-      ok: false,
-      status: 500,
-    })
-
-    const result = await fetchHatenaArticles(cronEnv)
-
-    expect(result.isErr()).toBe(true)
-    if (result.isErr()) {
-      expect(result.error).toBeInstanceOf(Error)
-    }
-    expect(await countArticles()).toBe(0)
-  })
-
-  it('contentが欠損した記事は優先順位でdescriptionを補完する', async () => {
-    parseStringMock.mockResolvedValue({
-      items: [
+    it('description は content > content:encoded > contentSnippet の優先順位で補完する', async () => {
+      mockParsedItems([
         {
           title: '記事1',
           creator: '投稿者1',
+          content: 'content本文',
           'content:encoded': 'encoded本文',
+          contentSnippet: 'snippet本文',
           link: 'https://example.com/1',
         },
         {
           title: '記事2',
           creator: '投稿者2',
+          'content:encoded': 'encoded本文',
           contentSnippet: 'snippet本文',
           link: 'https://example.com/2',
         },
         {
           title: '記事3',
           creator: '投稿者3',
+          contentSnippet: 'snippet本文',
           link: 'https://example.com/3',
         },
-      ],
+        {
+          title: '記事4',
+          creator: '投稿者4',
+          link: 'https://example.com/4',
+        },
+      ])
+
+      const result = await fetchHatenaArticles(cronEnv)
+
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) expect(result.value).toBe(4)
+      expect((await findByUrl('https://example.com/1')).description).toBe('content本文')
+      expect((await findByUrl('https://example.com/2')).description).toBe('encoded本文')
+      expect((await findByUrl('https://example.com/3')).description).toBe('snippet本文')
+      expect((await findByUrl('https://example.com/4')).description).toBe('')
+    })
+  })
+
+  describe('正規化（truncate）', () => {
+    it('各フィールドを最大長で切り詰める', async () => {
+      mockParsedItems([
+        {
+          title: 'あ'.repeat(150),
+          creator: 'い'.repeat(40),
+          content: 'う'.repeat(1100),
+          link: 'https://example.com/long',
+        },
+      ])
+
+      const result = await fetchHatenaArticles(cronEnv)
+
+      expect(result.isOk()).toBe(true)
+      const saved = await findByUrl('https://example.com/long')
+      expect([...saved.title].length).toBe(100)
+      expect([...saved.author].length).toBe(30)
+      expect([...saved.description].length).toBe(1024)
     })
 
-    const result = await fetchHatenaArticles(cronEnv)
+    it('コードポイント単位で切り詰めサロゲートペア（絵文字）を壊さない', async () => {
+      mockParsedItems([
+        {
+          title: '記事',
+          creator: '😀'.repeat(40),
+          content: '本文',
+          link: 'https://example.com/emoji',
+        },
+      ])
 
-    expect(result.isOk()).toBe(true)
-    if (result.isOk()) {
-      expect(result.value).toBe(3)
-    }
-    expect((await findByUrl('https://example.com/1')).description).toBe('encoded本文')
-    expect((await findByUrl('https://example.com/2')).description).toBe('snippet本文')
-    expect((await findByUrl('https://example.com/3')).description).toBe('')
+      const result = await fetchHatenaArticles(cronEnv)
+
+      expect(result.isOk()).toBe(true)
+      const saved = await findByUrl('https://example.com/emoji')
+      // 30コードポイント＝絵文字30個。UTF-16長は60だが文字化け（U+FFFD）しない。
+      expect([...saved.author].length).toBe(30)
+      expect(saved.author).toBe('😀'.repeat(30))
+      expect(saved.author).not.toContain('�')
+    })
+
+    it('description は 255 超〜1024 文字まで保存される（domain schema との不整合は別タスクで対応）', async () => {
+      mockParsedItems([
+        {
+          title: '記事',
+          creator: '投稿者',
+          content: 'え'.repeat(600),
+          link: 'https://example.com/desc',
+        },
+      ])
+
+      const result = await fetchHatenaArticles(cronEnv)
+
+      expect(result.isOk()).toBe(true)
+      const saved = await findByUrl('https://example.com/desc')
+      expect([...saved.description].length).toBe(600)
+    })
+  })
+
+  describe('永続化挙動', () => {
+    it('空フィードは ok(0) を返し何も保存しない', async () => {
+      mockParsedItems([])
+
+      const result = await fetchHatenaArticles(cronEnv)
+
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) expect(result.value).toBe(0)
+      expect(await countArticles()).toBe(0)
+    })
+
+    it('新規記事は全件保存される（D1互換のため1件ずつ）', async () => {
+      mockParsedItems([
+        { title: '記事A', creator: '投稿者A', content: '本文A', link: 'https://example.com/a' },
+        { title: '記事B', creator: '投稿者B', content: '本文B', link: 'https://example.com/b' },
+      ])
+
+      const result = await fetchHatenaArticles(cronEnv)
+
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) expect(result.value).toBe(2)
+      expect(await countArticles()).toBe(2)
+    })
+
+    it('フィード内で同一URLが重複する場合は1件だけ保存する', async () => {
+      mockParsedItems([
+        { title: '記事A', creator: '投稿者A', content: '本文A', link: 'https://example.com/a' },
+        {
+          title: '記事A重複',
+          creator: '投稿者A',
+          content: '本文A重複',
+          link: 'https://example.com/a',
+        },
+      ])
+
+      const result = await fetchHatenaArticles(cronEnv)
+
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) expect(result.value).toBe(1)
+      expect(await countArticles()).toBe(1)
+    })
+
+    it('既にDBへ保存済みのURLはスキップし、新規分のみ保存する', async () => {
+      mockParsedItems([
+        { title: '記事A', creator: '投稿者A', content: '本文A', link: 'https://example.com/a' },
+      ])
+      const firstResult = await fetchHatenaArticles(cronEnv)
+      expect(firstResult.isOk()).toBe(true)
+      if (firstResult.isOk()) expect(firstResult.value).toBe(1)
+
+      mockParsedItems([
+        { title: '記事A', creator: '投稿者A', content: '本文A', link: 'https://example.com/a' },
+        { title: '記事B', creator: '投稿者B', content: '本文B', link: 'https://example.com/b' },
+      ])
+      const secondResult = await fetchHatenaArticles(cronEnv)
+
+      expect(secondResult.isOk()).toBe(true)
+      if (secondResult.isOk()) expect(secondResult.value).toBe(1)
+      expect(await countArticles()).toBe(2)
+      expect((await findByUrl('https://example.com/b')).author).toBe('投稿者B')
+    })
+
+    it('RSS取得に失敗した場合は err を返し何も保存しない', async () => {
+      fetchMock.mockResolvedValue({ ok: false, status: 500 })
+
+      const result = await fetchHatenaArticles(cronEnv)
+
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) expect(result.error).toBeInstanceOf(Error)
+      expect(await countArticles()).toBe(0)
+    })
   })
 })

--- a/application/packages/cron/src/fetch-articles.test.ts
+++ b/application/packages/cron/src/fetch-articles.test.ts
@@ -132,26 +132,68 @@ describe('fetchHatenaArticles', () => {
       if (result.isOk()) expect(result.value).toBe(2)
       expect(await countArticles()).toBe(2)
     })
+  })
 
-    it('description は content を content:encoded より優先する', async () => {
-      stubHatena([
-        {
-          title: '記事',
-          author: '投稿者',
-          content: 'content本文',
-          contentEncoded: 'encoded本文',
-          url: 'https://example.com/priority',
-        },
-      ])
+  describe('準正常系', () => {
+    const descriptionCases: { name: string; overrides: Partial<FeedItem>; expected: string }[] = [
+      {
+        name: 'content を content:encoded より優先する',
+        overrides: { content: 'content本文', contentEncoded: 'encoded本文' },
+        expected: 'content本文',
+      },
+      {
+        name: 'content 欠損時は content:encoded で補完する',
+        overrides: { contentEncoded: 'encoded本文' },
+        expected: 'encoded本文',
+      },
+      {
+        name: 'content 系がすべて欠損なら空にする',
+        overrides: {},
+        expected: '',
+      },
+    ]
+
+    it.each(descriptionCases)('description は $name', async ({ overrides, expected }) => {
+      const url = 'https://example.com/description'
+      stubHatena([{ title: '記事', author: '投稿者', url, ...overrides }])
 
       const result = await fetchHatenaArticles(cronEnv)
 
       expect(result.isOk()).toBe(true)
-      expect((await findByUrl('https://example.com/priority')).description).toBe('content本文')
+      expect((await findByUrl(url)).description).toBe(expected)
     })
-  })
 
-  describe('準正常系', () => {
+    const saveCountCases: { name: string; items: FeedItem[]; expected: number }[] = [
+      {
+        name: 'フィード内で同一URLが重複する場合は1件だけ保存する',
+        items: [
+          { title: '記事A', author: '投稿者A', content: '本文A', url: 'https://example.com/a' },
+          {
+            title: '記事A重複',
+            author: '投稿者A',
+            content: '本文A重複',
+            url: 'https://example.com/a',
+          },
+        ],
+        expected: 1,
+      },
+      {
+        name: '空フィードは何も保存しない',
+        items: [],
+        expected: 0,
+      },
+    ]
+
+    it.each(saveCountCases)('$name', async ({ items, expected }) => {
+      stubHatena(items)
+
+      const result = await fetchHatenaArticles(cronEnv)
+
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) expect(result.value).toBe(expected)
+      expect(await countArticles()).toBe(expected)
+    })
+
     it('creator が欠損した記事は author をはてなブックマークで補完する', async () => {
       stubHatena([{ title: 'はてな記事', content: 'はてな本文', url: 'https://example.com/h1' }])
 
@@ -159,31 +201,6 @@ describe('fetchHatenaArticles', () => {
 
       expect(result.isOk()).toBe(true)
       expect((await findByUrl('https://example.com/h1')).author).toBe('はてなブックマーク')
-    })
-
-    it('content が欠損した記事は content:encoded で補完する', async () => {
-      stubHatena([
-        {
-          title: '記事',
-          author: '投稿者',
-          contentEncoded: 'encoded本文',
-          url: 'https://example.com/encoded',
-        },
-      ])
-
-      const result = await fetchHatenaArticles(cronEnv)
-
-      expect(result.isOk()).toBe(true)
-      expect((await findByUrl('https://example.com/encoded')).description).toBe('encoded本文')
-    })
-
-    it('content 系がすべて欠損した記事は description を空にする', async () => {
-      stubHatena([{ title: '記事', author: '投稿者', url: 'https://example.com/empty-desc' }])
-
-      const result = await fetchHatenaArticles(cronEnv)
-
-      expect(result.isOk()).toBe(true)
-      expect((await findByUrl('https://example.com/empty-desc')).description).toBe('')
     })
 
     it('各フィールドを最大長で切り詰める', async () => {
@@ -224,24 +241,6 @@ describe('fetchHatenaArticles', () => {
       expect(saved.author).not.toContain('�')
     })
 
-    it('フィード内で同一URLが重複する場合は1件だけ保存する', async () => {
-      stubHatena([
-        { title: '記事A', author: '投稿者A', content: '本文A', url: 'https://example.com/a' },
-        {
-          title: '記事A重複',
-          author: '投稿者A',
-          content: '本文A重複',
-          url: 'https://example.com/a',
-        },
-      ])
-
-      const result = await fetchHatenaArticles(cronEnv)
-
-      expect(result.isOk()).toBe(true)
-      if (result.isOk()) expect(result.value).toBe(1)
-      expect(await countArticles()).toBe(1)
-    })
-
     it('既にDBへ保存済みのURLはスキップし新規分のみ保存する', async () => {
       stubHatena([
         { title: '記事A', author: '投稿者A', content: '本文A', url: 'https://example.com/a' },
@@ -259,16 +258,6 @@ describe('fetchHatenaArticles', () => {
       if (secondResult.isOk()) expect(secondResult.value).toBe(1)
       expect(await countArticles()).toBe(2)
       expect((await findByUrl('https://example.com/b')).author).toBe('投稿者B')
-    })
-
-    it('空フィードは何も保存しない', async () => {
-      stubHatena([])
-
-      const result = await fetchHatenaArticles(cronEnv)
-
-      expect(result.isOk()).toBe(true)
-      if (result.isOk()) expect(result.value).toBe(0)
-      expect(await countArticles()).toBe(0)
     })
   })
 

--- a/application/packages/cron/src/test-helper/env.ts
+++ b/application/packages/cron/src/test-helper/env.ts
@@ -1,0 +1,9 @@
+import { env } from 'cloudflare:test'
+
+const TEST_ENV = {
+  DB: env.DB,
+  DISCORD_WEBHOOK_URL: 'https://discord.test/webhook',
+  LOG_LEVEL: 'silent' as const,
+}
+
+export default TEST_ENV

--- a/application/packages/cron/src/test-helper/feed.ts
+++ b/application/packages/cron/src/test-helper/feed.ts
@@ -1,0 +1,91 @@
+export const FEED_URL = {
+  qiita: 'https://qiita.com/popular-items/feed.atom',
+  zenn: 'https://zenn.dev/feed',
+  hatena: 'https://b.hatena.ne.jp/hotentry/it.rss',
+} as const
+
+export type FeedItem = {
+  title: string
+  url: string
+  author?: string
+  content?: string
+  contentEncoded?: string
+}
+
+export function buildQiitaAtom(items: FeedItem[]): string {
+  const entries = items
+    .map((item) =>
+      [
+        '  <entry>',
+        `    <title>${item.title}</title>`,
+        `    <link href="${item.url}"/>`,
+        item.author === undefined ? '' : `    <author><name>${item.author}</name></author>`,
+        item.content === undefined ? '' : `    <content type="html">${item.content}</content>`,
+        '  </entry>',
+      ]
+        .filter((line) => line !== '')
+        .join('\n'),
+    )
+    .join('\n')
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+${entries}
+</feed>`
+}
+
+export function buildZennRss(items: FeedItem[]): string {
+  const entries = items
+    .map((item) =>
+      [
+        '    <item>',
+        `      <title>${item.title}</title>`,
+        `      <link>${item.url}</link>`,
+        item.content === undefined ? '' : `      <description>${item.content}</description>`,
+        item.author === undefined ? '' : `      <dc:creator>${item.author}</dc:creator>`,
+        '    </item>',
+      ]
+        .filter((line) => line !== '')
+        .join('\n'),
+    )
+    .join('\n')
+  return `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+${entries}
+  </channel>
+</rss>`
+}
+
+export function buildHatenaRdf(items: FeedItem[]): string {
+  const seq = items.map((item) => `<rdf:li rdf:resource="${item.url}"/>`).join('')
+  const entries = items
+    .map((item) =>
+      [
+        `  <item rdf:about="${item.url}">`,
+        `    <title>${item.title}</title>`,
+        `    <link>${item.url}</link>`,
+        item.content === undefined ? '' : `    <description>${item.content}</description>`,
+        item.contentEncoded === undefined
+          ? ''
+          : `    <content:encoded>${item.contentEncoded}</content:encoded>`,
+        item.author === undefined ? '' : `    <dc:creator>${item.author}</dc:creator>`,
+        '  </item>',
+      ]
+        .filter((line) => line !== '')
+        .join('\n'),
+    )
+    .join('\n')
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel rdf:about="${FEED_URL.hatena}">
+    <title>はてなブックマーク - 人気エントリー - テクノロジー</title>
+    <link>https://b.hatena.ne.jp/hotentry/it</link>
+    <items><rdf:Seq>${seq}</rdf:Seq></items>
+  </channel>
+${entries}
+</rdf:RDF>`
+}
+
+export function rssResponse(xml: string) {
+  return { ok: true, status: 200, text: async () => xml }
+}

--- a/application/packages/cron/src/worker.test.ts
+++ b/application/packages/cron/src/worker.test.ts
@@ -1,88 +1,23 @@
+import type { ExecutionContext, ScheduledController } from '@cloudflare/workers-types'
 import { articles } from '@trend-diary/datastore/drizzle-orm/schema'
 import { eq } from 'drizzle-orm'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
-
-// e2e: worker.scheduled を実 D1・実 rss-parser で貫通させ、
-// 外部境界（RSSフィード取得 / Discord通知）のみ global fetch でスタブする。
-const fetchMock = vi.hoisted(() => vi.fn())
-
-vi.stubGlobal('fetch', fetchMock)
-
-import { env } from 'cloudflare:test'
+import TEST_ENV from './test-helper/env'
+import {
+  buildHatenaRdf,
+  buildQiitaAtom,
+  buildZennRss,
+  FEED_URL,
+  type FeedItem,
+  rssResponse,
+} from './test-helper/feed'
 import { testRdb as db } from './test-helper/rdb'
 import worker from './worker'
 
-const QIITA_FEED_URL = 'https://qiita.com/popular-items/feed.atom'
-const ZENN_FEED_URL = 'https://zenn.dev/feed'
-const HATENA_FEED_URL = 'https://b.hatena.ne.jp/hotentry/it.rss'
-const DISCORD_WEBHOOK_URL = 'https://discord.test/webhook'
+const fetchMock = vi.fn()
+vi.stubGlobal('fetch', fetchMock)
 
-type FeedArticle = { title: string; author: string; content: string; url: string }
-
-function buildQiitaAtom(items: FeedArticle[]): string {
-  const entries = items
-    .map(
-      (item) => `  <entry>
-    <title>${item.title}</title>
-    <link href="${item.url}"/>
-    <author><name>${item.author}</name></author>
-    <content type="html">${item.content}</content>
-  </entry>`,
-    )
-    .join('\n')
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
-${entries}
-</feed>`
-}
-
-function buildZennRss(items: FeedArticle[]): string {
-  const entries = items
-    .map(
-      (item) => `    <item>
-      <title>${item.title}</title>
-      <link>${item.url}</link>
-      <description>${item.content}</description>
-      <dc:creator>${item.author}</dc:creator>
-    </item>`,
-    )
-    .join('\n')
-  return `<?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <channel>
-${entries}
-  </channel>
-</rss>`
-}
-
-function buildHatenaRdf(items: FeedArticle[]): string {
-  const lis = items.map((item) => `<rdf:li rdf:resource="${item.url}"/>`).join('')
-  const entries = items
-    .map(
-      (item) => `  <item rdf:about="${item.url}">
-    <title>${item.title}</title>
-    <link>${item.url}</link>
-    <description>${item.content}</description>
-    <dc:creator>${item.author}</dc:creator>
-  </item>`,
-    )
-    .join('\n')
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/" xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <channel rdf:about="${HATENA_FEED_URL}">
-    <title>はてブIT</title>
-    <link>https://b.hatena.ne.jp/hotentry/it</link>
-    <items><rdf:Seq>${lis}</rdf:Seq></items>
-  </channel>
-${entries}
-</rdf:RDF>`
-}
-
-function rssResponse(xml: string) {
-  return { ok: true, status: 200, text: async () => xml }
-}
-
-const QIITA_ITEMS: FeedArticle[] = [
+const QIITA_ITEMS: FeedItem[] = [
   {
     title: 'Qiita記事1',
     author: 'qiita_author1',
@@ -96,7 +31,7 @@ const QIITA_ITEMS: FeedArticle[] = [
     url: 'https://qiita.com/u/items/q2',
   },
 ]
-const ZENN_ITEMS: FeedArticle[] = [
+const ZENN_ITEMS: FeedItem[] = [
   {
     title: 'Zenn記事1',
     author: 'zenn_creator1',
@@ -104,7 +39,7 @@ const ZENN_ITEMS: FeedArticle[] = [
     url: 'https://zenn.dev/u/articles/z1',
   },
 ]
-const HATENA_ITEMS: FeedArticle[] = [
+const HATENA_ITEMS: FeedItem[] = [
   {
     title: 'はてな記事1',
     author: 'hatena_creator1',
@@ -112,47 +47,48 @@ const HATENA_ITEMS: FeedArticle[] = [
     url: 'https://example.com/hatena/h1',
   },
 ]
+const TOTAL_ITEMS = QIITA_ITEMS.length + ZENN_ITEMS.length + HATENA_ITEMS.length
 
-// 各メディアのフィードを返す既定ルーティング。media ごとに上書き可能。
-function setupFetchRouting(overrides?: {
-  qiita?: () => unknown
-  zenn?: () => unknown
-  hatena?: () => unknown
-}): void {
-  fetchMock.mockImplementation(async (url: string) => {
-    const target = String(url)
-    if (target.startsWith(DISCORD_WEBHOOK_URL)) return { ok: true, status: 204 }
-    if (target === QIITA_FEED_URL)
-      return (overrides?.qiita ?? (() => rssResponse(buildQiitaAtom(QIITA_ITEMS))))()
-    if (target === ZENN_FEED_URL)
-      return (overrides?.zenn ?? (() => rssResponse(buildZennRss(ZENN_ITEMS))))()
-    if (target === HATENA_FEED_URL)
+// fetch には文字列だけでなく Request が渡される場合があるため URL を正規化する。
+function resolveUrl(input: unknown): string {
+  return input instanceof Request ? input.url : String(input)
+}
+
+function setupFetchRouting(overrides?: { hatena?: () => unknown }): void {
+  fetchMock.mockImplementation(async (input: unknown) => {
+    const target = resolveUrl(input)
+    if (target.startsWith(TEST_ENV.DISCORD_WEBHOOK_URL)) return { ok: true, status: 204 }
+    if (target === FEED_URL.qiita) return rssResponse(buildQiitaAtom(QIITA_ITEMS))
+    if (target === FEED_URL.zenn) return rssResponse(buildZennRss(ZENN_ITEMS))
+    if (target === FEED_URL.hatena)
       return (overrides?.hatena ?? (() => rssResponse(buildHatenaRdf(HATENA_ITEMS))))()
     throw new Error(`unexpected fetch: ${target}`)
   })
 }
 
-function buildEnv() {
-  return {
-    DB: env.DB,
-    DISCORD_WEBHOOK_URL,
-    LOG_LEVEL: 'silent' as const,
-  }
-}
-
-// worker.scheduled を実行し、waitUntil に登録された Promise を回収する。
-async function runScheduled(cron: string, scheduledTime: number): Promise<Promise<unknown>[]> {
+async function runScheduled(scheduledTime: number): Promise<void> {
   const waitUntilCalls: Promise<unknown>[] = []
-  const event = { cron, scheduledTime } as ScheduledController
-  await worker.scheduled(event, buildEnv(), {
+  const event = { cron: '0 */1 * * *', scheduledTime } as unknown as ScheduledController
+  await worker.scheduled(event, TEST_ENV, {
     waitUntil: (promise: Promise<unknown>) => {
       waitUntilCalls.push(promise)
     },
-  } as ExecutionContext)
-  return waitUntilCalls
+  } as unknown as ExecutionContext)
+  await Promise.all(waitUntilCalls)
 }
 
-async function fetchedUrls(): Promise<string[]> {
+async function expectScheduledToReject(scheduledTime: number): Promise<void> {
+  const waitUntilCalls: Promise<unknown>[] = []
+  const event = { cron: '0 */1 * * *', scheduledTime } as unknown as ScheduledController
+  await worker.scheduled(event, TEST_ENV, {
+    waitUntil: (promise: Promise<unknown>) => {
+      waitUntilCalls.push(promise)
+    },
+  } as unknown as ExecutionContext)
+  await expect(Promise.all(waitUntilCalls)).rejects.toThrow()
+}
+
+async function savedUrls(): Promise<string[]> {
   const rows = await db.select({ url: articles.url }).from(articles)
   return rows.map((row) => row.url)
 }
@@ -163,11 +99,12 @@ async function findByUrl(url: string) {
 }
 
 function discordCallCount(): number {
-  return fetchMock.mock.calls.filter((call) => String(call[0]).startsWith(DISCORD_WEBHOOK_URL))
-    .length
+  return fetchMock.mock.calls.filter((call) =>
+    resolveUrl(call[0]).startsWith(TEST_ENV.DISCORD_WEBHOOK_URL),
+  ).length
 }
 
-describe('cron worker（e2e: 実D1貫通）', () => {
+describe('cron worker scheduled', () => {
   beforeEach(async () => {
     await db.delete(articles)
     fetchMock.mockReset()
@@ -176,61 +113,53 @@ describe('cron worker（e2e: 実D1貫通）', () => {
 
   afterAll(async () => {
     await db.delete(articles)
+    vi.unstubAllGlobals()
   })
 
-  it('全メディアのRSSを取得し、記事をD1へ保存する', async () => {
-    const waitUntilCalls = await runScheduled('0 */1 * * *', 1000)
+  describe('正常系', () => {
+    it('全メディアのRSSを取得し記事をD1へ保存する', async () => {
+      await runScheduled(1000)
 
-    expect(waitUntilCalls).toHaveLength(1)
-    await Promise.all(waitUntilCalls)
-
-    const urls = await fetchedUrls()
-    expect(urls).toHaveLength(QIITA_ITEMS.length + ZENN_ITEMS.length + HATENA_ITEMS.length)
-    expect(urls).toEqual(
-      expect.arrayContaining([
-        'https://qiita.com/u/items/q1',
-        'https://qiita.com/u/items/q2',
-        'https://zenn.dev/u/articles/z1',
-        'https://example.com/hatena/h1',
-      ]),
-    )
-
-    expect((await findByUrl('https://qiita.com/u/items/q1')).media).toBe('qiita')
-    expect((await findByUrl('https://zenn.dev/u/articles/z1')).author).toBe('zenn_creator1')
-    expect((await findByUrl('https://example.com/hatena/h1')).description).toBe('はてな本文1')
-
-    // 全件成功時は Discord 通知されない。
-    expect(discordCallCount()).toBe(0)
+      const urls = await savedUrls()
+      expect(urls).toHaveLength(TOTAL_ITEMS)
+      expect(urls).toEqual(
+        expect.arrayContaining([
+          'https://qiita.com/u/items/q1',
+          'https://qiita.com/u/items/q2',
+          'https://zenn.dev/u/articles/z1',
+          'https://example.com/hatena/h1',
+        ]),
+      )
+      expect((await findByUrl('https://qiita.com/u/items/q1')).media).toBe('qiita')
+      expect((await findByUrl('https://zenn.dev/u/articles/z1')).author).toBe('zenn_creator1')
+      expect((await findByUrl('https://example.com/hatena/h1')).description).toBe('はてな本文1')
+      expect(discordCallCount()).toBe(0)
+    })
   })
 
-  it('一部メディアの取得が失敗しても残りは保存し、Discord通知のうえCloudflareへ失敗を伝播する', async () => {
-    setupFetchRouting({ hatena: () => ({ ok: false, status: 500 }) })
+  describe('準正常系', () => {
+    it('再実行しても既存URLはスキップされ記事は重複保存されない', async () => {
+      await runScheduled(2000)
+      const firstCount = (await savedUrls()).length
 
-    const waitUntilCalls = await runScheduled('0 */1 * * *', 2000)
+      await runScheduled(3000)
+      const secondCount = (await savedUrls()).length
 
-    expect(waitUntilCalls).toHaveLength(1)
-    await expect(Promise.all(waitUntilCalls)).rejects.toThrow()
-
-    // qiita / zenn は保存される。
-    const urls = await fetchedUrls()
-    expect(urls).toHaveLength(QIITA_ITEMS.length + ZENN_ITEMS.length)
-    expect(urls).not.toContain('https://example.com/hatena/h1')
-
-    // 失敗メディア通知 + ジョブ失敗通知で Discord が呼ばれる。
-    expect(discordCallCount()).toBeGreaterThanOrEqual(1)
+      expect(firstCount).toBe(TOTAL_ITEMS)
+      expect(secondCount).toBe(TOTAL_ITEMS)
+    })
   })
 
-  it('再実行しても既存URLはスキップされ、記事は重複保存されない（冪等性）', async () => {
-    await Promise.all(await runScheduled('0 */1 * * *', 3000))
-    const firstCount = (await fetchedUrls()).length
+  describe('異常系', () => {
+    it('一部メディアの取得が失敗しても残りを保存し、Discord通知のうえCloudflareへ失敗を伝播する', async () => {
+      setupFetchRouting({ hatena: () => ({ ok: false, status: 500 }) })
 
-    await Promise.all(await runScheduled('0 */1 * * *', 4000))
-    const secondCount = (await fetchedUrls()).length
+      await expectScheduledToReject(4000)
 
-    expect(secondCount).toBe(firstCount)
-    expect(secondCount).toBe(QIITA_ITEMS.length + ZENN_ITEMS.length + HATENA_ITEMS.length)
+      const urls = await savedUrls()
+      expect(urls).toHaveLength(QIITA_ITEMS.length + ZENN_ITEMS.length)
+      expect(urls).not.toContain('https://example.com/hatena/h1')
+      expect(discordCallCount()).toBeGreaterThanOrEqual(1)
+    })
   })
 })
-
-type ScheduledController = import('@cloudflare/workers-types').ScheduledController
-type ExecutionContext = import('@cloudflare/workers-types').ExecutionContext

--- a/application/packages/cron/src/worker.test.ts
+++ b/application/packages/cron/src/worker.test.ts
@@ -1,217 +1,236 @@
-import { ARTICLE_MEDIA, type ArticleMedia } from '@trend-diary/domain/article/media'
-import { err, ok } from 'neverthrow'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { articles } from '@trend-diary/datastore/drizzle-orm/schema'
+import { eq } from 'drizzle-orm'
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// e2e: worker.scheduled を実 D1・実 rss-parser で貫通させ、
+// 外部境界（RSSフィード取得 / Discord通知）のみ global fetch でスタブする。
+const fetchMock = vi.hoisted(() => vi.fn())
+
+vi.stubGlobal('fetch', fetchMock)
+
+import { env } from 'cloudflare:test'
+import { testRdb as db } from './test-helper/rdb'
 import worker from './worker'
 
-const runScheduledFetchMock = vi.hoisted(() => vi.fn())
-const loggerInfoMock = vi.hoisted(() => vi.fn())
-const loggerErrorMock = vi.hoisted(() => vi.fn())
-const sendMessageMock = vi.hoisted(() => vi.fn())
+const QIITA_FEED_URL = 'https://qiita.com/popular-items/feed.atom'
+const ZENN_FEED_URL = 'https://zenn.dev/feed'
+const HATENA_FEED_URL = 'https://b.hatena.ne.jp/hotentry/it.rss'
+const DISCORD_WEBHOOK_URL = 'https://discord.test/webhook'
 
-vi.mock('./fetch-articles', () => ({
-  runScheduledFetch: runScheduledFetchMock,
-}))
+type FeedArticle = { title: string; author: string; content: string; url: string }
 
-vi.mock('@trend-diary/notification', () => ({
-  DiscordWebhookClient: class {
-    sendMessage = sendMessageMock
+function buildQiitaAtom(items: FeedArticle[]): string {
+  const entries = items
+    .map(
+      (item) => `  <entry>
+    <title>${item.title}</title>
+    <link href="${item.url}"/>
+    <author><name>${item.author}</name></author>
+    <content type="html">${item.content}</content>
+  </entry>`,
+    )
+    .join('\n')
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+${entries}
+</feed>`
+}
+
+function buildZennRss(items: FeedArticle[]): string {
+  const entries = items
+    .map(
+      (item) => `    <item>
+      <title>${item.title}</title>
+      <link>${item.url}</link>
+      <description>${item.content}</description>
+      <dc:creator>${item.author}</dc:creator>
+    </item>`,
+    )
+    .join('\n')
+  return `<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+${entries}
+  </channel>
+</rss>`
+}
+
+function buildHatenaRdf(items: FeedArticle[]): string {
+  const lis = items.map((item) => `<rdf:li rdf:resource="${item.url}"/>`).join('')
+  const entries = items
+    .map(
+      (item) => `  <item rdf:about="${item.url}">
+    <title>${item.title}</title>
+    <link>${item.url}</link>
+    <description>${item.content}</description>
+    <dc:creator>${item.author}</dc:creator>
+  </item>`,
+    )
+    .join('\n')
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel rdf:about="${HATENA_FEED_URL}">
+    <title>はてブIT</title>
+    <link>https://b.hatena.ne.jp/hotentry/it</link>
+    <items><rdf:Seq>${lis}</rdf:Seq></items>
+  </channel>
+${entries}
+</rdf:RDF>`
+}
+
+function rssResponse(xml: string) {
+  return { ok: true, status: 200, text: async () => xml }
+}
+
+const QIITA_ITEMS: FeedArticle[] = [
+  {
+    title: 'Qiita記事1',
+    author: 'qiita_author1',
+    content: 'Qiita本文1',
+    url: 'https://qiita.com/u/items/q1',
   },
-}))
-
-vi.mock('@trend-diary/common/logger', () => ({
-  default: class MockLogger {
-    info(message: unknown) {
-      loggerInfoMock(message)
-    }
-
-    error(message: unknown, error: unknown) {
-      loggerErrorMock(message, error)
-    }
+  {
+    title: 'Qiita記事2',
+    author: 'qiita_author2',
+    content: 'Qiita本文2',
+    url: 'https://qiita.com/u/items/q2',
   },
-}))
+]
+const ZENN_ITEMS: FeedArticle[] = [
+  {
+    title: 'Zenn記事1',
+    author: 'zenn_creator1',
+    content: 'Zenn本文1',
+    url: 'https://zenn.dev/u/articles/z1',
+  },
+]
+const HATENA_ITEMS: FeedArticle[] = [
+  {
+    title: 'はてな記事1',
+    author: 'hatena_creator1',
+    content: 'はてな本文1',
+    url: 'https://example.com/hatena/h1',
+  },
+]
 
-describe('cron worker', () => {
-  beforeEach(() => {
-    runScheduledFetchMock.mockReset()
-    loggerInfoMock.mockReset()
-    loggerErrorMock.mockReset()
-    sendMessageMock.mockReset()
+// 各メディアのフィードを返す既定ルーティング。media ごとに上書き可能。
+function setupFetchRouting(overrides?: {
+  qiita?: () => unknown
+  zenn?: () => unknown
+  hatena?: () => unknown
+}): void {
+  fetchMock.mockImplementation(async (url: string) => {
+    const target = String(url)
+    if (target.startsWith(DISCORD_WEBHOOK_URL)) return { ok: true, status: 204 }
+    if (target === QIITA_FEED_URL)
+      return (overrides?.qiita ?? (() => rssResponse(buildQiitaAtom(QIITA_ITEMS))))()
+    if (target === ZENN_FEED_URL)
+      return (overrides?.zenn ?? (() => rssResponse(buildZennRss(ZENN_ITEMS))))()
+    if (target === HATENA_FEED_URL)
+      return (overrides?.hatena ?? (() => rssResponse(buildHatenaRdf(HATENA_ITEMS))))()
+    throw new Error(`unexpected fetch: ${target}`)
+  })
+}
+
+function buildEnv() {
+  return {
+    DB: env.DB,
+    DISCORD_WEBHOOK_URL,
+    LOG_LEVEL: 'silent' as const,
+  }
+}
+
+// worker.scheduled を実行し、waitUntil に登録された Promise を回収する。
+async function runScheduled(cron: string, scheduledTime: number): Promise<Promise<unknown>[]> {
+  const waitUntilCalls: Promise<unknown>[] = []
+  const event = { cron, scheduledTime } as ScheduledController
+  await worker.scheduled(event, buildEnv(), {
+    waitUntil: (promise: Promise<unknown>) => {
+      waitUntilCalls.push(promise)
+    },
+  } as ExecutionContext)
+  return waitUntilCalls
+}
+
+async function fetchedUrls(): Promise<string[]> {
+  const rows = await db.select({ url: articles.url }).from(articles)
+  return rows.map((row) => row.url)
+}
+
+async function findByUrl(url: string) {
+  const [row] = await db.select().from(articles).where(eq(articles.url, url)).limit(1)
+  return row
+}
+
+function discordCallCount(): number {
+  return fetchMock.mock.calls.filter((call) => String(call[0]).startsWith(DISCORD_WEBHOOK_URL))
+    .length
+}
+
+describe('cron worker（e2e: 実D1貫通）', () => {
+  beforeEach(async () => {
+    await db.delete(articles)
+    fetchMock.mockReset()
+    setupFetchRouting()
   })
 
-  it('既知のcron式でfetchジョブを実行する', async () => {
-    runScheduledFetchMock.mockResolvedValue(ok(3))
+  afterAll(async () => {
+    await db.delete(articles)
+  })
 
-    const waitUntilCalls: Promise<unknown>[] = []
-    const event = { cron: '0 */8 * * *', scheduledTime: 1000 } as ScheduledController
-    const env = {
-      DB: {} as D1Database,
-      DISCORD_WEBHOOK_URL: '',
-      LOG_LEVEL: 'silent' as const,
-    }
-
-    await worker.scheduled(event, env, {
-      waitUntil: (promise: Promise<unknown>) => {
-        waitUntilCalls.push(promise)
-      },
-    } as ExecutionContext)
+  it('全メディアのRSSを取得し、記事をD1へ保存する', async () => {
+    const waitUntilCalls = await runScheduled('0 */1 * * *', 1000)
 
     expect(waitUntilCalls).toHaveLength(1)
     await Promise.all(waitUntilCalls)
-    expect(runScheduledFetchMock).toHaveBeenCalledTimes(ARTICLE_MEDIA.length)
-    expect(runScheduledFetchMock).toHaveBeenNthCalledWith(1, 'qiita', env)
-    expect(runScheduledFetchMock).toHaveBeenNthCalledWith(2, 'zenn', env)
-    expect(runScheduledFetchMock).toHaveBeenNthCalledWith(3, 'hatena', env)
 
-    expect(loggerInfoMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        msg: 'cron job started',
-        scheduledTime: 1000,
-        mediaCount: ARTICLE_MEDIA.length,
-      }),
+    const urls = await fetchedUrls()
+    expect(urls).toHaveLength(QIITA_ITEMS.length + ZENN_ITEMS.length + HATENA_ITEMS.length)
+    expect(urls).toEqual(
+      expect.arrayContaining([
+        'https://qiita.com/u/items/q1',
+        'https://qiita.com/u/items/q2',
+        'https://zenn.dev/u/articles/z1',
+        'https://example.com/hatena/h1',
+      ]),
     )
-    expect(loggerInfoMock).toHaveBeenCalledWith(
-      expect.objectContaining({ msg: 'cron media fetch started', media: 'qiita' }),
-    )
-    expect(loggerInfoMock).toHaveBeenCalledWith(
-      expect.objectContaining({ msg: 'cron media fetch started', media: 'zenn' }),
-    )
-    expect(loggerInfoMock).toHaveBeenCalledWith(
-      expect.objectContaining({ msg: 'cron media fetch started', media: 'hatena' }),
-    )
-    expect(loggerInfoMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        msg: 'cron media fetch completed',
-        media: 'qiita',
-        insertedCount: 3,
-      }),
-    )
-    expect(loggerInfoMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        msg: 'cron media fetch completed',
-        media: 'zenn',
-        insertedCount: 3,
-      }),
-    )
-    expect(loggerInfoMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        msg: 'cron media fetch completed',
-        media: 'hatena',
-        insertedCount: 3,
-      }),
-    )
-    expect(loggerInfoMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        msg: 'cron job completed',
-        successCount: ARTICLE_MEDIA.length,
-        failedCount: 0,
-        insertedTotal: 9,
-      }),
-    )
+
+    expect((await findByUrl('https://qiita.com/u/items/q1')).media).toBe('qiita')
+    expect((await findByUrl('https://zenn.dev/u/articles/z1')).author).toBe('zenn_creator1')
+    expect((await findByUrl('https://example.com/hatena/h1')).description).toBe('はてな本文1')
+
+    // 全件成功時は Discord 通知されない。
+    expect(discordCallCount()).toBe(0)
   })
 
-  it('cron式に関係なくfetchジョブを実行する', async () => {
-    runScheduledFetchMock.mockResolvedValue(ok(0))
+  it('一部メディアの取得が失敗しても残りは保存し、Discord通知のうえCloudflareへ失敗を伝播する', async () => {
+    setupFetchRouting({ hatena: () => ({ ok: false, status: 500 }) })
 
-    const waitUntilCalls: Promise<unknown>[] = []
-    const event = { cron: '5 * * * *', scheduledTime: 2000 } as ScheduledController
-    const env = {
-      DB: {} as D1Database,
-      DISCORD_WEBHOOK_URL: '',
-      LOG_LEVEL: 'silent' as const,
-    }
-
-    await worker.scheduled(event, env, {
-      waitUntil: (promise: Promise<unknown>) => {
-        waitUntilCalls.push(promise)
-      },
-    } as ExecutionContext)
-
-    expect(waitUntilCalls).toHaveLength(1)
-    await Promise.all(waitUntilCalls)
-    expect(runScheduledFetchMock).toHaveBeenCalledTimes(ARTICLE_MEDIA.length)
-    expect(runScheduledFetchMock).toHaveBeenNthCalledWith(1, 'qiita', env)
-    expect(runScheduledFetchMock).toHaveBeenNthCalledWith(2, 'zenn', env)
-    expect(runScheduledFetchMock).toHaveBeenNthCalledWith(3, 'hatena', env)
-  })
-
-  it('片方のmediaで失敗(err)しても残りのmediaを実行し、最上位でthrowする', async () => {
-    runScheduledFetchMock.mockImplementation(async (media: ArticleMedia) => {
-      if (media === 'qiita') {
-        return err(new Error('qiita failed'))
-      }
-
-      return ok(2)
-    })
-
-    const waitUntilCalls: Promise<unknown>[] = []
-    const event = { cron: '0 */8 * * *', scheduledTime: 3000 } as ScheduledController
-    const env = {
-      DB: {} as D1Database,
-      DISCORD_WEBHOOK_URL: '',
-      LOG_LEVEL: 'silent' as const,
-    }
-
-    await worker.scheduled(event, env, {
-      waitUntil: (promise: Promise<unknown>) => {
-        waitUntilCalls.push(promise)
-      },
-    } as ExecutionContext)
+    const waitUntilCalls = await runScheduled('0 */1 * * *', 2000)
 
     expect(waitUntilCalls).toHaveLength(1)
     await expect(Promise.all(waitUntilCalls)).rejects.toThrow()
-    expect(runScheduledFetchMock).toHaveBeenCalledTimes(ARTICLE_MEDIA.length)
-    expect(runScheduledFetchMock).toHaveBeenNthCalledWith(1, 'qiita', env)
-    expect(runScheduledFetchMock).toHaveBeenNthCalledWith(2, 'zenn', env)
-    expect(runScheduledFetchMock).toHaveBeenNthCalledWith(3, 'hatena', env)
-    expect(loggerErrorMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        msg: 'cron media fetch failed',
-        media: 'qiita',
-      }),
-      expect.any(Error),
-    )
-    expect(loggerInfoMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        msg: 'cron job completed',
-        successCount: 2,
-        failedCount: 1,
-        insertedTotal: 4,
-      }),
-    )
-    expect(sendMessageMock).toHaveBeenCalledWith(expect.stringContaining('media: qiita'))
+
+    // qiita / zenn は保存される。
+    const urls = await fetchedUrls()
+    expect(urls).toHaveLength(QIITA_ITEMS.length + ZENN_ITEMS.length)
+    expect(urls).not.toContain('https://example.com/hatena/h1')
+
+    // 失敗メディア通知 + ジョブ失敗通知で Discord が呼ばれる。
+    expect(discordCallCount()).toBeGreaterThanOrEqual(1)
   })
 
-  it('ジョブ全体が予期せず失敗したらDiscordに通知し、Cloudflareにも失敗として伝播させる', async () => {
-    const failure = new Error('logger boom')
-    loggerInfoMock.mockImplementation((message: { msg?: string }) => {
-      if (message?.msg === 'cron job started') {
-        throw failure
-      }
-    })
+  it('再実行しても既存URLはスキップされ、記事は重複保存されない（冪等性）', async () => {
+    await Promise.all(await runScheduled('0 */1 * * *', 3000))
+    const firstCount = (await fetchedUrls()).length
 
-    const waitUntilCalls: Promise<unknown>[] = []
-    const event = { cron: '0 */1 * * *', scheduledTime: 4000 } as ScheduledController
-    const env = {
-      DB: {} as D1Database,
-      DISCORD_WEBHOOK_URL: 'https://example.com/webhook',
-      LOG_LEVEL: 'silent' as const,
-    }
+    await Promise.all(await runScheduled('0 */1 * * *', 4000))
+    const secondCount = (await fetchedUrls()).length
 
-    await worker.scheduled(event, env, {
-      waitUntil: (promise: Promise<unknown>) => {
-        waitUntilCalls.push(promise)
-      },
-    } as ExecutionContext)
-
-    expect(waitUntilCalls).toHaveLength(1)
-    await expect(Promise.all(waitUntilCalls)).rejects.toThrow('logger boom')
-    expect(runScheduledFetchMock).not.toHaveBeenCalled()
-    expect(sendMessageMock).toHaveBeenCalledWith(expect.stringContaining('job failed'))
-    expect(loggerErrorMock).toHaveBeenCalledWith(
-      expect.objectContaining({ msg: 'cron job failed' }),
-      failure,
-    )
+    expect(secondCount).toBe(firstCount)
+    expect(secondCount).toBe(QIITA_ITEMS.length + ZENN_ITEMS.length + HATENA_ITEMS.length)
   })
 })
 
-type D1Database = import('@cloudflare/workers-types').D1Database
+type ScheduledController = import('@cloudflare/workers-types').ScheduledController
+type ExecutionContext = import('@cloudflare/workers-types').ExecutionContext

--- a/application/packages/cron/src/worker.test.ts
+++ b/application/packages/cron/src/worker.test.ts
@@ -49,14 +49,9 @@ const HATENA_ITEMS: FeedItem[] = [
 ]
 const TOTAL_ITEMS = QIITA_ITEMS.length + ZENN_ITEMS.length + HATENA_ITEMS.length
 
-// fetch には文字列だけでなく Request が渡される場合があるため URL を正規化する。
-function resolveUrl(input: unknown): string {
-  return input instanceof Request ? input.url : String(input)
-}
-
 function setupFetchRouting(overrides?: { hatena?: () => unknown }): void {
   fetchMock.mockImplementation(async (input: unknown) => {
-    const target = resolveUrl(input)
+    const target = String(input)
     if (target.startsWith(TEST_ENV.DISCORD_WEBHOOK_URL)) return { ok: true, status: 204 }
     if (target === FEED_URL.qiita) return rssResponse(buildQiitaAtom(QIITA_ITEMS))
     if (target === FEED_URL.zenn) return rssResponse(buildZennRss(ZENN_ITEMS))
@@ -66,7 +61,7 @@ function setupFetchRouting(overrides?: { hatena?: () => unknown }): void {
   })
 }
 
-async function runScheduled(scheduledTime: number): Promise<void> {
+async function runScheduled(scheduledTime: number): Promise<Promise<unknown>[]> {
   const waitUntilCalls: Promise<unknown>[] = []
   const event = { cron: '0 */1 * * *', scheduledTime } as unknown as ScheduledController
   await worker.scheduled(event, TEST_ENV, {
@@ -74,18 +69,7 @@ async function runScheduled(scheduledTime: number): Promise<void> {
       waitUntilCalls.push(promise)
     },
   } as unknown as ExecutionContext)
-  await Promise.all(waitUntilCalls)
-}
-
-async function expectScheduledToReject(scheduledTime: number): Promise<void> {
-  const waitUntilCalls: Promise<unknown>[] = []
-  const event = { cron: '0 */1 * * *', scheduledTime } as unknown as ScheduledController
-  await worker.scheduled(event, TEST_ENV, {
-    waitUntil: (promise: Promise<unknown>) => {
-      waitUntilCalls.push(promise)
-    },
-  } as unknown as ExecutionContext)
-  await expect(Promise.all(waitUntilCalls)).rejects.toThrow()
+  return waitUntilCalls
 }
 
 async function savedUrls(): Promise<string[]> {
@@ -100,7 +84,7 @@ async function findByUrl(url: string) {
 
 function discordCallCount(): number {
   return fetchMock.mock.calls.filter((call) =>
-    resolveUrl(call[0]).startsWith(TEST_ENV.DISCORD_WEBHOOK_URL),
+    String(call[0]).startsWith(TEST_ENV.DISCORD_WEBHOOK_URL),
   ).length
 }
 
@@ -118,7 +102,7 @@ describe('cron worker scheduled', () => {
 
   describe('正常系', () => {
     it('全メディアのRSSを取得し記事をD1へ保存する', async () => {
-      await runScheduled(1000)
+      await Promise.all(await runScheduled(1000))
 
       const urls = await savedUrls()
       expect(urls).toHaveLength(TOTAL_ITEMS)
@@ -139,10 +123,10 @@ describe('cron worker scheduled', () => {
 
   describe('準正常系', () => {
     it('再実行しても既存URLはスキップされ記事は重複保存されない', async () => {
-      await runScheduled(2000)
+      await Promise.all(await runScheduled(2000))
       const firstCount = (await savedUrls()).length
 
-      await runScheduled(3000)
+      await Promise.all(await runScheduled(3000))
       const secondCount = (await savedUrls()).length
 
       expect(firstCount).toBe(TOTAL_ITEMS)
@@ -154,7 +138,7 @@ describe('cron worker scheduled', () => {
     it('一部メディアの取得が失敗しても残りを保存し、Discord通知のうえCloudflareへ失敗を伝播する', async () => {
       setupFetchRouting({ hatena: () => ({ ok: false, status: 500 }) })
 
-      await expectScheduledToReject(4000)
+      await expect(Promise.all(await runScheduled(4000))).rejects.toThrow()
 
       const urls = await savedUrls()
       expect(urls).toHaveLength(QIITA_ITEMS.length + ZENN_ITEMS.length)


### PR DESCRIPTION
## 背景・課題

cron のテスト構造が破綻していたため再設計した。

- `fetch-articles.test.ts` は **hatena のみ** を検証し、qiita/zenn のマッピングが未検証だった
- 1つの `describe` にビジネスロジック検証（fallback・description優先順位・truncate）とデータ層検証（dedup・既存スキップ）が混在し、層の責務が分離されていなかった
- `worker.test.ts` は全モックで、**実D1を貫通する真のe2eが存在しなかった**

> ビジネスロジックが薄いため、ロジック検証とデータ層検証は1つの結合テストに統合する方針。

## 変更内容

production コード（`fetch-articles.ts` / `worker.ts`）は**一切変更せず**、テストを公開API越しに駆動する2層へ再編。

### 1. 結合テスト `fetch-articles.test.ts`（リライト）
公開API `fetchQiita/Zenn/Hatena` を fetch + rss-parser スタブで駆動し、D1への保存内容・件数で検証。全メディア網羅。
- メディア別マッピング（qiita: author/content、zenn: creator→author、hatena: creator + description優先順位）
- hatena フォールバック（creator欠損→`はてなブックマーク`、description `content` > `content:encoded` > `contentSnippet` > `''`）
- 正規化（最大長 truncate、コードポイント単位で絵文字非破壊）
- 永続化挙動（空フィード→ok(0)、複数insert、フィード内dedup、既存URLスキップ、RSS取得失敗→err）

### 2. e2e `worker.test.ts`（リライト）
`worker.scheduled()` を**実D1・実rss-parser**で貫通させ、外部境界（RSS取得 / Discord通知）のみ global fetch でスタブ。
- 正常系: 3メディアのRSSを取得しD1へ保存
- 部分失敗: 1メディア失敗でも残りは保存、Discord通知＋Cloudflareへ失敗伝播
- 冪等性: 再実行で既存URLはスキップ

## 確認

- `pnpm --filter @trend-diary/cron test` → 16 passed
- `pnpm --filter @trend-diary/cron typecheck` → OK
- `pnpm lint`（biome + 全パッケージtypecheck）→ OK

## 補足（別タスク）

ドメイン `articleSchema.description = max(255)` と cron `MAX_LENGTH.description = 1024` の不整合を確認。本PRでは**記録のみ**で修正しない（テストにもコメントで明記）。


---
_Generated by [Claude Code](https://claude.ai/code/session_015kqfPkgE5CAK1G2S6oJ5hY)_