### PR TITLE
test: クロスユーザー認可のテストを追加

### DIFF
--- a/application/packages/web/src/server/article/handler/read-article.test.ts
+++ b/application/packages/web/src/server/article/handler/read-article.test.ts
@@ -176,9 +176,7 @@ describe('POST /api/articles/:article_id/read', () => {
       const response = await requestReadArticle(testArticleId.toString(), authCookies)
       expect(response.status).toBe(201)
 
-      // 操作したユーザーAには既読履歴が作成される
       expect(await articleHelper.findReadHistory(testActiveUserId, testArticleId)).toBeTruthy()
-      // 他ユーザーBの既読履歴には影響しない
       expect(await articleHelper.findReadHistory(userB.activeUserId, testArticleId)).toBeNull()
     })
   })

--- a/application/packages/web/src/server/article/handler/read-article.test.ts
+++ b/application/packages/web/src/server/article/handler/read-article.test.ts
@@ -164,4 +164,22 @@ describe('POST /api/articles/:article_id/read', () => {
       expect(response.status).toBe(404)
     })
   })
+
+  describe('クロスユーザー認可', () => {
+    // セッション由来のactiveUserIdで既読履歴を作成する不変条件を担保する。
+    // 将来リクエストパラメータからユーザーIDを受け取る変更が入った際に検知できるようにする。
+    it('ユーザーAの既読化が他ユーザーの既読履歴に影響しないこと', async () => {
+      const userB = await userHelper.create('read-cross-user@example.com', 'Test@password123')
+      createdUserIds.userIds.push(userB.userId)
+      createdUserIds.authIds.push(userB.authenticationId)
+
+      const response = await requestReadArticle(testArticleId.toString(), authCookies)
+      expect(response.status).toBe(201)
+
+      // 操作したユーザーAには既読履歴が作成される
+      expect(await articleHelper.findReadHistory(testActiveUserId, testArticleId)).toBeTruthy()
+      // 他ユーザーBの既読履歴には影響しない
+      expect(await articleHelper.findReadHistory(userB.activeUserId, testArticleId)).toBeNull()
+    })
+  })
 })

--- a/application/packages/web/src/server/article/handler/skip-article.test.ts
+++ b/application/packages/web/src/server/article/handler/skip-article.test.ts
@@ -92,9 +92,7 @@ describe('POST /api/articles/:article_id/skip', () => {
       const response = await requestSkipArticle(testArticleId.toString(), authCookies)
       expect(response.status).toBe(201)
 
-      // 操作したユーザーAにはスキップ状態が作成される
       expect(await articleHelper.countSkippedArticles(testActiveUserId, testArticleId)).toBe(1)
-      // 他ユーザーBのスキップ状態には影響しない
       expect(await articleHelper.countSkippedArticles(userB.activeUserId, testArticleId)).toBe(0)
     })
   })

--- a/application/packages/web/src/server/article/handler/skip-article.test.ts
+++ b/application/packages/web/src/server/article/handler/skip-article.test.ts
@@ -5,6 +5,7 @@ import type { CleanUpIds } from '@/test/helper/user'
 import * as userHelper from '@/test/helper/user'
 
 describe('POST /api/articles/:article_id/skip', () => {
+  let testActiveUserId: bigint
   let testArticleId: bigint
   let authCookies: string
   const createdArticleIds: bigint[] = []
@@ -36,6 +37,7 @@ describe('POST /api/articles/:article_id/skip', () => {
     createdUserIds.authIds.push(authenticationId)
 
     const loginData = await userHelper.login('skiptest@example.com', 'Test@password123')
+    testActiveUserId = loginData.activeUserId
     authCookies = loginData.cookies
 
     const article = await articleHelper.createArticle()
@@ -77,5 +79,23 @@ describe('POST /api/articles/:article_id/skip', () => {
   ])('$name で期待ステータスになる', async ({ articleId, cookies, status }) => {
     const response = await requestSkipArticle(articleId, cookies())
     expect(response.status).toBe(status)
+  })
+
+  describe('クロスユーザー認可', () => {
+    // セッション由来のactiveUserIdでスキップ状態を作成する不変条件を担保する。
+    // 将来リクエストパラメータからユーザーIDを受け取る変更が入った際に検知できるようにする。
+    it('ユーザーAのスキップが他ユーザーのスキップ状態に影響しないこと', async () => {
+      const userB = await userHelper.create('skip-cross-user@example.com', 'Test@password123')
+      createdUserIds.userIds.push(userB.userId)
+      createdUserIds.authIds.push(userB.authenticationId)
+
+      const response = await requestSkipArticle(testArticleId.toString(), authCookies)
+      expect(response.status).toBe(201)
+
+      // 操作したユーザーAにはスキップ状態が作成される
+      expect(await articleHelper.countSkippedArticles(testActiveUserId, testArticleId)).toBe(1)
+      // 他ユーザーBのスキップ状態には影響しない
+      expect(await articleHelper.countSkippedArticles(userB.activeUserId, testArticleId)).toBe(0)
+    })
   })
 })

--- a/application/packages/web/src/server/article/handler/unread-article.test.ts
+++ b/application/packages/web/src/server/article/handler/unread-article.test.ts
@@ -112,4 +112,22 @@ describe('DELETE /api/articles/:article_id/unread', () => {
       expect(response.status).toBe(404)
     })
   })
