### PR TITLE
refactor(web): 認証状態の取得をuseEffectからloaderへ移行

### DIFF
--- a/application/packages/web/src/client/routes/app-layout.test.ts
+++ b/application/packages/web/src/client/routes/app-layout.test.ts
@@ -1,0 +1,54 @@
+import { err, ok } from 'neverthrow'
+import type { LoaderFunctionArgs } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAuthActionUseCase } from '@/client/features/authenticate/auth-action-use-case'
+import { loader } from './app-layout'
+
+const { getCurrentActiveUser } = vi.hoisted(() => ({ getCurrentActiveUser: vi.fn() }))
+
+vi.mock('@/client/features/authenticate/auth-action-use-case', () => ({
+  createAuthActionUseCase: vi.fn(() => ({ useCase: { getCurrentActiveUser } })),
+}))
+
+function buildLoaderArgs(): LoaderFunctionArgs {
+  const request = new Request('http://localhost/trends')
+  return {
+    request,
+    context: {} as LoaderFunctionArgs['context'],
+    params: {},
+    url: new URL(request.url),
+    pattern: '/trends',
+  } as LoaderFunctionArgs
+}
+
+describe('app-layout loader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('認証済みユーザーが取得できた場合はisLoggedInがtrueになる', async () => {
+    getCurrentActiveUser.mockResolvedValue(ok({ userId: 'user-1', displayName: 'テスト' }))
+
+    const result = await loader(buildLoaderArgs())
+
+    expect(result).toEqual({ isLoggedIn: true })
+  })
+
+  it('認証情報の取得に失敗した場合はisLoggedInがfalseになる', async () => {
+    getCurrentActiveUser.mockResolvedValue(err(new Error('unauthorized')))
+
+    const result = await loader(buildLoaderArgs())
+
+    expect(result).toEqual({ isLoggedIn: false })
+  })
+
+  it('UseCase生成時に例外が発生した場合はisLoggedInがfalseにフォールバックする', async () => {
+    vi.mocked(createAuthActionUseCase).mockImplementationOnce(() => {
+      throw new Error('Supabase auth is not configured.')
+    })
+
+    const result = await loader(buildLoaderArgs())
+
+    expect(result).toEqual({ isLoggedIn: false })
+  })
+})

