### PR TITLE
refactor(web): AnchorLink の内部リンク処理を href で簡略化

### DIFF
--- a/application/packages/web/src/client/components/ui/navigation/link/index.tsx
+++ b/application/packages/web/src/client/components/ui/navigation/link/index.tsx
@@ -1,5 +1,5 @@
 import type { ComponentPropsWithoutRef, PropsWithChildren } from 'react'
-import { Link } from 'react-router'
+import { href, Link } from 'react-router'
 import { Button } from '@/client/components/shadcn/button'
 import { InternalPath } from '@/client/routes'
 
@@ -15,18 +15,6 @@ function ExternalLink({ to, children, ...props }: PropsWithChildren<ExternalLink
     <a href={to} target='_blank' rel='noopener noreferrer nofollow' {...props}>
       {children}
     </a>
-  )
-}
-
-interface InternalLinkProps extends Omit<ComponentPropsWithoutRef<typeof Link>, 'to'> {
-  to: InternalPath
-}
-
-function InternalLink({ to, children, ...props }: PropsWithChildren<InternalLinkProps>) {
-  return (
-    <Link to={to} {...props}>
-      {children}
-    </Link>
   )
 }
 
@@ -54,9 +42,9 @@ export function AnchorLink({ to, children, ...props }: AnchorLinkProps) {
       {children}
     </ExternalLink>
   ) : (
-    <InternalLink to={to} {...props}>
+    <Link to={href(to)} {...props}>
       {children}
-    </InternalLink>
+    </Link>
   )
 }
 

--- a/application/packages/web/src/client/routes.ts
+++ b/application/packages/web/src/client/routes.ts
@@ -6,6 +6,7 @@ import {
   RouteConfigEntry,
   route,
 } from '@react-router/dev/routes'
+import { href } from 'react-router'
 
 const PATH_INDEX = '/'
 
@@ -57,58 +58,9 @@ const routing: RouteConfig = groupRoutes.flatMap(buildGroupRoute)
 export default routing
 
 /**
- * CombinePrefix<P, Path>
- *
- * グループの prefix (P) とルートの path (Path) を結合して
- * 実際のパス文字列リテラルを生成するユーティリティ型。
- *
- * 型の振る舞い:
- * - Path が '/' の場合（インデックスルート）
- *   - P === '' -> '/'
- *   - P !== '' -> `/${P}` (末尾スラッシュなし)
- *
- * - Path が '/<Rest>' の場合
- *   - P === '' -> `/${Rest}`
- *   - P !== '' -> `/${P}/${Rest}`
- *
- * - それ以外の形式の Path は `never` を返す（未想定のパターン）
- *
- * 注意:
- * - `groupRoutes` の値は `as const` にしてリテラル型を保持すること。
- * - `prefix` および `path` は文字列リテラルとして評価される必要がある。
- *
- * @template P グループの prefix（例: 'admin' または ''）
- * @template Path ルートの path（例: '/' または '/users'）
- */
-type CombinePrefix<P extends string, Path extends string> = Path extends '/'
-  ? P extends ''
-    ? '/'
-    : `/${P}`
-  : Path extends `/${infer Rest}`
-    ? P extends ''
-      ? `/${Rest}`
-      : `/${P}/${Rest}`
-    : never
-
-/**
- * Paths<T>
- *
- * groupRoutes の型から全てのパス文字列リテラルのユニオンを生成する型。
- * ジェネリックは明示的に `GroupRoute` 配列を受け取るようにして、
- * `any` による曖昧なケースを排除する。
- *
- * @template T groupRoutes のリテラル配列型（readonly GroupRoute[]）
- */
-type Paths<T extends readonly GroupRoute[]> = T[number] extends infer Item
-  ? Item extends GroupRoute
-    ? CombinePrefix<Item['prefix'], Item['routes'][number]['path']>
-    : never
-  : never
-
-/**
  * InternalPath
  *
- * 実際にアプリケーションで使用されるパスのユニオン型。
- * `groupRoutes` を `as const` のまま保持していることで具体的なリテラルが推論される。
+ * アプリケーションで使用される内部パスのユニオン型。
+ * React Router の href ヘルパーの引数型（型生成されたルート定義が正）から導出する。
  */
-export type InternalPath = Paths<typeof groupRoutes>
+export type InternalPath = Parameters<typeof href>[0]


### PR DESCRIPTION
## 概要

Issue #770 の対応です。`AnchorLink` の内部リンク処理を React Router の [`href`](https://reactrouter.com/api/utils/href) ヘルパーで簡略化しました。

## 変更内容

- 薄いラッパだった `InternalLink` コンポーネントと `InternalLinkProps` 型を削除
- `AnchorLink` の内部リンク分岐で `<Link to={href(to)}>` を直接使用し、React Router の `href` で型安全にパスを生成

`href` の引数型（`keyof Register["pages"]`）は、`routes.ts` で定義している `InternalPath` と同一のパスリテラル集合のため、既存の型・公開 API を変えずに導入できました。

## 受け入れ条件

- [x] 内部リンクの実装が簡略化される（`InternalLink` ラッパと型を削減）
- [x] 内部リンクの SPA 遷移挙動が維持される（`<Link>` を維持）
- [x] `AnchorLink` / `LinkAsButton` の利用側に破壊的変更がない（`to` プロパティ不変）
- [x] `pnpm lint`（typecheck・biome）/ 既存テストが通る

Closes #770

https://claude.ai/code/session_01VryLZyn6e4MRRyEcyyEKeo

---
_Generated by [Claude Code](https://claude.ai/code/session_01VryLZyn6e4MRRyEcyyEKeo)_