### PR TITLE
refactor(common): 外部fetchのタイムアウト処理を共通化する

### DIFF
--- a/application/packages/common/package.json
+++ b/application/packages/common/package.json
@@ -6,6 +6,7 @@
   "exports": {
     "./env": "./src/env/index.ts",
     "./errors": "./src/errors/index.ts",
+    "./http": "./src/http/index.ts",
     "./locale": "./src/locale/index.ts",
     "./pagination": "./src/pagination/index.ts",
     "./result": "./src/result/index.ts",

--- a/application/packages/common/src/http/index.test.ts
+++ b/application/packages/common/src/http/index.test.ts
@@ -7,6 +7,11 @@ vi.stubGlobal('fetch', mockFetch)
 // signalがabortされるまで解決しないfetchを模し、タイムアウト挙動を検証する
 const neverResolvingFetch = (_input: unknown, init: { signal: AbortSignal }) =>
   new Promise((_resolve, reject) => {
+    // 既にabort済みのsignalではabortイベントが発火しないため即座にrejectする
+    if (init.signal.aborted) {
+      reject(init.signal.reason)
+      return
+    }
     init.signal.addEventListener('abort', () => reject(init.signal.reason))
   })
 
@@ -64,5 +69,47 @@ describe('fetchWithTimeout', () => {
 
   it('既定のタイムアウト値を公開していること', () => {
     expect(DEFAULT_FETCH_TIMEOUT_MS).toBe(5000)
+  })
+
+  // iOS 16 等のAbortSignal.any未対応環境を想定し、フォールバック経路を検証する
+  describe('AbortSignal.any未対応環境', () => {
+    let originalAny: typeof AbortSignal.any
+
+    beforeEach(() => {
+      originalAny = AbortSignal.any
+      // biome-ignore lint/suspicious/noExplicitAny: 未対応環境を再現するため一時的に除去する
+      ;(AbortSignal as any).any = undefined
+    })
+
+    afterEach(() => {
+      AbortSignal.any = originalAny
+    })
+
+    it('タイムアウト経過でリクエストを中断すること', async () => {
+      mockFetch.mockImplementation(neverResolvingFetch)
+      const controller = new AbortController()
+
+      await expect(
+        fetchWithTimeout('https://example.com', { timeoutMs: 10, signal: controller.signal }),
+      ).rejects.toThrow()
+    })
+
+    it('呼び出し元のsignalによる中断も尊重すること', async () => {
+      mockFetch.mockImplementation(neverResolvingFetch)
+      const controller = new AbortController()
+
+      const promise = fetchWithTimeout('https://example.com', { signal: controller.signal })
+      controller.abort(new Error('caller aborted'))
+
+      await expect(promise).rejects.toThrow('caller aborted')
+    })
+
+    it('既にabort済みのsignalでも中断を伝播すること', async () => {
+      mockFetch.mockImplementation(neverResolvingFetch)
+
+      await expect(
+        fetchWithTimeout('https://example.com', { signal: AbortSignal.abort(new Error('pre')) }),
+      ).rejects.toThrow('pre')
+    })
   })
 })

--- a/application/packages/common/src/http/index.test.ts
+++ b/application/packages/common/src/http/index.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DEFAULT_FETCH_TIMEOUT_MS, fetchWithTimeout } from './index'
 
 const mockFetch = vi.fn()
@@ -42,22 +42,6 @@ describe('fetchWithTimeout', () => {
     expect(mockFetch.mock.calls[0][1]).not.toHaveProperty('timeoutMs')
   })
 
