### PR TITLE
fix(cron): RSSフィード項目の実行時バリデーションを追加する

### DIFF
--- a/application/packages/cron/package.json
+++ b/application/packages/cron/package.json
@@ -20,7 +20,8 @@
     "@trend-diary/notification": "workspace:*",
     "drizzle-orm": "catalog:",
     "neverthrow": "catalog:",
-    "rss-parser": "^3.13.0"
+    "rss-parser": "^3.13.0",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "catalog:",

--- a/application/packages/cron/src/feed-config.ts
+++ b/application/packages/cron/src/feed-config.ts
@@ -1,4 +1,5 @@
 import extractTrimmed from '@trend-diary/common/sanitization'
+import { z } from 'zod'
 
 export const FEED_URL = {
   qiita: 'https://qiita.com/popular-items/feed.atom',
@@ -14,6 +15,21 @@ export interface NormalizedItem {
   description: string
   url: string
 }
+
+// 外部フィードは欠落フィールドを undefined で返すため、保存前に実行時検証する。
+// title / author / url は欠落・空文字なら不正としてスキップ対象にし、
+// description は欠落しても致命的でないため空文字で補完する。
+const requiredText = z.string().trim().min(1)
+
+export const normalizedItemSchema = z.object({
+  title: requiredText,
+  author: requiredText,
+  description: z
+    .string()
+    .optional()
+    .transform((value) => value ?? ''),
+  url: requiredText,
+})
 
 export interface FeedConfig<RawItem> {
   url: string

--- a/application/packages/cron/src/feed-config.ts
+++ b/application/packages/cron/src/feed-config.ts
@@ -16,7 +16,7 @@ export interface NormalizedItem {
   url: string
 }
 
-// 外部フィードは欠落フィールドを undefined で返すため、保存前に実行時検証する。
+// 外部フィードは欠落フィールドを undefined / null で返すため、保存前に実行時検証する。
 // title / author / url は欠落・空文字なら不正としてスキップ対象にし、
 // description は欠落しても致命的でないため空文字で補完する。
 const requiredText = z.string().trim().min(1)
@@ -26,7 +26,7 @@ export const normalizedItemSchema = z.object({
   author: requiredText,
   description: z
     .string()
-    .optional()
+    .nullish()
     .transform((value) => value ?? ''),
   url: requiredText,
 })

--- a/application/packages/cron/src/fetch-all-articles.ts
+++ b/application/packages/cron/src/fetch-all-articles.ts
@@ -35,7 +35,7 @@ export async function fetchAllArticles({
     const mediaStartedAt = Date.now()
     logger.info({ msg: 'cron media fetch started', media })
 
-    const result = await runScheduledFetch(media, env)
+    const result = await runScheduledFetch(media, env, logger)
 
     if (result.isErr()) {
       failedCount += 1

--- a/application/packages/cron/src/fetch-articles.test.ts
+++ b/application/packages/cron/src/fetch-articles.test.ts
@@ -1,4 +1,5 @@
 import { env } from 'cloudflare:test'
+import Logger from '@trend-diary/common/logger'
 import { articles } from '@trend-diary/datastore/drizzle-orm/schema'
 import { eq } from 'drizzle-orm'
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -16,6 +17,7 @@ const fetchMock = vi.fn()
 vi.stubGlobal('fetch', fetchMock)
 
 const cronEnv = { DB: env.DB }
+const logger = new Logger('silent')
 
 function stubFeed(xml: string): void {
   fetchMock.mockResolvedValue(rssResponse(xml))
@@ -55,7 +57,7 @@ describe('fetchQiitaArticles', () => {
         ]),
       )
 
-      const result = await fetchQiitaArticles(cronEnv)
+      const result = await fetchQiitaArticles(cronEnv, logger)
 
       expect(result.isOk()).toBe(true)
       if (result.isOk()) expect(result.value).toBe(1)
@@ -64,6 +66,93 @@ describe('fetchQiitaArticles', () => {
       expect(saved.title).toBe('Qiita記事')
       expect(saved.author).toBe('qiita_author')
       expect(saved.description).toBe('Qiita本文')
+    })
+
+    it('content が欠損した記事は description を空文字で補完して保存する', async () => {
+      stubFeed(
+        buildQiitaAtom([
+          {
+            title: 'Qiita記事',
+            author: 'qiita_author',
+            url: 'https://qiita.com/u/items/no-content',
+          },
+        ]),
+      )
+
+      const result = await fetchQiitaArticles(cronEnv, logger)
+
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) expect(result.value).toBe(1)
+      expect((await findByUrl('https://qiita.com/u/items/no-content')).description).toBe('')
+    })
+  })
+
+  describe('準正常系', () => {
+    const skipCases: { name: string; item: FeedItem }[] = [
+      {
+        name: 'title が欠損した記事',
+        item: { author: 'qiita_author', content: '本文', url: 'https://qiita.com/u/items/skip' },
+      },
+      {
+        name: 'author が欠損した記事',
+        item: { title: 'Qiita記事', content: '本文', url: 'https://qiita.com/u/items/skip' },
+      },
+      {
+        name: 'url が欠損した記事',
+        item: { title: 'Qiita記事', author: 'qiita_author', content: '本文' },
+      },
+    ]
+
+    it.each(skipCases)('$name はスキップして保存しない', async ({ item }) => {
+      stubFeed(buildQiitaAtom([item]))
+
+      const result = await fetchQiitaArticles(cronEnv, logger)
+
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) expect(result.value).toBe(0)
+      expect(await countArticles()).toBe(0)
+    })
+
+    it('不正な記事を除外し正常な記事のみ保存する（部分成功）', async () => {
+      stubFeed(
+        buildQiitaAtom([
+          { author: 'qiita_author', content: '本文', url: 'https://qiita.com/u/items/skip' },
+          {
+            title: 'Qiita正常',
+            author: 'qiita_author',
+            content: '本文',
+            url: 'https://qiita.com/u/items/ok',
+          },
+        ]),
+      )
+
+      const result = await fetchQiitaArticles(cronEnv, logger)
+
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) expect(result.value).toBe(1)
+      expect(await countArticles()).toBe(1)
+      expect((await findByUrl('https://qiita.com/u/items/ok')).title).toBe('Qiita正常')
+    })
+
+    it('スキップした件数を警告ログに出力する', async () => {
+      const spyLogger = new Logger('silent')
+      const warnSpy = vi.spyOn(spyLogger, 'warn')
+      stubFeed(
+        buildQiitaAtom([
+          { author: 'qiita_author', content: '本文', url: 'https://qiita.com/u/items/skip1' },
+          { author: 'qiita_author', content: '本文', url: 'https://qiita.com/u/items/skip2' },
+        ]),
+      )
+
+      await fetchQiitaArticles(cronEnv, spyLogger)
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          msg: 'cron feed items skipped',
+          media: 'qiita',
+          skippedCount: 2,
+        }),
+      )
     })
   })
 })
