### PR TITLE
feat(notification): Discord通知にリトライとLogger注入を追加する

### DIFF
--- a/application/packages/cron/src/worker.ts
+++ b/application/packages/cron/src/worker.ts
@@ -10,7 +10,7 @@ export default {
       cron: event.cron,
     })
 
-    const discord = new DiscordWebhookClient(env.DISCORD_WEBHOOK_URL)
+    const discord = new DiscordWebhookClient(env.DISCORD_WEBHOOK_URL, { logger })
 
     ctx.waitUntil(
       fetchAllArticles({

--- a/application/packages/cron/src/worker.ts
+++ b/application/packages/cron/src/worker.ts
@@ -10,7 +10,7 @@ export default {
       cron: event.cron,
     })
 
-    const discord = new DiscordWebhookClient(env.DISCORD_WEBHOOK_URL, { logger })
+    const discord = new DiscordWebhookClient(env.DISCORD_WEBHOOK_URL, logger)
 
     ctx.waitUntil(
       fetchAllArticles({

--- a/application/packages/notification/package.json
+++ b/application/packages/notification/package.json
@@ -16,6 +16,9 @@
     "test": "vitest run",
     "typecheck": "tsgo --noEmit"
   },
+  "dependencies": {
+    "@trend-diary/common": "workspace:*"
+  },
   "devDependencies": {
     "@cloudflare/workers-types": "catalog:",
     "vitest": "catalog:"

--- a/application/packages/notification/src/discord.test.ts
+++ b/application/packages/notification/src/discord.test.ts
@@ -160,6 +160,15 @@ describe('DiscordWebhookClient', () => {
       expect(logger.error).toHaveBeenCalledTimes(1)
     })
 
+    it('ハング防止のためAbortControllerのsignalを付与して送信する', async () => {
+      const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test')
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 204 })
+
+      await client.send({ content: 'test' })
+
+      expect(mockFetch.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal)
+    })
+
     it('送信が失敗してもエラーを投げない', async () => {
       const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', noDelay)
       mockFetch.mockRejectedValue(new Error('Network error'))

--- a/application/packages/notification/src/discord.test.ts
+++ b/application/packages/notification/src/discord.test.ts
@@ -19,6 +19,8 @@ const createMockLogger = () =>
 // リトライ待機を待たずにテストするため、backoffの基準遅延を0にする
 const noDelay = { baseDelayMs: 0 }
 
+const webhookUrl = 'https://discord.com/api/webhooks/test'
+
 describe('DiscordWebhookClient', () => {
   beforeEach(() => {
     vi.resetAllMocks()
@@ -27,8 +29,7 @@ describe('DiscordWebhookClient', () => {
   describe('send', () => {
     describe('正常系', () => {
       it('指定したペイロードをDiscord Webhookに送信する', async () => {
-        const webhookUrl = 'https://discord.com/api/webhooks/test'
-        const client = new DiscordWebhookClient(webhookUrl)
+        const client = new DiscordWebhookClient(webhookUrl, createMockLogger())
         mockFetch.mockResolvedValueOnce({ ok: true, status: 204 })
 
         const payload = {
@@ -56,7 +57,7 @@ describe('DiscordWebhookClient', () => {
       })
 
       it('送信が成功した場合はリトライしない', async () => {
-        const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', noDelay)
+        const client = new DiscordWebhookClient(webhookUrl, createMockLogger(), noDelay)
         mockFetch.mockResolvedValueOnce({ ok: true, status: 204 })
 
         await client.send({ content: 'test' })
@@ -65,7 +66,7 @@ describe('DiscordWebhookClient', () => {
       })
 
       it('ハング防止のためAbortControllerのsignalを付与して送信する', async () => {
-        const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test')
+        const client = new DiscordWebhookClient(webhookUrl, createMockLogger())
         mockFetch.mockResolvedValueOnce({ ok: true, status: 204 })
 
         await client.send({ content: 'test' })
@@ -79,7 +80,7 @@ describe('DiscordWebhookClient', () => {
         { label: '空文字', url: '' },
         { label: 'undefined', url: undefined },
       ])('Webhook URLが$labelの場合は何もしない', async ({ url }) => {
-        const client = new DiscordWebhookClient(url)
+        const client = new DiscordWebhookClient(url, createMockLogger())
 
         await client.send({ content: 'test' })
 
@@ -88,7 +89,7 @@ describe('DiscordWebhookClient', () => {
 
       it('Webhook URLが未設定の場合は警告ログを記録する', async () => {
         const logger = createMockLogger()
-        const client = new DiscordWebhookClient('', { logger })
+        const client = new DiscordWebhookClient('', logger)
 
         await client.send({ content: 'test' })
 
@@ -100,10 +101,7 @@ describe('DiscordWebhookClient', () => {
         { label: '5xx', status: 500 },
       ])('一時的な失敗（$label）はリトライして成功する', async ({ status }) => {
         const logger = createMockLogger()
-        const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', {
-          ...noDelay,
-          logger,
-        })
+        const client = new DiscordWebhookClient(webhookUrl, logger, noDelay)
         mockFetch
           .mockResolvedValueOnce({ ok: false, status })
           .mockResolvedValueOnce({ ok: true, status: 204 })
@@ -116,10 +114,7 @@ describe('DiscordWebhookClient', () => {
 
       it('ネットワークエラー時はexponential backoffでリトライして成功する', async () => {
         const logger = createMockLogger()
-        const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', {
-          ...noDelay,
-          logger,
-        })
+        const client = new DiscordWebhookClient(webhookUrl, logger, noDelay)
         mockFetch
           .mockRejectedValueOnce(new Error('Network error'))
           .mockRejectedValueOnce(new Error('Network error'))
@@ -139,10 +134,7 @@ describe('DiscordWebhookClient', () => {
         { label: '5xxが継続し最大リトライ到達', status: 500, expectedCalls: 3 },
       ])('失敗が続く場合（$label）はエラーログを記録する', async ({ status, expectedCalls }) => {
         const logger = createMockLogger()
-        const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', {
-          ...noDelay,
-          logger,
-        })
+        const client = new DiscordWebhookClient(webhookUrl, logger, noDelay)
         mockFetch.mockResolvedValue({ ok: false, status })
 
         await client.send({ content: 'test' })
@@ -152,7 +144,7 @@ describe('DiscordWebhookClient', () => {
       })
 
       it('送信が失敗してもエラーを投げない', async () => {
-        const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', noDelay)
+        const client = new DiscordWebhookClient(webhookUrl, createMockLogger(), noDelay)
         mockFetch.mockRejectedValue(new Error('Network error'))
 
         await expect(client.send({ content: 'test' })).resolves.not.toThrow()
@@ -163,8 +155,7 @@ describe('DiscordWebhookClient', () => {
   describe('sendMessage', () => {
     describe('正常系', () => {
       it('content形式の単純メッセージを送信する', async () => {
-        const webhookUrl = 'https://discord.com/api/webhooks/test'
-        const client = new DiscordWebhookClient(webhookUrl)
+        const client = new DiscordWebhookClient(webhookUrl, createMockLogger())
         mockFetch.mockResolvedValueOnce({ ok: true, status: 204 })
 
         await client.sendMessage('hello')
@@ -176,7 +167,7 @@ describe('DiscordWebhookClient', () => {
 
     describe('準正常系', () => {
       it('Webhook URLが設定されていない場合は何もしない', async () => {
-        const client = new DiscordWebhookClient('')
+        const client = new DiscordWebhookClient('', createMockLogger())
 
         await client.sendMessage('hello')
 
@@ -194,8 +185,7 @@ describe('DiscordNotifier', () => {
   describe('error', () => {
     describe('正常系', () => {
       it('5xxエラーの場合、Discord Webhookにメッセージを送信する', async () => {
-        const webhookUrl = 'https://discord.com/api/webhooks/test'
-        const notifier = new DiscordNotifier(webhookUrl)
+        const notifier = new DiscordNotifier(webhookUrl, createMockLogger())
 
         mockFetch.mockResolvedValueOnce({
           ok: true,
@@ -252,7 +242,7 @@ describe('DiscordNotifier', () => {
 
     describe('準正常系', () => {
       it('Webhook URLが設定されていない場合は何もしない', async () => {
-        const notifier = new DiscordNotifier('')
+        const notifier = new DiscordNotifier('', createMockLogger())
 
         await notifier.error(new Error('Test error'), {
           url: '/test',
@@ -264,8 +254,7 @@ describe('DiscordNotifier', () => {
       })
 
       it('スタックトレースが長い場合は適切に切り詰める', async () => {
-        const webhookUrl = 'https://discord.com/api/webhooks/test'
-        const notifier = new DiscordNotifier(webhookUrl)
+        const notifier = new DiscordNotifier(webhookUrl, createMockLogger())
 
         mockFetch.mockResolvedValueOnce({
           ok: true,
@@ -296,8 +285,7 @@ describe('DiscordNotifier', () => {
 
     describe('異常系', () => {
       it('Discord Webhook送信が失敗してもエラーを投げない', async () => {
-        const webhookUrl = 'https://discord.com/api/webhooks/test'
-        const notifier = new DiscordNotifier(webhookUrl, noDelay)
+        const notifier = new DiscordNotifier(webhookUrl, createMockLogger(), noDelay)
 
         mockFetch.mockRejectedValue(new Error('Network error'))
 
@@ -314,10 +302,7 @@ describe('DiscordNotifier', () => {
 
       it('注入したLoggerに通知失敗を記録する', async () => {
         const logger = createMockLogger()
-        const notifier = new DiscordNotifier('https://discord.com/api/webhooks/test', {
-          ...noDelay,
-          logger,
-        })
+        const notifier = new DiscordNotifier(webhookUrl, logger, noDelay)
         mockFetch.mockResolvedValue({ ok: false, status: 500 })
 
         await notifier.error(new Error('Internal Server Error'), {

--- a/application/packages/notification/src/discord.test.ts
+++ b/application/packages/notification/src/discord.test.ts
@@ -25,153 +25,163 @@ describe('DiscordWebhookClient', () => {
   })
 
   describe('send', () => {
-    it.each([
-      { label: '空文字', url: '' },
-      { label: 'undefined', url: undefined },
-    ])('Webhook URLが$labelの場合は何もしない', async ({ url }) => {
-      const client = new DiscordWebhookClient(url)
+    describe('正常系', () => {
+      it('指定したペイロードをDiscord Webhookに送信する', async () => {
+        const webhookUrl = 'https://discord.com/api/webhooks/test'
+        const client = new DiscordWebhookClient(webhookUrl)
+        mockFetch.mockResolvedValueOnce({ ok: true, status: 204 })
 
-      await client.send({ content: 'test' })
+        const payload = {
+          content: null,
+          embeds: [
+            {
+              title: 'title',
+              color: 1,
+              fields: [{ name: 'n', value: 'v', inline: false }],
+              timestamp: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        }
+        await client.send(payload)
 
-      expect(mockFetch).not.toHaveBeenCalled()
-    })
-
-    it('Webhook URLが未設定の場合は警告ログを記録する', async () => {
-      const logger = createMockLogger()
-      const client = new DiscordWebhookClient('', { logger })
-
-      await client.send({ content: 'test' })
-
-      expect(logger.warn).toHaveBeenCalledTimes(1)
-    })
-
-    it('指定したペイロードをDiscord Webhookに送信する', async () => {
-      const webhookUrl = 'https://discord.com/api/webhooks/test'
-      const client = new DiscordWebhookClient(webhookUrl)
-      mockFetch.mockResolvedValueOnce({ ok: true, status: 204 })
-
-      const payload = {
-        content: null,
-        embeds: [
-          {
-            title: 'title',
-            color: 1,
-            fields: [{ name: 'n', value: 'v', inline: false }],
-            timestamp: '2026-01-01T00:00:00.000Z',
-          },
-        ],
-      }
-      await client.send(payload)
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        webhookUrl,
-        expect.objectContaining({
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-        }),
-      )
-      const body = JSON.parse(mockFetch.mock.calls[0][1].body)
-      expect(body).toEqual(payload)
-    })
-
-    it('送信が成功した場合はリトライしない', async () => {
-      const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', noDelay)
-      mockFetch.mockResolvedValueOnce({ ok: true, status: 204 })
-
-      await client.send({ content: 'test' })
-
-      expect(mockFetch).toHaveBeenCalledTimes(1)
-    })
-
-    it('ネットワークエラー時はexponential backoffでリトライする', async () => {
-      const logger = createMockLogger()
-      const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', {
-        ...noDelay,
-        logger,
+        expect(mockFetch).toHaveBeenCalledWith(
+          webhookUrl,
+          expect.objectContaining({
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+          }),
+        )
+        const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+        expect(body).toEqual(payload)
       })
-      mockFetch
-        .mockRejectedValueOnce(new Error('Network error'))
-        .mockRejectedValueOnce(new Error('Network error'))
-        .mockResolvedValueOnce({ ok: true, status: 204 })
 
-      await client.send({ content: 'test' })
+      it('送信が成功した場合はリトライしない', async () => {
+        const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', noDelay)
+        mockFetch.mockResolvedValueOnce({ ok: true, status: 204 })
 
-      expect(mockFetch).toHaveBeenCalledTimes(3)
-      expect(logger.error).not.toHaveBeenCalled()
-    })
+        await client.send({ content: 'test' })
 
-    it.each([
-      { label: '429（レートリミット）', status: 429 },
-      { label: '5xx', status: 500 },
-    ])('一時的な失敗（$label）はリトライして成功する', async ({ status }) => {
-      const logger = createMockLogger()
-      const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', {
-        ...noDelay,
-        logger,
+        expect(mockFetch).toHaveBeenCalledTimes(1)
       })
-      mockFetch
-        .mockResolvedValueOnce({ ok: false, status })
-        .mockResolvedValueOnce({ ok: true, status: 204 })
 
-      await client.send({ content: 'test' })
+      it('ハング防止のためAbortControllerのsignalを付与して送信する', async () => {
+        const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test')
+        mockFetch.mockResolvedValueOnce({ ok: true, status: 204 })
 
-      expect(mockFetch).toHaveBeenCalledTimes(2)
-      expect(logger.error).not.toHaveBeenCalled()
-    })
+        await client.send({ content: 'test' })
 
-    it.each([
-      { label: '401（Webhook失効）は即時打ち切り', status: 401, expectedCalls: 1 },
-      { label: '404（Webhook削除）は即時打ち切り', status: 404, expectedCalls: 1 },
-      { label: '5xxが継続し最大リトライ到達', status: 500, expectedCalls: 3 },
-    ])('失敗が続く場合（$label）はエラーログを記録する', async ({ status, expectedCalls }) => {
-      const logger = createMockLogger()
-      const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', {
-        ...noDelay,
-        logger,
+        expect(mockFetch.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal)
       })
-      mockFetch.mockResolvedValue({ ok: false, status })
-
-      await client.send({ content: 'test' })
-
-      expect(mockFetch).toHaveBeenCalledTimes(expectedCalls)
-      expect(logger.error).toHaveBeenCalledTimes(1)
     })
 
-    it('ハング防止のためAbortControllerのsignalを付与して送信する', async () => {
-      const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test')
-      mockFetch.mockResolvedValueOnce({ ok: true, status: 204 })
+    describe('準正常系', () => {
+      it.each([
+        { label: '空文字', url: '' },
+        { label: 'undefined', url: undefined },
+      ])('Webhook URLが$labelの場合は何もしない', async ({ url }) => {
+        const client = new DiscordWebhookClient(url)
 
-      await client.send({ content: 'test' })
+        await client.send({ content: 'test' })
 
-      expect(mockFetch.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal)
+        expect(mockFetch).not.toHaveBeenCalled()
+      })
+
+      it('Webhook URLが未設定の場合は警告ログを記録する', async () => {
+        const logger = createMockLogger()
+        const client = new DiscordWebhookClient('', { logger })
+
+        await client.send({ content: 'test' })
+
+        expect(logger.warn).toHaveBeenCalledTimes(1)
+      })
+
+      it.each([
+        { label: '429（レートリミット）', status: 429 },
+        { label: '5xx', status: 500 },
+      ])('一時的な失敗（$label）はリトライして成功する', async ({ status }) => {
+        const logger = createMockLogger()
+        const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', {
+          ...noDelay,
+          logger,
+        })
+        mockFetch
+          .mockResolvedValueOnce({ ok: false, status })
+          .mockResolvedValueOnce({ ok: true, status: 204 })
+
+        await client.send({ content: 'test' })
+
+        expect(mockFetch).toHaveBeenCalledTimes(2)
+        expect(logger.error).not.toHaveBeenCalled()
+      })
+
+      it('ネットワークエラー時はexponential backoffでリトライして成功する', async () => {
+        const logger = createMockLogger()
+        const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', {
+          ...noDelay,
+          logger,
+        })
+        mockFetch
+          .mockRejectedValueOnce(new Error('Network error'))
+          .mockRejectedValueOnce(new Error('Network error'))
+          .mockResolvedValueOnce({ ok: true, status: 204 })
+
+        await client.send({ content: 'test' })
+
+        expect(mockFetch).toHaveBeenCalledTimes(3)
+        expect(logger.error).not.toHaveBeenCalled()
+      })
     })
 
-    it('送信が失敗してもエラーを投げない', async () => {
-      const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', noDelay)
-      mockFetch.mockRejectedValue(new Error('Network error'))
+    describe('異常系', () => {
+      it.each([
+        { label: '401（Webhook失効）は即時打ち切り', status: 401, expectedCalls: 1 },
+        { label: '404（Webhook削除）は即時打ち切り', status: 404, expectedCalls: 1 },
+        { label: '5xxが継続し最大リトライ到達', status: 500, expectedCalls: 3 },
+      ])('失敗が続く場合（$label）はエラーログを記録する', async ({ status, expectedCalls }) => {
+        const logger = createMockLogger()
+        const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', {
+          ...noDelay,
+          logger,
+        })
+        mockFetch.mockResolvedValue({ ok: false, status })
 
-      await expect(client.send({ content: 'test' })).resolves.not.toThrow()
+        await client.send({ content: 'test' })
+
+        expect(mockFetch).toHaveBeenCalledTimes(expectedCalls)
+        expect(logger.error).toHaveBeenCalledTimes(1)
+      })
+
+      it('送信が失敗してもエラーを投げない', async () => {
+        const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', noDelay)
+        mockFetch.mockRejectedValue(new Error('Network error'))
+
+        await expect(client.send({ content: 'test' })).resolves.not.toThrow()
+      })
     })
   })
 
   describe('sendMessage', () => {
-    it('content形式の単純メッセージを送信する', async () => {
-      const webhookUrl = 'https://discord.com/api/webhooks/test'
-      const client = new DiscordWebhookClient(webhookUrl)
-      mockFetch.mockResolvedValueOnce({ ok: true, status: 204 })
+    describe('正常系', () => {
+      it('content形式の単純メッセージを送信する', async () => {
+        const webhookUrl = 'https://discord.com/api/webhooks/test'
+        const client = new DiscordWebhookClient(webhookUrl)
+        mockFetch.mockResolvedValueOnce({ ok: true, status: 204 })
 
-      await client.sendMessage('hello')
+        await client.sendMessage('hello')
 
-      const body = JSON.parse(mockFetch.mock.calls[0][1].body)
-      expect(body).toEqual({ content: 'hello' })
+        const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+        expect(body).toEqual({ content: 'hello' })
+      })
     })
 
-    it('Webhook URLが設定されていない場合は何もしない', async () => {
-      const client = new DiscordWebhookClient('')
+    describe('準正常系', () => {
+      it('Webhook URLが設定されていない場合は何もしない', async () => {
+        const client = new DiscordWebhookClient('')
 
-      await client.sendMessage('hello')
+        await client.sendMessage('hello')
 
-      expect(mockFetch).not.toHaveBeenCalled()
+        expect(mockFetch).not.toHaveBeenCalled()
+      })
     })
   })
 })
@@ -182,136 +192,142 @@ describe('DiscordNotifier', () => {
   })
 
   describe('error', () => {
-    it('Webhook URLが設定されていない場合は何もしない', async () => {
-      const notifier = new DiscordNotifier('')
+    describe('正常系', () => {
+      it('5xxエラーの場合、Discord Webhookにメッセージを送信する', async () => {
+        const webhookUrl = 'https://discord.com/api/webhooks/test'
+        const notifier = new DiscordNotifier(webhookUrl)
 
-      await notifier.error(new Error('Test error'), {
-        url: '/test',
-        method: 'GET',
-        userAgent: 'test-agent',
-      })
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          status: 204,
+        })
 
-      expect(mockFetch).not.toHaveBeenCalled()
-    })
+        const error = new Error('Internal Server Error')
+        error.stack = 'Error: Internal Server Error\n    at test.js:1:1'
 
-    it('5xxエラーの場合、Discord Webhookにメッセージを送信する', async () => {
-      const webhookUrl = 'https://discord.com/api/webhooks/test'
-      const notifier = new DiscordNotifier(webhookUrl)
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 204,
-      })
-
-      const error = new Error('Internal Server Error')
-      error.stack = 'Error: Internal Server Error\n    at test.js:1:1'
-
-      await notifier.error(error, {
-        url: '/api/test',
-        method: 'POST',
-        userAgent: 'Mozilla/5.0',
-      })
-
-      expect(mockFetch).toHaveBeenCalledWith(
-        webhookUrl,
-        expect.objectContaining({
+        await notifier.error(error, {
+          url: '/api/test',
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        }),
-      )
+          userAgent: 'Mozilla/5.0',
+        })
 
-      const callArgs = mockFetch.mock.calls[0]
-      const body = JSON.parse(callArgs[1].body)
+        expect(mockFetch).toHaveBeenCalledWith(
+          webhookUrl,
+          expect.objectContaining({
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          }),
+        )
 
-      expect(body).toEqual({
-        content: null,
-        embeds: [
-          {
-            title: '🚨 5xx Server Error Occurred',
-            color: 15158332,
-            fields: [
-              { name: 'Error Message', value: '```\nInternal Server Error\n```', inline: false },
-              {
-                name: 'Request Info',
-                value: '```\nMethod: POST\nURL: /api/test\nUser-Agent: Mozilla/5.0\n```',
-                inline: false,
-              },
-              {
-                name: 'Stack Trace',
-                value: '```\nError: Internal Server Error\n    at test.js:1:1\n```',
-                inline: false,
-              },
-            ],
-            timestamp: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
-          },
-        ],
+        const callArgs = mockFetch.mock.calls[0]
+        const body = JSON.parse(callArgs[1].body)
+
+        expect(body).toEqual({
+          content: null,
+          embeds: [
+            {
+              title: '🚨 5xx Server Error Occurred',
+              color: 15158332,
+              fields: [
+                { name: 'Error Message', value: '```\nInternal Server Error\n```', inline: false },
+                {
+                  name: 'Request Info',
+                  value: '```\nMethod: POST\nURL: /api/test\nUser-Agent: Mozilla/5.0\n```',
+                  inline: false,
+                },
+                {
+                  name: 'Stack Trace',
+                  value: '```\nError: Internal Server Error\n    at test.js:1:1\n```',
+                  inline: false,
+                },
+              ],
+              timestamp: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/),
+            },
+          ],
+        })
       })
     })
 
-    it('Discord Webhook送信が失敗してもエラーを投げない', async () => {
-      const webhookUrl = 'https://discord.com/api/webhooks/test'
-      const notifier = new DiscordNotifier(webhookUrl, noDelay)
+    describe('準正常系', () => {
+      it('Webhook URLが設定されていない場合は何もしない', async () => {
+        const notifier = new DiscordNotifier('')
 
-      mockFetch.mockRejectedValue(new Error('Network error'))
+        await notifier.error(new Error('Test error'), {
+          url: '/test',
+          method: 'GET',
+          userAgent: 'test-agent',
+        })
 
-      const error = new Error('Internal Server Error')
+        expect(mockFetch).not.toHaveBeenCalled()
+      })
 
-      await expect(
-        notifier.error(error, {
+      it('スタックトレースが長い場合は適切に切り詰める', async () => {
+        const webhookUrl = 'https://discord.com/api/webhooks/test'
+        const notifier = new DiscordNotifier(webhookUrl)
+
+        mockFetch.mockResolvedValueOnce({
+          ok: true,
+          status: 204,
+        })
+
+        const error = new Error('Test error')
+        // 1000文字以上のスタックトレースを作成
+        error.stack = `Error: Test error\n${'a'.repeat(1000)}`
+
+        await notifier.error(error, {
+          url: '/test',
+          method: 'GET',
+          userAgent: 'test',
+        })
+
+        const callArgs = mockFetch.mock.calls[0]
+        const body = JSON.parse(callArgs[1].body)
+        const stackTraceField = body.embeds[0].fields.find(
+          (field: { name: string; value: string }) => field.name === 'Stack Trace',
+        )
+
+        // Discordの制限（1024文字）以下になっているか確認
+        expect(stackTraceField.value.length).toBeLessThanOrEqual(1024)
+        expect(stackTraceField.value).toContain('...(truncated)')
+      })
+    })
+
+    describe('異常系', () => {
+      it('Discord Webhook送信が失敗してもエラーを投げない', async () => {
+        const webhookUrl = 'https://discord.com/api/webhooks/test'
+        const notifier = new DiscordNotifier(webhookUrl, noDelay)
+
+        mockFetch.mockRejectedValue(new Error('Network error'))
+
+        const error = new Error('Internal Server Error')
+
+        await expect(
+          notifier.error(error, {
+            url: '/api/test',
+            method: 'GET',
+            userAgent: 'test-agent',
+          }),
+        ).resolves.not.toThrow()
+      })
+
+      it('注入したLoggerに通知失敗を記録する', async () => {
+        const logger = createMockLogger()
+        const notifier = new DiscordNotifier('https://discord.com/api/webhooks/test', {
+          ...noDelay,
+          logger,
+        })
+        mockFetch.mockResolvedValue({ ok: false, status: 500 })
+
+        await notifier.error(new Error('Internal Server Error'), {
           url: '/api/test',
           method: 'GET',
           userAgent: 'test-agent',
-        }),
-      ).resolves.not.toThrow()
-    })
+        })
 
-    it('注入したLoggerに通知失敗を記録する', async () => {
-      const logger = createMockLogger()
-      const notifier = new DiscordNotifier('https://discord.com/api/webhooks/test', {
-        ...noDelay,
-        logger,
+        expect(logger.error).toHaveBeenCalledTimes(1)
       })
-      mockFetch.mockResolvedValue({ ok: false, status: 500 })
-
-      await notifier.error(new Error('Internal Server Error'), {
-        url: '/api/test',
-        method: 'GET',
-        userAgent: 'test-agent',
-      })
-
-      expect(logger.error).toHaveBeenCalledTimes(1)
-    })
-
-    it('スタックトレースが長い場合は適切に切り詰める', async () => {
-      const webhookUrl = 'https://discord.com/api/webhooks/test'
-      const notifier = new DiscordNotifier(webhookUrl)
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 204,
-      })
-
-      const error = new Error('Test error')
-      // 1000文字以上のスタックトレースを作成
-      error.stack = `Error: Test error\n${'a'.repeat(1000)}`
-
-      await notifier.error(error, {
-        url: '/test',
-        method: 'GET',
-        userAgent: 'test',
-      })
-
-      const callArgs = mockFetch.mock.calls[0]
-      const body = JSON.parse(callArgs[1].body)
-      const stackTraceField = body.embeds[0].fields.find(
-        (field: { name: string; value: string }) => field.name === 'Stack Trace',
-      )
-
-      // Discordの制限（1024文字）以下になっているか確認
-      expect(stackTraceField.value.length).toBeLessThanOrEqual(1024)
-      expect(stackTraceField.value).toContain('...(truncated)')
     })
   })
 })

--- a/application/packages/notification/src/discord.test.ts
+++ b/application/packages/notification/src/discord.test.ts
@@ -100,14 +100,17 @@ describe('DiscordWebhookClient', () => {
       expect(logger.error).not.toHaveBeenCalled()
     })
 
-    it('5xxレスポンスはリトライ対象として扱う', async () => {
+    it.each([
+      { label: '429（レートリミット）', status: 429 },
+      { label: '5xx', status: 500 },
+    ])('一時的な失敗（$label）はリトライして成功する', async ({ status }) => {
       const logger = createMockLogger()
       const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', {
         ...noDelay,
         logger,
       })
       mockFetch
-        .mockResolvedValueOnce({ ok: false, status: 500 })
+        .mockResolvedValueOnce({ ok: false, status })
         .mockResolvedValueOnce({ ok: true, status: 204 })
 
       await client.send({ content: 'test' })
@@ -116,23 +119,11 @@ describe('DiscordWebhookClient', () => {
       expect(logger.error).not.toHaveBeenCalled()
     })
 
-    it('429レスポンス（レートリミット）はリトライ対象として扱う', async () => {
-      const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', noDelay)
-      mockFetch
-        .mockResolvedValueOnce({ ok: false, status: 429 })
-        .mockResolvedValueOnce({ ok: true, status: 204 })
-
-      await client.send({ content: 'test' })
-
-      expect(mockFetch).toHaveBeenCalledTimes(2)
-    })
-
     it.each([
-      { label: '401（Webhook失効）', status: 401 },
-      { label: '404（Webhook削除）', status: 404 },
-    ])('恒久的な失敗（$label）はリトライせず1回で打ち切りエラーログを記録する', async ({
-      status,
-    }) => {
+      { label: '401（Webhook失効）は即時打ち切り', status: 401, expectedCalls: 1 },
+      { label: '404（Webhook削除）は即時打ち切り', status: 404, expectedCalls: 1 },
+      { label: '5xxが継続し最大リトライ到達', status: 500, expectedCalls: 3 },
+    ])('失敗が続く場合（$label）はエラーログを記録する', async ({ status, expectedCalls }) => {
       const logger = createMockLogger()
       const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', {
         ...noDelay,
@@ -142,21 +133,7 @@ describe('DiscordWebhookClient', () => {
 
       await client.send({ content: 'test' })
 
-      expect(mockFetch).toHaveBeenCalledTimes(1)
-      expect(logger.error).toHaveBeenCalledTimes(1)
-    })
-
-    it('最大リトライ回数を使い切った場合はエラーログを記録する', async () => {
-      const logger = createMockLogger()
-      const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', {
-        ...noDelay,
-        logger,
-      })
-      mockFetch.mockResolvedValue({ ok: false, status: 500 })
-
-      await client.send({ content: 'test' })
-
-      expect(mockFetch).toHaveBeenCalledTimes(3)
+      expect(mockFetch).toHaveBeenCalledTimes(expectedCalls)
       expect(logger.error).toHaveBeenCalledTimes(1)
     })
 

--- a/application/packages/notification/src/discord.test.ts
+++ b/application/packages/notification/src/discord.test.ts
@@ -1,9 +1,23 @@
+import type { LoggerType } from '@trend-diary/common/logger'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DiscordNotifier, DiscordWebhookClient } from './discord'
 
 // fetchをモック
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
+
+// Logger注入の検証用モック
+const createMockLogger = () =>
+  ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    with: vi.fn(),
+  }) as unknown as LoggerType
+
+// リトライ待機を待たずにテストするため、backoffの基準遅延を0にする
+const noDelay = { baseDelayMs: 0 }
 
 describe('DiscordWebhookClient', () => {
   beforeEach(() => {
@@ -20,6 +34,15 @@ describe('DiscordWebhookClient', () => {
       await client.send({ content: 'test' })
 
       expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('Webhook URLが未設定の場合は警告ログを記録する', async () => {
+      const logger = createMockLogger()
+      const client = new DiscordWebhookClient('', { logger })
+
+      await client.send({ content: 'test' })
+
+      expect(logger.warn).toHaveBeenCalledTimes(1)
     })
 
     it('指定したペイロードをDiscord Webhookに送信する', async () => {
@@ -51,9 +74,95 @@ describe('DiscordWebhookClient', () => {
       expect(body).toEqual(payload)
     })
 
+    it('送信が成功した場合はリトライしない', async () => {
+      const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', noDelay)
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 204 })
+
+      await client.send({ content: 'test' })
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('ネットワークエラー時はexponential backoffでリトライする', async () => {
+      const logger = createMockLogger()
+      const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', {
+        ...noDelay,
+        logger,
+      })
+      mockFetch
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce({ ok: true, status: 204 })
+
+      await client.send({ content: 'test' })
+
+      expect(mockFetch).toHaveBeenCalledTimes(3)
+      expect(logger.error).not.toHaveBeenCalled()
+    })
+
+    it('5xxレスポンスはリトライ対象として扱う', async () => {
+      const logger = createMockLogger()
+      const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', {
+        ...noDelay,
+        logger,
+      })
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 500 })
+        .mockResolvedValueOnce({ ok: true, status: 204 })
+
+      await client.send({ content: 'test' })
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(logger.error).not.toHaveBeenCalled()
+    })
+
+    it('429レスポンス（レートリミット）はリトライ対象として扱う', async () => {
+      const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', noDelay)
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 429 })
+        .mockResolvedValueOnce({ ok: true, status: 204 })
+
+      await client.send({ content: 'test' })
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+    })
+
+    it.each([
+      { label: '401（Webhook失効）', status: 401 },
+      { label: '404（Webhook削除）', status: 404 },
+    ])('恒久的な失敗（$label）はリトライせず1回で打ち切りエラーログを記録する', async ({
+      status,
+    }) => {
+      const logger = createMockLogger()
+      const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', {
+        ...noDelay,
+        logger,
+      })
+      mockFetch.mockResolvedValue({ ok: false, status })
+
+      await client.send({ content: 'test' })
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(logger.error).toHaveBeenCalledTimes(1)
+    })
+
+    it('最大リトライ回数を使い切った場合はエラーログを記録する', async () => {
+      const logger = createMockLogger()
+      const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', {
+        ...noDelay,
+        logger,
+      })
+      mockFetch.mockResolvedValue({ ok: false, status: 500 })
+
+      await client.send({ content: 'test' })
+
+      expect(mockFetch).toHaveBeenCalledTimes(3)
+      expect(logger.error).toHaveBeenCalledTimes(1)
+    })
+
     it('送信が失敗してもエラーを投げない', async () => {
-      const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test')
-      mockFetch.mockRejectedValueOnce(new Error('Network error'))
+      const client = new DiscordWebhookClient('https://discord.com/api/webhooks/test', noDelay)
+      mockFetch.mockRejectedValue(new Error('Network error'))
 
       await expect(client.send({ content: 'test' })).resolves.not.toThrow()
     })
@@ -157,9 +266,9 @@ describe('DiscordNotifier', () => {
 
     it('Discord Webhook送信が失敗してもエラーを投げない', async () => {
       const webhookUrl = 'https://discord.com/api/webhooks/test'
-      const notifier = new DiscordNotifier(webhookUrl)
+      const notifier = new DiscordNotifier(webhookUrl, noDelay)
 
-      mockFetch.mockRejectedValueOnce(new Error('Network error'))
+      mockFetch.mockRejectedValue(new Error('Network error'))
 
       const error = new Error('Internal Server Error')
 
@@ -170,6 +279,23 @@ describe('DiscordNotifier', () => {
           userAgent: 'test-agent',
         }),
       ).resolves.not.toThrow()
+    })
+
+    it('注入したLoggerに通知失敗を記録する', async () => {
+      const logger = createMockLogger()
+      const notifier = new DiscordNotifier('https://discord.com/api/webhooks/test', {
+        ...noDelay,
+        logger,
+      })
+      mockFetch.mockResolvedValue({ ok: false, status: 500 })
+
+      await notifier.error(new Error('Internal Server Error'), {
+        url: '/api/test',
+        method: 'GET',
+        userAgent: 'test-agent',
+      })
+
+      expect(logger.error).toHaveBeenCalledTimes(1)
     })
 
     it('スタックトレースが長い場合は適切に切り詰める', async () => {

--- a/application/packages/notification/src/discord.test.ts
+++ b/application/packages/notification/src/discord.test.ts
@@ -2,11 +2,9 @@ import type { LoggerType } from '@trend-diary/common/logger'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DiscordNotifier, DiscordWebhookClient } from './discord'
 
-// fetchをモック
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
 
-// Logger注入の検証用モック
 const createMockLogger = () =>
   ({
     debug: vi.fn(),
@@ -16,7 +14,7 @@ const createMockLogger = () =>
     with: vi.fn(),
   }) as unknown as LoggerType
 
-// リトライ待機を待たずにテストするため、backoffの基準遅延を0にする
+// リトライ待機を待たずにテストするため
 const noDelay = { baseDelayMs: 0 }
 
 const webhookUrl = 'https://discord.com/api/webhooks/test'
@@ -262,7 +260,6 @@ describe('DiscordNotifier', () => {
         })
 
         const error = new Error('Test error')
-        // 1000文字以上のスタックトレースを作成
         error.stack = `Error: Test error\n${'a'.repeat(1000)}`
 
         await notifier.error(error, {
@@ -277,7 +274,7 @@ describe('DiscordNotifier', () => {
           (field: { name: string; value: string }) => field.name === 'Stack Trace',
         )
 
-        // Discordの制限（1024文字）以下になっているか確認
+        // 1024はDiscordのフィールド上限
         expect(stackTraceField.value.length).toBeLessThanOrEqual(1024)
         expect(stackTraceField.value).toContain('...(truncated)')
       })

--- a/application/packages/notification/src/discord.ts
+++ b/application/packages/notification/src/discord.ts
@@ -18,15 +18,10 @@ export interface DiscordWebhookPayload {
   embeds?: DiscordEmbed[]
 }
 
-/** Discord Webhook クライアントの設定。 */
 export interface DiscordWebhookClientOptions {
-  /** 通知失敗を構造化ログに記録するための Logger。 */
   logger?: LoggerType
-  /** 送信を試行する最大回数。 */
   maxRetries?: number
-  /** exponential backoff の基準遅延（ミリ秒）。 */
   baseDelayMs?: number
-  /** 1回の送信のタイムアウト（ミリ秒）。 */
   timeoutMs?: number
 }
 
@@ -67,7 +62,7 @@ export class DiscordWebhookClient {
     let attempts = 0
     for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
       attempts = attempt
-      // 応答が遅い相手で処理がハングするのを防ぐ（Workers の実行時間制限対策）。タイムアウトは catch でリトライ対象として扱われる
+      // 応答が遅い相手で処理がハングするのを防ぐ（Workers の実行時間制限対策）
       const controller = new AbortController()
       const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs)
       try {
@@ -84,7 +79,7 @@ export class DiscordWebhookClient {
 
         lastError = new Error(`Discord responded with status ${response.status}`)
 
-        // 401/404 等の恒久的な失敗はリトライしても回復しないため即座に打ち切る（429・5xx は一時的とみなす）
+        // 401/404 等の恒久的な失敗はリトライしても回復しないため即座に打ち切る
         const isRetryable = response.status === 429 || response.status >= 500
         if (!isRetryable) break
       } catch (notificationError) {
@@ -101,7 +96,7 @@ export class DiscordWebhookClient {
       }
     }
 
-    // 通知の失敗は呼び出し元の処理に影響させず、構造化ログへの記録のみ行う
+    // 通知の失敗は呼び出し元の処理に影響させない
     this.logger?.error({ msg: 'Failed to send notification to Discord', attempts }, lastError)
   }
 

--- a/application/packages/notification/src/discord.ts
+++ b/application/packages/notification/src/discord.ts
@@ -1,3 +1,5 @@
+import type { LoggerType } from '@trend-diary/common/logger'
+
 export interface DiscordEmbedField {
   name: string
   value: string
@@ -16,36 +18,87 @@ export interface DiscordWebhookPayload {
   embeds?: DiscordEmbed[]
 }
 
+/** Discord Webhook クライアントの設定。 */
+export interface DiscordWebhookClientOptions {
+  /** 通知失敗を構造化ログに記録するための Logger。 */
+  logger?: LoggerType
+  /** 送信を試行する最大回数。 */
+  maxRetries?: number
+  /** exponential backoff の基準遅延（ミリ秒）。 */
+  baseDelayMs?: number
+}
+
+const DEFAULT_MAX_RETRIES = 3
+const DEFAULT_BASE_DELAY_MS = 200
+
 /**
  * Discord Webhook への汎用送信クライアント。
  */
 export class DiscordWebhookClient {
   private readonly webhookUrl: string
 
-  constructor(webhookUrl?: string) {
+  private readonly logger?: LoggerType
+
+  private readonly maxRetries: number
+
+  private readonly baseDelayMs: number
+
+  constructor(webhookUrl?: string, options: DiscordWebhookClientOptions = {}) {
     this.webhookUrl = webhookUrl ?? ''
+    this.logger = options.logger
+    this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES
+    this.baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS
   }
 
   async send(payload: DiscordWebhookPayload): Promise<void> {
-    if (this.webhookUrl === '') return
-
-    try {
-      await fetch(this.webhookUrl, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(payload),
-      })
-    } catch (notificationError) {
-      // 通知の失敗は呼び出し元の処理に影響させない
-      // biome-ignore lint/suspicious/noConsole: 通知失敗はログに出力する
-      console.error('Failed to send notification to Discord', notificationError)
+    if (this.webhookUrl === '') {
+      // 未設定のまま稼働すると障害通知が無音で失われ、本来気づくべき障害を見逃すため警告する
+      this.logger?.warn('Discord webhook URL is not configured; skipping notification')
+      return
     }
+
+    let lastError: Error = new Error('Discord notification failed')
+    let attempts = 0
+    for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
+      attempts = attempt
+      try {
+        const response = await fetch(this.webhookUrl, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        })
+
+        if (response.ok) return
+
+        lastError = new Error(`Discord responded with status ${response.status}`)
+
+        // 401/404 等の恒久的な失敗はリトライしても回復しないため即座に打ち切る（429・5xx は一時的とみなす）
+        const isRetryable = response.status === 429 || response.status >= 500
+        if (!isRetryable) break
+      } catch (notificationError) {
+        lastError =
+          notificationError instanceof Error
+            ? notificationError
+            : new Error(String(notificationError))
+      }
+
+      if (attempt < this.maxRetries) {
+        await this.delay(this.baseDelayMs * 2 ** (attempt - 1))
+      }
+    }
+
+    // 通知の失敗は呼び出し元の処理に影響させず、構造化ログへの記録のみ行う
+    this.logger?.error({ msg: 'Failed to send notification to Discord', attempts }, lastError)
   }
 
   async sendMessage(content: string): Promise<void> {
     await this.send({ content })
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
   }
 }
 
@@ -62,8 +115,8 @@ export class DiscordNotifier {
 
   private readonly maxFieldLength = 1018 // Discord field limit (1024) minus code block chars (6)
 
-  constructor(webhookUrl?: string) {
-    this.client = new DiscordWebhookClient(webhookUrl)
+  constructor(webhookUrl?: string, options: DiscordWebhookClientOptions = {}) {
+    this.client = new DiscordWebhookClient(webhookUrl, options)
   }
 
   async error(error: Error, requestInfo: ErrorRequestInfo): Promise<void> {

--- a/application/packages/notification/src/discord.ts
+++ b/application/packages/notification/src/discord.ts
@@ -19,7 +19,6 @@ export interface DiscordWebhookPayload {
 }
 
 export interface DiscordWebhookClientOptions {
-  logger?: LoggerType
   maxRetries?: number
   baseDelayMs?: number
   timeoutMs?: number
@@ -35,7 +34,7 @@ const DEFAULT_TIMEOUT_MS = 5000
 export class DiscordWebhookClient {
   private readonly webhookUrl: string
 
-  private readonly logger?: LoggerType
+  private readonly logger: LoggerType
 
   private readonly maxRetries: number
 
@@ -43,9 +42,13 @@ export class DiscordWebhookClient {
 
   private readonly timeoutMs: number
 
-  constructor(webhookUrl?: string, options: DiscordWebhookClientOptions = {}) {
+  constructor(
+    webhookUrl: string | undefined,
+    logger: LoggerType,
+    options: DiscordWebhookClientOptions = {},
+  ) {
     this.webhookUrl = webhookUrl ?? ''
-    this.logger = options.logger
+    this.logger = logger
     this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES
     this.baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS
     this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
@@ -54,7 +57,7 @@ export class DiscordWebhookClient {
   async send(payload: DiscordWebhookPayload): Promise<void> {
     if (this.webhookUrl === '') {
       // 未設定のまま稼働すると障害通知が無音で失われ、本来気づくべき障害を見逃すため警告する
-      this.logger?.warn('Discord webhook URL is not configured; skipping notification')
+      this.logger.warn('Discord webhook URL is not configured; skipping notification')
       return
     }
 
@@ -97,7 +100,7 @@ export class DiscordWebhookClient {
     }
 
     // 通知の失敗は呼び出し元の処理に影響させない
-    this.logger?.error({ msg: 'Failed to send notification to Discord', attempts }, lastError)
+    this.logger.error({ msg: 'Failed to send notification to Discord', attempts }, lastError)
   }
 
   async sendMessage(content: string): Promise<void> {
@@ -122,8 +125,12 @@ export class DiscordNotifier {
 
   private readonly maxFieldLength = 1018 // Discord field limit (1024) minus code block chars (6)
 
-  constructor(webhookUrl?: string, options: DiscordWebhookClientOptions = {}) {
-    this.client = new DiscordWebhookClient(webhookUrl, options)
+  constructor(
+    webhookUrl: string | undefined,
+    logger: LoggerType,
+    options: DiscordWebhookClientOptions = {},
+  ) {
+    this.client = new DiscordWebhookClient(webhookUrl, logger, options)
   }
 
   async error(error: Error, requestInfo: ErrorRequestInfo): Promise<void> {

--- a/application/packages/notification/src/discord.ts
+++ b/application/packages/notification/src/discord.ts
@@ -26,10 +26,13 @@ export interface DiscordWebhookClientOptions {
   maxRetries?: number
   /** exponential backoff の基準遅延（ミリ秒）。 */
   baseDelayMs?: number
+  /** 1回の送信のタイムアウト（ミリ秒）。 */
+  timeoutMs?: number
 }
 
 const DEFAULT_MAX_RETRIES = 3
 const DEFAULT_BASE_DELAY_MS = 200
+const DEFAULT_TIMEOUT_MS = 5000
 
 /**
  * Discord Webhook への汎用送信クライアント。
@@ -43,11 +46,14 @@ export class DiscordWebhookClient {
 
   private readonly baseDelayMs: number
 
+  private readonly timeoutMs: number
+
   constructor(webhookUrl?: string, options: DiscordWebhookClientOptions = {}) {
     this.webhookUrl = webhookUrl ?? ''
     this.logger = options.logger
     this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES
     this.baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
   }
 
   async send(payload: DiscordWebhookPayload): Promise<void> {
@@ -61,6 +67,9 @@ export class DiscordWebhookClient {
     let attempts = 0
     for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
       attempts = attempt
+      // 応答が遅い相手で処理がハングするのを防ぐ（Workers の実行時間制限対策）。タイムアウトは catch でリトライ対象として扱われる
+      const controller = new AbortController()
+      const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs)
       try {
         const response = await fetch(this.webhookUrl, {
           method: 'POST',
@@ -68,6 +77,7 @@ export class DiscordWebhookClient {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify(payload),
+          signal: controller.signal,
         })
 
         if (response.ok) return
@@ -82,6 +92,8 @@ export class DiscordWebhookClient {
           notificationError instanceof Error
             ? notificationError
             : new Error(String(notificationError))
+      } finally {
+        clearTimeout(timeoutId)
       }
 
       if (attempt < this.maxRetries) {

--- a/application/packages/notification/src/index.ts
+++ b/application/packages/notification/src/index.ts
@@ -3,6 +3,7 @@ export {
   type DiscordEmbedField,
   DiscordNotifier,
   DiscordWebhookClient,
+  type DiscordWebhookClientOptions,
   type DiscordWebhookPayload,
   type ErrorRequestInfo,
 } from './discord'

--- a/application/packages/web/src/middleware/error-handler.ts
+++ b/application/packages/web/src/middleware/error-handler.ts
@@ -1,4 +1,4 @@
-import { LoggerType } from '@trend-diary/common/logger'
+import Logger, { LoggerType } from '@trend-diary/common/logger'
 import { DiscordNotifier } from '@trend-diary/notification'
 import { Context } from 'hono'
 import { HTTPException } from 'hono/http-exception'
@@ -22,7 +22,11 @@ const errorHandler = async (err: Error, c: Context<Env>): Promise<Response> => {
     userAgent: c.req.header('User-Agent') || '',
   }
 
-  const discordNotifier = new DiscordNotifier(discordWebhookUrl, { logger })
+  // request-logger未設定時でも通知失敗を記録できるようフォールバックのLoggerを用意する
+  const discordNotifier = new DiscordNotifier(
+    discordWebhookUrl,
+    logger ?? new Logger(c.env.LOG_LEVEL || 'info'),
+  )
   if (err instanceof HTTPException) {
     if (err.status >= 500) {
       if (logger && typeof logger.error === 'function') {

--- a/application/packages/web/src/middleware/error-handler.ts
+++ b/application/packages/web/src/middleware/error-handler.ts
@@ -22,7 +22,7 @@ const errorHandler = async (err: Error, c: Context<Env>): Promise<Response> => {
     userAgent: c.req.header('User-Agent') || '',
   }
 
-  const discordNotifier = new DiscordNotifier(discordWebhookUrl)
+  const discordNotifier = new DiscordNotifier(discordWebhookUrl, { logger })
   if (err instanceof HTTPException) {
     if (err.status >= 500) {
       if (logger && typeof logger.error === 'function') {

--- a/application/packages/web/src/middleware/error-handler.ts
+++ b/application/packages/web/src/middleware/error-handler.ts
@@ -22,7 +22,7 @@ const errorHandler = async (err: Error, c: Context<Env>): Promise<Response> => {
     userAgent: c.req.header('User-Agent') || '',
   }
 
-  // request-logger未設定時でも通知失敗を記録できるようフォールバックのLoggerを用意する
+  // request-logger未設定時でも通知失敗を記録できるようにする
   const discordNotifier = new DiscordNotifier(
     discordWebhookUrl,
     logger ?? new Logger(c.env.LOG_LEVEL || 'info'),

--- a/application/pnpm-lock.yaml
+++ b/application/pnpm-lock.yaml
@@ -231,6 +231,10 @@ importers:
         version: 1.60.0
 
   packages/notification:
+    dependencies:
+      '@trend-diary/common':
+        specifier: workspace:*
+        version: link:../common
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'


### PR DESCRIPTION
## 概要

Closes #731

Discord 通知（障害アラート経路）の信頼性が低い問題に対応します。これまでは `console.error` のみの記録・リトライなし・HTTP ステータス未チェックのため、**一時的なネットワークエラーや Webhook 失効（401/404）・レートリミット（429）で障害通知そのものが無検知で失われる**状態でした。

## 変更内容

`application/packages/notification/src/discord.ts` の `DiscordWebhookClient` を改善しました。

- **Logger 注入**: `Logger` をコンストラクタ（`options.logger`）で注入し、通知失敗を構造化ログ（Pino）で記録します。`console.error` を廃止しました。
- **リトライ（exponential backoff）**: 最大 3 回まで、`200ms → 400ms` の backoff でリトライします。
- **HTTP ステータスのチェック**: `response.ok` を確認します。
  - `429`（レートリミット）・`5xx` は一時的失敗とみなしリトライ対象に含めます。
  - `401`/`404` 等の恒久的失敗はリトライせず即座に打ち切り、エラーログを記録します。
- **未設定時の警告**: `webhookUrl` 未設定時は警告ログを出力します。無音 no-op による設定漏れ（wrangler の設定ミス等）の見逃しを防ぎます。

通知失敗が呼び出し元の処理を阻害しない現行設計は維持しています。

## 呼び出し元

- `cron/src/worker.ts`・`web/src/middleware/error-handler.ts` から、既存の `logger` を `{ logger }` として注入するよう更新しました。

## テスト

`discord.test.ts` に以下の仕様を追加しました（全 19 ケース pass）。

- 未設定時の警告ログ
- 成功時はリトライしない
- ネットワークエラー / 5xx / 429 でのリトライ
- 401/404 の即時打ち切り
- 最大リトライ回数到達時のエラーログ
- 注入 Logger への失敗記録

## 確認事項

- `pnpm --filter @trend-diary/notification test` ✅（19 passed）
- `pnpm exec biome ci .` ✅
- `typecheck`（notification / cron / web）✅
- web パッケージの `test` は Playwright ブラウザ未インストールの環境要因で起動前に失敗しますが、本変更とは無関係です（typecheck は通過）。

## 将来検討（issue 備考より）

成功時メトリクス（successCount / failedCount）の embed 送信は本 PR のスコープ外としています。

https://claude.ai/code/session_01NjNXbsw4NCXEnzuFNvR2Yn

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjNXbsw4NCXEnzuFNvR2Yn)_