--- a/application/packages/web/src/client/routes/app-layout.test.ts
+++ b/application/packages/web/src/client/routes/app-layout.test.ts
@@ -7,7 +7,10 @@ import { loader } from './app-layout'
 const { getCurrentActiveUser } = vi.hoisted(() => ({ getCurrentActiveUser: vi.fn() }))
 
 vi.mock('@/client/features/authenticate/auth-action-use-case', () => ({
-  createAuthActionUseCase: vi.fn(() => ({ useCase: { getCurrentActiveUser } })),
+  createAuthActionUseCase: vi.fn(() => ({
+    useCase: { getCurrentActiveUser },
+    headers: new Headers(),
+  })),
 }))
 
 function buildLoaderArgs(): LoaderFunctionArgs {
@@ -31,7 +34,21 @@ describe('app-layout loader', () => {
 
     const result = await loader(buildLoaderArgs())
 
-    expect(result).toEqual({ isLoggedIn: true })
+    expect(result.data).toEqual({ isLoggedIn: true })
+  })
+
+  it('セッション更新で付与されたSet-Cookieヘッダーがレスポンスに転送される', async () => {
+    getCurrentActiveUser.mockResolvedValue(ok({ userId: 'user-1', displayName: 'テスト' }))
+    const headers = new Headers()
+    headers.append('Set-Cookie', 'sb-access-token=refreshed; Path=/')
+    vi.mocked(createAuthActionUseCase).mockReturnValueOnce({
+      useCase: { getCurrentActiveUser },
+      headers,
+    } as unknown as ReturnType<typeof createAuthActionUseCase>)
+
+    const result = await loader(buildLoaderArgs())
+
+    expect(result.init?.headers).toBe(headers)
   })
 
   it('認証情報の取得に失敗した場合はisLoggedInがfalseになる', async () => {
@@ -39,7 +56,7 @@ describe('app-layout loader', () => {
 
     const result = await loader(buildLoaderArgs())
 
-    expect(result).toEqual({ isLoggedIn: false })
+    expect(result.data).toEqual({ isLoggedIn: false })
   })
 
   it('UseCase生成時に例外が発生した場合はisLoggedInがfalseにフォールバックする', async () => {
@@ -49,6 +66,6 @@ describe('app-layout loader', () => {
 
     const result = await loader(buildLoaderArgs())
 
-    expect(result).toEqual({ isLoggedIn: false })
+    expect(result.data).toEqual({ isLoggedIn: false })
   })
 })

--- a/application/packages/web/src/client/routes/app-layout.test.ts
+++ b/application/packages/web/src/client/routes/app-layout.test.ts
@@ -4,24 +4,26 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createAuthActionUseCase } from '@/client/features/authenticate/auth-action-use-case'
 import { loader } from './app-layout'
 
-const { getCurrentActiveUser } = vi.hoisted(() => ({ getCurrentActiveUser: vi.fn() }))
+const { getCurrentActiveUser, headers } = vi.hoisted(() => {
+  const headers = new Headers()
+  // Supabaseのセッション更新で付与される Set-Cookie を模す
+  headers.append('Set-Cookie', 'sb-access-token=refreshed; Path=/')
+  return { getCurrentActiveUser: vi.fn(), headers }
+})
 
 vi.mock('@/client/features/authenticate/auth-action-use-case', () => ({
-  createAuthActionUseCase: vi.fn(() => ({
-    useCase: { getCurrentActiveUser },
-    headers: new Headers(),
-  })),
+  createAuthActionUseCase: vi.fn(() => ({ useCase: { getCurrentActiveUser }, headers })),
 }))
 
 function buildLoaderArgs(): LoaderFunctionArgs {
   const request = new Request('http://localhost/trends')
   return {
     request,
-    context: {} as LoaderFunctionArgs['context'],
-    params: {},
     url: new URL(request.url),
     pattern: '/trends',
-  } as LoaderFunctionArgs
+    params: {},
+    context: {},
+  }
 }
 
 describe('app-layout loader', () => {
@@ -39,12 +41,6 @@ describe('app-layout loader', () => {
 
   it('セッション更新で付与されたSet-Cookieヘッダーがレスポンスに転送される', async () => {
     getCurrentActiveUser.mockResolvedValue(ok({ userId: 'user-1', displayName: 'テスト' }))
-    const headers = new Headers()
-    headers.append('Set-Cookie', 'sb-access-token=refreshed; Path=/')
-    vi.mocked(createAuthActionUseCase).mockReturnValueOnce({
-      useCase: { getCurrentActiveUser },
-      headers,
-    } as unknown as ReturnType<typeof createAuthActionUseCase>)
 
     const result = await loader(buildLoaderArgs())
 

--- a/application/packages/web/src/client/routes/app-layout.tsx
+++ b/application/packages/web/src/client/routes/app-layout.tsx
@@ -1,38 +1,31 @@
-import { useEffect, useState } from 'react'
-import { Outlet } from 'react-router'
+import Logger from '@trend-diary/common/logger'
+import type { LoaderFunctionArgs } from 'react-router'
+import { Outlet, useLoaderData } from 'react-router'
+import { createAuthActionUseCase } from '@/client/features/authenticate/auth-action-use-case'
 import { SidebarProvider } from '../components/shadcn/sidebar'
 import AppHeader from '../components/ui/layout/app-header'
 import AppSidebar from '../components/ui/layout/sidebar'
-import getApiClientForClient from '../infrastructure/api'
 
 export interface AppLayoutOutletContext {
   isLoggedIn: boolean
 }
 
+const logger = new Logger('info', { route: 'web/client/routes/app-layout/loader' })
+
+export async function loader({ request, context }: LoaderFunctionArgs) {
+  try {
+    const { useCase } = createAuthActionUseCase(request, context)
+    const result = await useCase.getCurrentActiveUser()
+    return { isLoggedIn: result.isOk() }
+  } catch (error) {
+    // 認証設定不備などで loader が 500 になると配下の全画面が落ちるため、未ログイン扱いにフォールバックする
+    logger.error('Unexpected error in app-layout loader', error)
+    return { isLoggedIn: false }
+  }
+}
+
 export default function AppLayout() {
-  const [isLoggedIn, setIsLoggedIn] = useState(false)
-
-  useEffect(() => {
-    let isCancelled = false
-    const client = getApiClientForClient()
-
-    const fetchAuthState = async () => {
-      const res = await client.auth.me.$get({}, { init: { credentials: 'include' } })
-      if (!isCancelled) {
-        setIsLoggedIn(res.status === 200)
-      }
-    }
-
-    fetchAuthState().catch(() => {
-      if (!isCancelled) {
-        setIsLoggedIn(false)
-      }
-    })
-
-    return () => {
-      isCancelled = true
-    }
-  }, [])
+  const { isLoggedIn } = useLoaderData<typeof loader>()
 
   const outletContext: AppLayoutOutletContext = {
     isLoggedIn,

--- a/application/packages/web/src/client/routes/app-layout.tsx
+++ b/application/packages/web/src/client/routes/app-layout.tsx
@@ -1,6 +1,6 @@
 import Logger from '@trend-diary/common/logger'
 import type { LoaderFunctionArgs } from 'react-router'
-import { Outlet, useLoaderData } from 'react-router'
+import { data, Outlet, useLoaderData } from 'react-router'
 import { createAuthActionUseCase } from '@/client/features/authenticate/auth-action-use-case'
 import { SidebarProvider } from '../components/shadcn/sidebar'
 import AppHeader from '../components/ui/layout/app-header'
@@ -14,13 +14,14 @@ const logger = new Logger('info', { route: 'web/client/routes/app-layout/loader'
 
 export async function loader({ request, context }: LoaderFunctionArgs) {
   try {
-    const { useCase } = createAuthActionUseCase(request, context)
+    const { useCase, headers } = createAuthActionUseCase(request, context)
     const result = await useCase.getCurrentActiveUser()
-    return { isLoggedIn: result.isOk() }
+    // Supabaseのセッション更新で付与される Set-Cookie を転送しないと、トークン期限切れ時にログアウトされてしまう
+    return data({ isLoggedIn: result.isOk() }, { headers })
   } catch (error) {
     // 認証設定不備などで loader が 500 になると配下の全画面が落ちるため、未ログイン扱いにフォールバックする
     logger.error('Unexpected error in app-layout loader', error)
-    return { isLoggedIn: false }
+    return data({ isLoggedIn: false })
   }
 }
 


### PR DESCRIPTION
## 概要

Closes #732

`app-layout.tsx` で `useEffect` により認証状態を取得していたため、SSR時には認証情報が存在せず、クライアント側で非同期に確定していました。これにより hydration ミスマッチや初回描画のちらつき（未ログイン表示→ログイン済み表示）が発生するリスクがありました。

React Router の `loader` でSSR時に認証チェックを行い、初回レンダリングから正しい認証状態を反映するように変更します。

## 変更内容

- `app-layout.tsx` に `loader` を追加し、`createAuthActionUseCase` 経由で `getCurrentActiveUser()` を呼び出して認証状態を判定
- コンポーネントは `useState` + `useEffect` をやめ、`useLoaderData` から `isLoggedIn` を取得
- 配下ルートへ渡す `useOutletContext`（`AppLayoutOutletContext`）のインターフェースは変更なし。consumer 側（trends / inbox / diary / analytics）の修正は不要
- 認証設定不備などで loader が 500 になると配下の全画面が落ちるため、例外時は未ログイン扱いにフォールバック

## テスト

`app-layout.test.ts` を追加し、loader の挙動を検証:

- 認証済みユーザーが取得できた場合は `isLoggedIn: true`
- 認証情報の取得に失敗した場合は `isLoggedIn: false`
- UseCase 生成時に例外が発生した場合は `isLoggedIn: false` にフォールバック

## 備考

`react-router.config.ts` の `v8_middleware: false`（`hono-react-router-adapter` の middleware 未対応に起因）は本変更では維持しています。loader は通常の data loader として動作するため、middleware 有効化を待たずに移行可能です。

## 確認コマンド

- `pnpm check`（biome）: pass
- `pnpm --filter @trend-diary/web typecheck`: pass
- `pnpm --filter @trend-diary/web test src/client/routes/app-layout.test.ts`: pass (3 passed)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CZaZvfdA7qk4NVhs5avk5d)_