@@ -82,7 +171,7 @@ describe('fetchZennArticles', () => {
         ]),
       )
 
-      const result = await fetchZennArticles(cronEnv)
+      const result = await fetchZennArticles(cronEnv, logger)
 
       expect(result.isOk()).toBe(true)
       if (result.isOk()) expect(result.value).toBe(1)
@@ -90,6 +179,54 @@ describe('fetchZennArticles', () => {
       expect(saved.media).toBe('zenn')
       expect(saved.author).toBe('zenn_creator')
       expect(saved.description).toBe('Zenn本文')
+    })
+  })
+
+  describe('準正常系', () => {
+    const skipCases: { name: string; item: FeedItem }[] = [
+      {
+        name: 'title が欠損した記事',
+        item: { author: 'zenn_creator', content: '本文', url: 'https://zenn.dev/u/articles/skip' },
+      },
+      {
+        name: 'creator が欠損した記事',
+        item: { title: 'Zenn記事', content: '本文', url: 'https://zenn.dev/u/articles/skip' },
+      },
+      {
+        name: 'link が欠損した記事',
+        item: { title: 'Zenn記事', author: 'zenn_creator', content: '本文' },
+      },
+    ]
+
+    it.each(skipCases)('$name はスキップして保存しない', async ({ item }) => {
+      stubFeed(buildZennRss([item]))
+
+      const result = await fetchZennArticles(cronEnv, logger)
+
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) expect(result.value).toBe(0)
+      expect(await countArticles()).toBe(0)
+    })
+
+    it('不正な記事を除外し正常な記事のみ保存する（部分成功）', async () => {
+      stubFeed(
+        buildZennRss([
+          { author: 'zenn_creator', content: '本文', url: 'https://zenn.dev/u/articles/skip' },
+          {
+            title: 'Zenn正常',
+            author: 'zenn_creator',
+            content: '本文',
+            url: 'https://zenn.dev/u/articles/ok',
+          },
+        ]),
+      )
+
+      const result = await fetchZennArticles(cronEnv, logger)
+
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) expect(result.value).toBe(1)
+      expect(await countArticles()).toBe(1)
+      expect((await findByUrl('https://zenn.dev/u/articles/ok')).title).toBe('Zenn正常')
     })
   })
 })
