### PR TITLE
chore(supabase): 未使用の setup_config.sql を削除

### DIFF
--- a/application/supabase/config.toml
+++ b/application/supabase/config.toml
@@ -48,7 +48,7 @@ max_client_conn = 100
 [db.migrations]
 # Specifies an ordered list of schema files that describe your database.
 # Supports glob patterns relative to supabase directory: "./schemas/*.sql"
-schema_paths = ["./schemas/setup_config.sql"]
+schema_paths = []
 
 [db.seed]
 # If enabled, seeds the database after migrations during a db reset.

--- a/application/supabase/schemas/setup_config.sql
+++ b/application/supabase/schemas/setup_config.sql
@@ -1,4 +1,0 @@
-ALTER DATABASE postgres SET client_encoding to 'UTF8';
-ALTER DATABASE postgres SET TimeZone to 'Asia/Tokyo';
-ALTER DATABASE postgres SET datestyle to 'ISO, YMD';
-ALTER DATABASE postgres SET idle_in_transaction_session_timeout to '10min';


### PR DESCRIPTION
## 概要

未使用となっていた `application/supabase/schemas/setup_config.sql` を削除します。

## 背景・調査結果

- このプロジェクトの Supabase は**認証(GoTrue)専用**で起動している（`supabase:start` / CI の `setup_supabase` action ともに `-x` で postgrest 等を除外）。アプリのデータは SQLite/D1 (drizzle) 側で管理。
- `setup_config.sql` の参照元は `config.toml` の `[db.migrations] schema_paths` のみ。
- `schema_paths`（宣言的スキーマ）は `supabase db diff` → migration生成 → 適用 のパイプラインで初めて効くが、本リポジトリには `supabase/migrations/` が存在せず、CI・scripts・workflow のどこにも `db diff/reset/push` が無い（実行されるのは `supabase start` のみ）。
- → `ALTER DATABASE postgres SET ...` 群は**事実上一度も適用されていなかった**ため削除する。

## 変更内容

- `application/supabase/schemas/setup_config.sql` を削除（空になった `schemas/` ディレクトリも削除）
- `application/supabase/config.toml` の `schema_paths` を `[]`（デフォルト）に戻す

## 影響

認証専用構成のため、保存データ・認証動作への影響なし。

https://claude.ai/code/session_01TDzhqTpKAZi1PSNE6BNtTF

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDzhqTpKAZi1PSNE6BNtTF)_