-  it('指定したtimeoutMs経過でリクエストを中断すること', async () => {
-    mockFetch.mockImplementation(neverResolvingFetch)
-
-    await expect(fetchWithTimeout('https://example.com', { timeoutMs: 10 })).rejects.toThrow()
-  })
-
-  it('呼び出し元のsignalによる中断も尊重すること', async () => {
-    mockFetch.mockImplementation(neverResolvingFetch)
-
-    const controller = new AbortController()
-    const promise = fetchWithTimeout('https://example.com', { signal: controller.signal })
-    controller.abort(new Error('caller aborted'))
-
-    await expect(promise).rejects.toThrow('caller aborted')
-  })
-
   it('成功時はResponseをそのまま返すこと', async () => {
     const response = { ok: true, status: 200 }
     mockFetch.mockResolvedValueOnce(response)
@@ -71,33 +55,30 @@ describe('fetchWithTimeout', () => {
     expect(DEFAULT_FETCH_TIMEOUT_MS).toBe(5000)
   })
 
-  // iOS 16 等のAbortSignal.any未対応環境を想定し、フォールバック経路を検証する
-  describe('AbortSignal.any未対応環境', () => {
+  // AbortSignal.any 対応環境と未対応環境(iOS 16 等)の双方で中断が伝播することを検証する
+  describe.each([
+    { env: 'AbortSignal.any対応環境', anyImpl: AbortSignal.any },
+    { env: 'AbortSignal.any未対応環境', anyImpl: undefined },
+  ])('$env', ({ anyImpl }) => {
     let originalAny: typeof AbortSignal.any
 
     beforeEach(() => {
       originalAny = AbortSignal.any
-      // biome-ignore lint/suspicious/noExplicitAny: 未対応環境を再現するため一時的に除去する
-      ;(AbortSignal as any).any = undefined
+      // biome-ignore lint/suspicious/noExplicitAny: 環境差を再現するため一時的に差し替える
+      ;(AbortSignal as any).any = anyImpl
+      mockFetch.mockImplementation(neverResolvingFetch)
     })
 
     afterEach(() => {
       AbortSignal.any = originalAny
     })
 
-    it('タイムアウト経過でリクエストを中断すること', async () => {
-      mockFetch.mockImplementation(neverResolvingFetch)
-      const controller = new AbortController()
-
-      await expect(
-        fetchWithTimeout('https://example.com', { timeoutMs: 10, signal: controller.signal }),
-      ).rejects.toThrow()
+    it('指定したtimeoutMs経過でリクエストを中断すること', async () => {
+      await expect(fetchWithTimeout('https://example.com', { timeoutMs: 10 })).rejects.toThrow()
     })
 
     it('呼び出し元のsignalによる中断も尊重すること', async () => {
-      mockFetch.mockImplementation(neverResolvingFetch)
       const controller = new AbortController()
-
       const promise = fetchWithTimeout('https://example.com', { signal: controller.signal })
       controller.abort(new Error('caller aborted'))
 
@@ -105,8 +86,6 @@ describe('fetchWithTimeout', () => {
     })
 
     it('既にabort済みのsignalでも中断を伝播すること', async () => {
-      mockFetch.mockImplementation(neverResolvingFetch)
-
       await expect(
         fetchWithTimeout('https://example.com', { signal: AbortSignal.abort(new Error('pre')) }),
       ).rejects.toThrow('pre')

--- a/application/packages/common/src/http/index.test.ts
+++ b/application/packages/common/src/http/index.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_FETCH_TIMEOUT_MS, fetchWithTimeout } from './index'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+// signalがabortされるまで解決しないfetchを模し、タイムアウト挙動を検証する
+const neverResolvingFetch = (_input: unknown, init: { signal: AbortSignal }) =>
+  new Promise((_resolve, reject) => {
+    init.signal.addEventListener('abort', () => reject(init.signal.reason))
+  })
+
+describe('fetchWithTimeout', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockFetch.mockResolvedValue({ ok: true, status: 200 })
+  })
+
+  it('指定したinputとinitでfetchを呼び出すこと', async () => {
+    await fetchWithTimeout('https://example.com', { method: 'POST' })
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://example.com',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('ハング防止のためAbortSignalを付与すること', async () => {
+    await fetchWithTimeout('https://example.com')
+
+    expect(mockFetch.mock.calls[0][1].signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('timeoutMsにはfetchへ渡すinitを含めないこと', async () => {
+    await fetchWithTimeout('https://example.com', { method: 'GET', timeoutMs: 1000 })
+
+    expect(mockFetch.mock.calls[0][1]).not.toHaveProperty('timeoutMs')
+  })
+
+  it('指定したtimeoutMs経過でリクエストを中断すること', async () => {
+    mockFetch.mockImplementation(neverResolvingFetch)
+
+    await expect(fetchWithTimeout('https://example.com', { timeoutMs: 10 })).rejects.toThrow()
+  })
+
+  it('呼び出し元のsignalによる中断も尊重すること', async () => {
+    mockFetch.mockImplementation(neverResolvingFetch)
+
+    const controller = new AbortController()
+    const promise = fetchWithTimeout('https://example.com', { signal: controller.signal })
+    controller.abort(new Error('caller aborted'))
+
+    await expect(promise).rejects.toThrow('caller aborted')
+  })
+
+  it('成功時はResponseをそのまま返すこと', async () => {
+    const response = { ok: true, status: 200 }
+    mockFetch.mockResolvedValueOnce(response)
+
+    const result = await fetchWithTimeout('https://example.com')
+
+    expect(result).toBe(response)
+  })
+
+  it('既定のタイムアウト値を公開していること', () => {
+    expect(DEFAULT_FETCH_TIMEOUT_MS).toBe(5000)
+  })
+})

--- a/application/packages/common/src/http/index.ts
+++ b/application/packages/common/src/http/index.ts
@@ -10,25 +10,24 @@ export interface FetchWithTimeoutOptions {
 
 // AbortSignal.any 未対応環境向けに、複数signalのいずれかの中断を伝播する合成signalを生成する。
 // 中断後はリスナーを解放できるよう、解放用のクリーンアップ関数もあわせて返す。
-const combineSignals = (
-  signal: AbortSignal,
-  timeoutSignal: AbortSignal,
-): { signal: AbortSignal; cleanup: () => void } => {
+const combineSignals = (signals: AbortSignal[]): { signal: AbortSignal; cleanup: () => void } => {
   const controller = new AbortController()
-  const onSignalAbort = () => controller.abort(signal.reason)
-  const onTimeoutAbort = () => controller.abort(timeoutSignal.reason)
 
-  if (signal.aborted) {
-    controller.abort(signal.reason)
-  } else {
-    signal.addEventListener('abort', onSignalAbort)
-    timeoutSignal.addEventListener('abort', onTimeoutAbort)
+  const alreadyAborted = signals.find((signal) => signal.aborted)
+  if (alreadyAborted) {
+    controller.abort(alreadyAborted.reason)
+    // 既に中断済みでリスナーを登録しないため、解放処理は不要
+    const noop = () => undefined
+    return { signal: controller.signal, cleanup: noop }
   }
 
-  const cleanup = () => {
-    signal.removeEventListener('abort', onSignalAbort)
-    timeoutSignal.removeEventListener('abort', onTimeoutAbort)
-  }
+  const removers = signals.map((signal) => {
+    const onAbort = () => controller.abort(signal.reason)
+    signal.addEventListener('abort', onAbort)
+    return () => signal.removeEventListener('abort', onAbort)
+  })
+
+  const cleanup = () => removers.forEach((remove) => remove())
   return { signal: controller.signal, cleanup }
 }
 
@@ -56,6 +55,6 @@ export const fetchWithTimeout = (
   }
 
   // iOS 16 等の AbortSignal.any 未対応環境ではリスナーリークを避けつつ手動で合成する
-  const { signal: combinedSignal, cleanup } = combineSignals(signal, timeoutSignal)
+  const { signal: combinedSignal, cleanup } = combineSignals([signal, timeoutSignal])
   return fetch(input, { ...rest, signal: combinedSignal }).finally(cleanup)
 }

--- a/application/packages/common/src/http/index.ts
+++ b/application/packages/common/src/http/index.ts
@@ -8,6 +8,30 @@ export interface FetchWithTimeoutOptions {
   timeoutMs?: number
 }
 
+// AbortSignal.any 未対応環境向けに、複数signalのいずれかの中断を伝播する合成signalを生成する。
+// 中断後はリスナーを解放できるよう、解放用のクリーンアップ関数もあわせて返す。
+const combineSignals = (
+  signal: AbortSignal,
+  timeoutSignal: AbortSignal,
+): { signal: AbortSignal; cleanup: () => void } => {
+  const controller = new AbortController()
+  const onSignalAbort = () => controller.abort(signal.reason)
+  const onTimeoutAbort = () => controller.abort(timeoutSignal.reason)
+
+  if (signal.aborted) {
+    controller.abort(signal.reason)
+  } else {
+    signal.addEventListener('abort', onSignalAbort)
+    timeoutSignal.addEventListener('abort', onTimeoutAbort)
+  }
+
+  const cleanup = () => {
+    signal.removeEventListener('abort', onSignalAbort)
+    timeoutSignal.removeEventListener('abort', onTimeoutAbort)
+  }
+  return { signal: controller.signal, cleanup }
+}
+
 /**
  * タイムアウト付きの fetch ラッパ。
  *
@@ -20,7 +44,18 @@ export const fetchWithTimeout = (
 ): Promise<Response> => {
   const { timeoutMs = DEFAULT_FETCH_TIMEOUT_MS, signal, ...rest } = init
   const timeoutSignal = AbortSignal.timeout(timeoutMs)
-  // 呼び出し元が渡したsignalによる中断とタイムアウトの両方を尊重する
-  const combinedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal
-  return fetch(input, { ...rest, signal: combinedSignal })
+
+  // 呼び出し元のsignalが無ければタイムアウトのみを適用する
+  if (!signal) {
+    return fetch(input, { ...rest, signal: timeoutSignal })
+  }
+
+  // AbortSignal.any はリスナー解放まで内部で面倒を見るため、対応環境では優先利用する
+  if (typeof AbortSignal.any === 'function') {
+    return fetch(input, { ...rest, signal: AbortSignal.any([signal, timeoutSignal]) })
+  }
+
+  // iOS 16 等の AbortSignal.any 未対応環境ではリスナーリークを避けつつ手動で合成する
+  const { signal: combinedSignal, cleanup } = combineSignals(signal, timeoutSignal)
+  return fetch(input, { ...rest, signal: combinedSignal }).finally(cleanup)
 }

--- a/application/packages/common/src/http/index.ts
+++ b/application/packages/common/src/http/index.ts
@@ -1,0 +1,26 @@
+type FetchInput = Parameters<typeof fetch>[0]
+type FetchInit = NonNullable<Parameters<typeof fetch>[1]>
+
+// 応答が遅い相手でハングするとWorkersの実行時間制限に直結するため、共通の既定値を設ける
+export const DEFAULT_FETCH_TIMEOUT_MS = 5000
+
+export interface FetchWithTimeoutOptions {
+  timeoutMs?: number
+}
+
+/**
+ * タイムアウト付きの fetch ラッパ。
+ *
+ * 外部HTTP呼び出しのタイムアウト処理を一箇所に集約し、各所での
+ * AbortController + setTimeout のボイラープレート増殖を防ぐ。
+ */
+export const fetchWithTimeout = (
+  input: FetchInput,
+  init: FetchInit & FetchWithTimeoutOptions = {},
+): Promise<Response> => {
+  const { timeoutMs = DEFAULT_FETCH_TIMEOUT_MS, signal, ...rest } = init
+  const timeoutSignal = AbortSignal.timeout(timeoutMs)
+  // 呼び出し元が渡したsignalによる中断とタイムアウトの両方を尊重する
+  const combinedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal
+  return fetch(input, { ...rest, signal: combinedSignal })
+}

--- a/application/packages/cron/src/fetch-articles.ts
+++ b/application/packages/cron/src/fetch-articles.ts
@@ -1,3 +1,4 @@
+import { fetchWithTimeout } from '@trend-diary/common/http'
 import type Logger from '@trend-diary/common/logger'
 import { wrapAsyncCall } from '@trend-diary/common/result'
 import { articles } from '@trend-diary/datastore/drizzle-orm/schema'
@@ -43,7 +44,7 @@ function backoffDelayMs(attempt: number): number {
 
 async function fetchRssFeedOnce<T>(url: string): Promise<Result<T[], Error>> {
   const responseResult = await wrapAsyncCall(() =>
-    fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) }),
+    fetchWithTimeout(url, { timeoutMs: FETCH_TIMEOUT_MS }),
   )
   if (responseResult.isErr()) return err(responseResult.error)
 

--- a/application/packages/notification/src/discord.ts
+++ b/application/packages/notification/src/discord.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_FETCH_TIMEOUT_MS, fetchWithTimeout } from '@trend-diary/common/http'
 import type { LoggerType } from '@trend-diary/common/logger'
 
 export interface DiscordEmbedField {
@@ -26,7 +27,6 @@ export interface DiscordWebhookClientOptions {
 
 const DEFAULT_MAX_RETRIES = 3
 const DEFAULT_BASE_DELAY_MS = 200
-const DEFAULT_TIMEOUT_MS = 5000
 
 /**
  * Discord Webhook への汎用送信クライアント。
@@ -51,7 +51,7 @@ export class DiscordWebhookClient {
     this.logger = logger
     this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES
     this.baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS
-    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS
   }
 
   async send(payload: DiscordWebhookPayload): Promise<void> {
@@ -65,17 +65,15 @@ export class DiscordWebhookClient {
     let attempts = 0
     for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
       attempts = attempt
-      // 応答が遅い相手で処理がハングするのを防ぐ（Workers の実行時間制限対策）
-      const controller = new AbortController()
-      const timeoutId = setTimeout(() => controller.abort(), this.timeoutMs)
       try {
-        const response = await fetch(this.webhookUrl, {
+        // 応答が遅い相手で処理がハングするのを防ぐ（Workers の実行時間制限対策）
+        const response = await fetchWithTimeout(this.webhookUrl, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify(payload),
-          signal: controller.signal,
+          timeoutMs: this.timeoutMs,
         })
 
         if (response.ok) return
@@ -90,8 +88,6 @@ export class DiscordWebhookClient {
           notificationError instanceof Error
             ? notificationError
             : new Error(String(notificationError))
-      } finally {
-        clearTimeout(timeoutId)
       }
 
       if (attempt < this.maxRetries) {

--- a/application/packages/web/src/client/infrastructure/create-swr-fetcher.test.ts
+++ b/application/packages/web/src/client/infrastructure/create-swr-fetcher.test.ts
@@ -28,9 +28,14 @@ describe('createSWRFetcher', () => {
       const { fetcher } = createSWRFetcher()
       const result = await fetcher('http://example.com/api')
 
-      expect(fetch).toHaveBeenCalledWith('http://example.com/api', {
-        credentials: 'include',
-      })
+      expect(fetch).toHaveBeenCalledWith(
+        'http://example.com/api',
+        expect.objectContaining({
+          credentials: 'include',
+          // ハング防止のためタイムアウトsignalを付与している
+          signal: expect.any(AbortSignal),
+        }),
+      )
       expect(result).toEqual({ data: 'test' })
     })
 

--- a/application/packages/web/src/client/infrastructure/create-swr-fetcher.ts
+++ b/application/packages/web/src/client/infrastructure/create-swr-fetcher.ts
@@ -1,4 +1,5 @@
 import { ClientError, ServerError } from '@trend-diary/common/errors'
+import { fetchWithTimeout } from '@trend-diary/common/http'
 import getApiClientForClient from '@/client/infrastructure/api'
 
 interface ApiCallResponse {
@@ -15,7 +16,8 @@ export const createSWRFetcher = () => {
   const client = getApiClientForClient()
 
   const fetcher = async <T>(url: string): Promise<T> => {
-    const response = await fetch(url, {
+    // 応答が遅い相手で画面がハングするのを防ぐ
+    const response = await fetchWithTimeout(url, {
       credentials: 'include',
     })
 


### PR DESCRIPTION
## 概要

Closes #760

外部 `fetch` 呼び出しのタイムアウト処理がサービス内で不統一だった問題を解消するため、タイムアウト付き `fetch` ラッパ `fetchWithTimeout` を `@trend-diary/common/http` に追加し、各所の外部 `fetch` 呼び出しを移行しました。

## 背景・課題

#731 / #758 で `DiscordWebhookClient` に `AbortController` + `setTimeout` の独自タイムアウト処理を実装しましたが、

- 同様のボイラープレートが各所にコピーされる懸念
- タイムアウト未設定の経路（SWR fetcher / cron RSS 取得）がハングするリスク（特に cron は Workers の実行時間制限に直結）
- タイムアウト値・`AbortError` 時の挙動が呼び出し元ごとに分散

という問題がありました。

## 変更内容

### 追加: `@trend-diary/common/http`

- `fetchWithTimeout(input, init)` — `AbortSignal.timeout` でタイムアウトを付与する `fetch` ラッパ
  - 呼び出し元が渡した `signal` とタイムアウト `signal` を `AbortSignal.any` で合成し、両方の中断を尊重
- `DEFAULT_FETCH_TIMEOUT_MS`（5000ms）— 既定タイムアウト値を共通化

### 移行（送信側 fetch のタイムアウト統一）

| 箇所 | 変更前 | 変更後 |
|------|------|------|
| `notification/src/discord.ts` | `AbortController` + `setTimeout` の独自実装 | `fetchWithTimeout` / 既定値も `DEFAULT_FETCH_TIMEOUT_MS` に統一 |
| `cron/src/fetch-articles.ts` | `fetch(url, { signal: AbortSignal.timeout(...) })` | `fetchWithTimeout(url, { timeoutMs })` |
| `web/.../create-swr-fetcher.ts` | タイムアウト**なし** | `fetchWithTimeout` でタイムアウト付与 |

## スコープ

- 本 PR は #760 の方針どおり**送信側 `fetch` のタイムアウト統一**にフォーカスしています。リトライ（exponential backoff）の共通化は別途検討とし、本 PR では既存の各リトライ実装を維持しています。
- 受信側（Hono の `timeout`）は対象外です。

## テスト

- `@trend-diary/common`・`@trend-diary/notification`・`@trend-diary/cron`・`create-swr-fetcher.test.ts` の各テストが通過することを確認済み
- `http/index.test.ts` を新規追加（タイムアウト中断・呼び出し元 signal の尊重・既定値の公開などを検証）

> [!NOTE]
> `web` パッケージの typecheck エラー（`auth-action-use-case.ts` / `signup.ts`）および一部の vitest browser テスト失敗（Playwright ブラウザ未インストール）は本変更前から存在する既存の事象で、本 PR とは無関係です。

https://claude.ai/code/session_01XRNKbP6JXABtNAS8uemEvQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRNKbP6JXABtNAS8uemEvQ)_