@@ -110,7 +247,7 @@ describe('fetchHatenaArticles', () => {
         },
       ])
 
-      const result = await fetchHatenaArticles(cronEnv)
+      const result = await fetchHatenaArticles(cronEnv, logger)
 
       expect(result.isOk()).toBe(true)
       if (result.isOk()) expect(result.value).toBe(1)
@@ -126,7 +263,7 @@ describe('fetchHatenaArticles', () => {
         { title: '記事B', author: '投稿者B', content: '本文B', url: 'https://example.com/b' },
       ])
 
-      const result = await fetchHatenaArticles(cronEnv)
+      const result = await fetchHatenaArticles(cronEnv, logger)
 
       expect(result.isOk()).toBe(true)
       if (result.isOk()) expect(result.value).toBe(2)
@@ -157,7 +294,7 @@ describe('fetchHatenaArticles', () => {
       const url = 'https://example.com/description'
       stubHatena([{ title: '記事', author: '投稿者', url, ...overrides }])
 
-      const result = await fetchHatenaArticles(cronEnv)
+      const result = await fetchHatenaArticles(cronEnv, logger)
 
       expect(result.isOk()).toBe(true)
       expect((await findByUrl(url)).description).toBe(expected)
@@ -187,7 +324,7 @@ describe('fetchHatenaArticles', () => {
     it.each(saveCountCases)('$name', async ({ items, expected }) => {
       stubHatena(items)
 
-      const result = await fetchHatenaArticles(cronEnv)
+      const result = await fetchHatenaArticles(cronEnv, logger)
 
       expect(result.isOk()).toBe(true)
       if (result.isOk()) expect(result.value).toBe(expected)
@@ -197,7 +334,7 @@ describe('fetchHatenaArticles', () => {
     it('creator が欠損した記事は author をはてなブックマークで補完する', async () => {
       stubHatena([{ title: 'はてな記事', content: 'はてな本文', url: 'https://example.com/h1' }])
 
-      const result = await fetchHatenaArticles(cronEnv)
+      const result = await fetchHatenaArticles(cronEnv, logger)
 
       expect(result.isOk()).toBe(true)
       expect((await findByUrl('https://example.com/h1')).author).toBe('はてなブックマーク')
@@ -213,7 +350,7 @@ describe('fetchHatenaArticles', () => {
         },
       ])
 
-      const result = await fetchHatenaArticles(cronEnv)
+      const result = await fetchHatenaArticles(cronEnv, logger)
 
       expect(result.isOk()).toBe(true)
       const saved = await findByUrl('https://example.com/long')
@@ -233,7 +370,7 @@ describe('fetchHatenaArticles', () => {
         },
       ])
 
-      const result = await fetchHatenaArticles(cronEnv)
+      const result = await fetchHatenaArticles(cronEnv, logger)
 
       expect(result.isOk()).toBe(true)
       const saved = await findByUrl('https://example.com/emoji')
@@ -245,14 +382,14 @@ describe('fetchHatenaArticles', () => {
       stubHatena([
         { title: '記事A', author: '投稿者A', content: '本文A', url: 'https://example.com/a' },
       ])
-      const firstResult = await fetchHatenaArticles(cronEnv)
+      const firstResult = await fetchHatenaArticles(cronEnv, logger)
       expect(firstResult.isOk()).toBe(true)
 
       stubHatena([
         { title: '記事A', author: '投稿者A', content: '本文A', url: 'https://example.com/a' },
         { title: '記事B', author: '投稿者B', content: '本文B', url: 'https://example.com/b' },
       ])
-      const secondResult = await fetchHatenaArticles(cronEnv)
+      const secondResult = await fetchHatenaArticles(cronEnv, logger)
 
       expect(secondResult.isOk()).toBe(true)
       if (secondResult.isOk()) expect(secondResult.value).toBe(1)
@@ -265,7 +402,7 @@ describe('fetchHatenaArticles', () => {
     it('RSS取得に失敗した場合は err を返し何も保存しない', async () => {
       fetchMock.mockResolvedValue({ ok: false, status: 500 })
 
-      const result = await fetchHatenaArticles(cronEnv)
+      const result = await fetchHatenaArticles(cronEnv, logger)
 
       expect(result.isErr()).toBe(true)
       if (result.isErr()) expect(result.error).toBeInstanceOf(Error)

--- a/application/packages/cron/src/fetch-articles.ts
+++ b/application/packages/cron/src/fetch-articles.ts
@@ -1,3 +1,4 @@
+import type Logger from '@trend-diary/common/logger'
 import { wrapAsyncCall } from '@trend-diary/common/result'
 import { articles } from '@trend-diary/datastore/drizzle-orm/schema'
 import getRdbClient, { wrapDbCall } from '@trend-diary/datastore/rdb'
@@ -6,7 +7,12 @@ import { inArray } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
 import Parser from 'rss-parser'
 import type { FetchEnv } from './env'
-import { FEED_CONFIGS, type FeedConfig, type NormalizedItem } from './feed-config'
+import {
+  FEED_CONFIGS,
+  type FeedConfig,
+  type NormalizedItem,
+  normalizedItemSchema,
+} from './feed-config'
 
 const MAX_LENGTH = {
   media: 10,
@@ -111,30 +117,74 @@ function isUniqueConstraintError(error: unknown): boolean {
   return false
 }
 
+// 1件の不正itemでメディア全体の取込を止めないよう、不正itemは警告ログを残してスキップする。
+function selectValidItems(
+  media: ArticleMedia,
+  items: NormalizedItem[],
+  logger: Logger,
+): NormalizedItem[] {
+  const validItems: NormalizedItem[] = []
+  let skippedCount = 0
+
+  for (const item of items) {
+    const parsed = normalizedItemSchema.safeParse(item)
+    if (!parsed.success) {
+      skippedCount += 1
+      logger.warn({
+        msg: 'cron feed item skipped: validation failed',
+        media,
+        url: typeof item?.url === 'string' ? item.url : undefined,
+        issues: parsed.error.issues.map((issue) => ({
+          path: issue.path.join('.'),
+          message: issue.message,
+        })),
+      })
+      continue
+    }
+    validItems.push(parsed.data)
+  }
+
+  if (skippedCount > 0) {
+    logger.warn({
+      msg: 'cron feed items skipped',
+      media,
+      skippedCount,
+      totalCount: items.length,
+    })
+  }
+
+  return validItems
+}
+
 async function fetchAndStore<RawItem>(
   media: ArticleMedia,
   config: FeedConfig<RawItem>,
   env: FetchEnv,
+  logger: Logger,
 ): Promise<Result<number, Error>> {
   const itemsResult = await fetchRssFeed<RawItem>(config.url)
   if (itemsResult.isErr()) return err(itemsResult.error)
 
-  return storeArticles(media, itemsResult.value.map(config.mapItem), env)
+  const validItems = selectValidItems(media, itemsResult.value.map(config.mapItem), logger)
+  return storeArticles(media, validItems, env)
 }
 
-export function fetchQiitaArticles(env: FetchEnv): Promise<Result<number, Error>> {
-  return fetchAndStore('qiita', FEED_CONFIGS.qiita, env)
+export function fetchQiitaArticles(env: FetchEnv, logger: Logger): Promise<Result<number, Error>> {
+  return fetchAndStore('qiita', FEED_CONFIGS.qiita, env, logger)
 }
 
-export function fetchZennArticles(env: FetchEnv): Promise<Result<number, Error>> {
-  return fetchAndStore('zenn', FEED_CONFIGS.zenn, env)
+export function fetchZennArticles(env: FetchEnv, logger: Logger): Promise<Result<number, Error>> {
+  return fetchAndStore('zenn', FEED_CONFIGS.zenn, env, logger)
 }
 
-export function fetchHatenaArticles(env: FetchEnv): Promise<Result<number, Error>> {
-  return fetchAndStore('hatena', FEED_CONFIGS.hatena, env)
+export function fetchHatenaArticles(env: FetchEnv, logger: Logger): Promise<Result<number, Error>> {
+  return fetchAndStore('hatena', FEED_CONFIGS.hatena, env, logger)
 }
 
-const FETCHERS: Record<ArticleMedia, (env: FetchEnv) => Promise<Result<number, Error>>> = {
+const FETCHERS: Record<
+  ArticleMedia,
+  (env: FetchEnv, logger: Logger) => Promise<Result<number, Error>>
+> = {
   qiita: fetchQiitaArticles,
   zenn: fetchZennArticles,
   hatena: fetchHatenaArticles,
@@ -143,6 +193,7 @@ const FETCHERS: Record<ArticleMedia, (env: FetchEnv) => Promise<Result<number, E
 export function runScheduledFetch(
   media: ArticleMedia,
   env: FetchEnv,
+  logger: Logger,
 ): Promise<Result<number, Error>> {
-  return FETCHERS[media](env)
+  return FETCHERS[media](env, logger)
 }

--- a/application/packages/cron/src/test-helper/feed.ts
+++ b/application/packages/cron/src/test-helper/feed.ts
@@ -3,8 +3,8 @@ import { FEED_URL } from '../feed-config'
 export { FEED_URL }
 
 export interface FeedItem {
-  title: string
-  url: string
+  title?: string
+  url?: string
   author?: string
   content?: string
   contentEncoded?: string
@@ -15,8 +15,8 @@ export function buildQiitaAtom(items: FeedItem[]): string {
     .map((item) =>
       [
         '  <entry>',
-        `    <title>${item.title}</title>`,
-        `    <link href="${item.url}"/>`,
+        item.title === undefined ? '' : `    <title>${item.title}</title>`,
+        item.url === undefined ? '' : `    <link href="${item.url}"/>`,
         item.author === undefined ? '' : `    <author><name>${item.author}</name></author>`,
         item.content === undefined ? '' : `    <content type="html">${item.content}</content>`,
         '  </entry>',
@@ -36,8 +36,8 @@ export function buildZennRss(items: FeedItem[]): string {
     .map((item) =>
       [
         '    <item>',
-        `      <title>${item.title}</title>`,
-        `      <link>${item.url}</link>`,
+        item.title === undefined ? '' : `      <title>${item.title}</title>`,
+        item.url === undefined ? '' : `      <link>${item.url}</link>`,
         item.content === undefined ? '' : `      <description>${item.content}</description>`,
         item.author === undefined ? '' : `      <dc:creator>${item.author}</dc:creator>`,
         '    </item>',

--- a/application/pnpm-lock.yaml
+++ b/application/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       rss-parser:
         specifier: ^3.13.0
         version: 3.13.0
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: 'catalog:'


### PR DESCRIPTION
## 概要

closes #738

qiita/zenn の `mapItem` は `title` / `author`(`creator`) / `link` を TypeScript の型宣言のみで必須扱いしており、実行時の検証がありませんでした。rss-parser は欠落フィールドを `undefined` で返すため、`title` 等が欠けた記事が1件でも含まれると `truncateByCodePoint(undefined)` の `[...text]` が TypeError を投げ、**そのメディアの取込全体が失敗**していました。

hatena のみ `extractTrimmed(...) ?? フォールバック` で防御されており、qiita/zenn が無防備な非対称構造でした。

## 変更内容

- `feed-config.ts`: `NormalizedItem` を実行時検証する `normalizedItemSchema`(Zod)を追加
  - `title` / `author` / `url` は欠落・空文字なら不正としてスキップ対象
  - `description` は欠落しても致命的でないため空文字で補完
- `fetch-articles.ts`: `selectValidItems` を追加し、保存前に各 item を検証。不正 item は警告ログを残してスキップし、1件の異常でメディア全体を止めず**部分成功**にする
  - `url` が `undefined`/空文字の item も DB の NOT NULL 制約に到達する前にスキップ
  - 不正 item 個別の issue ログと、メディア単位のスキップ件数ログを構造化ログで出力
- 検証に必要な logger を `runScheduledFetch` 経由で各 fetcher へ受け渡し

## テスト

- qiita/zenn の準正常系として「title/author/url 欠落でスキップ」「部分成功」「スキップ件数の警告ログ出力」をケース化
- qiita の「content 欠損時は description を空文字で補完」を追加
- `pnpm --filter @trend-diary/cron test` / `typecheck` / `biome ci` すべて green

## 関連

- #726（タイムアウト・リトライ）

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hbs7EYPRG4uCzVo1K27yVt)_