+
+  describe('クロスユーザー認可', () => {
+    // 削除対象をセッション由来のactiveUserIdに限定する不変条件を担保する。
+    // 将来リクエストパラメータからユーザーIDを受け取る変更が入った際に検知できるようにする。
+    it('他ユーザーBによる未読化がユーザーAの既読履歴を削除しないこと', async () => {
+      const userB = await userHelper.create('unread-cross-user@example.com', 'Test@password123')
+      createdUserIds.userIds.push(userB.userId)
+      createdUserIds.authIds.push(userB.authenticationId)
+      const userBLogin = await userHelper.login('unread-cross-user@example.com', 'Test@password123')
+
+      // 既読履歴を持たないユーザーBが同一記事をunreadする
+      const response = await requestUnreadArticle(testArticleId.toString(), userBLogin.cookies)
+      expect(response.status).toBe(200)
+
+      // ユーザーAの既読履歴は削除されない
+      expect(await articleHelper.countReadHistories(testActiveUserId, testArticleId)).toBe(1)
+    })
+  })
 })

--- a/application/packages/web/src/server/article/handler/unread-article.test.ts
+++ b/application/packages/web/src/server/article/handler/unread-article.test.ts
@@ -122,11 +122,9 @@ describe('DELETE /api/articles/:article_id/unread', () => {
       createdUserIds.authIds.push(userB.authenticationId)
       const userBLogin = await userHelper.login('unread-cross-user@example.com', 'Test@password123')
 
-      // 既読履歴を持たないユーザーBが同一記事をunreadする
       const response = await requestUnreadArticle(testArticleId.toString(), userBLogin.cookies)
       expect(response.status).toBe(200)
 
-      // ユーザーAの既読履歴は削除されない
       expect(await articleHelper.countReadHistories(testActiveUserId, testArticleId)).toBe(1)
     })
   })

--- a/application/packages/web/src/test/helper/article.ts
+++ b/application/packages/web/src/test/helper/article.ts
@@ -136,6 +136,22 @@ export async function countReadHistories(activeUserId: bigint, articleId: bigint
   return result.value
 }
 
+export async function countSkippedArticles(
+  activeUserId: bigint,
+  articleId: bigint,
+): Promise<number> {
+  const [result] = await rdb
+    .select({ value: count() })
+    .from(skippedArticles)
+    .where(
+      and(
+        eq(skippedArticles.activeUserId, toDbId(activeUserId)),
+        eq(skippedArticles.articleId, toDbId(articleId)),
+      ),
+    )
+  return result.value
+}
+
 export async function cleanUp(articleIds: bigint[]): Promise<void> {
   if (articleIds.length > 0) {
     const dbArticleIds = toDbIds(articleIds)


### PR DESCRIPTION
## 概要

closes #742

read / skip / unread系ハンドラのテストは「自ユーザーでの正常系・バリデーションエラー・未認証（401）」のみで、あるユーザーが他ユーザーのリソースを操作できないことを検証するテストが存在しませんでした。

API全体で最も壊してはいけない不変条件（操作対象をセッション由来の `activeUserId` に限定する）を、開発ルール「仕様はテストコードに記載する」に照らしてテストで担保します。将来「リクエストパラメータからユーザーIDを受け取る」ような変更が入った際に検知できるようにします。

## 変更内容

各ハンドラのテストに `クロスユーザー認可` describe を追加しました。

- `read-article.test.ts`: ユーザーAの既読化が他ユーザーの既読履歴に影響しないこと
- `skip-article.test.ts`: ユーザーAのスキップが他ユーザーのスキップ状態に影響しないこと
- `unread-article.test.ts`: 他ユーザーBによる未読化がユーザーAの既読履歴を削除しないこと

スキップ状態の検証用に `countSkippedArticles` ヘルパーを `test/helper/article.ts` に追加しました。

## 確認事項

- Biome check: パス
- 型チェック: 本変更による新規エラーなし（既存の `auth-action-use-case.ts` / `signup.ts` のエラーはベースから存在）
- これらはDB（D1）+ Supabase稼働前提の統合テストのため、本環境では `vitest` 実行を省略しています。CIでの実行を確認してください。


---
_Generated by [Claude Code](https://claude.ai/code/session_01MABo7irt2nc2SZg9Yif8wh)_