### PR TITLE
fix: .gemini/styleguide.md のシンボリックリンク切れを修正

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,1 +1,1 @@
-docs/development_rule.md
+../docs/development_rule.md


### PR DESCRIPTION
## 概要

イシュー #717 で報告された `.gemini/styleguide.md` のシンボリックリンク切れを修正します。

## 原因

シンボリックリンクの相対パスはリンク自身のあるディレクトリ（`.gemini/`）を基準に解決されます。リンク先が `docs/development_rule.md` だったため、実際には `.gemini/docs/development_rule.md` を指してしまい、ファイルが存在せずリンク切れになっていました。

## 修正内容

リンク先を `.gemini/` から見た相対パスに修正しました。

```diff
-.gemini/styleguide.md -> docs/development_rule.md
+.gemini/styleguide.md -> ../docs/development_rule.md
```

## 確認

- `test -e .gemini/styleguide.md` が成功し、リンクが解決されることを確認
- リンク経由で `docs/development_rule.md`（開発ルール）の内容が読めることを確認

## 補足

Gemini Code Assist がスタイルガイドを正しく読み込めているかは、マージ後の挙動で確認するのが望ましいです。

Closes #717

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DViNLwvJfiCg6KPKWzJzTX)_