### PR TITLE
fix(web): read記事ハンドラを従来パターン化し as any を解消 (#736)

### DIFF
--- a/application/packages/web/src/client/routes/trends._index/hooks/use-read-article.ts
+++ b/application/packages/web/src/client/routes/trends._index/hooks/use-read-article.ts
@@ -14,9 +14,7 @@ export default function useReadArticle() {
 
     const result = await wrapAsyncCall(async () => {
       const client = getApiClientForClient()
-      // biome-ignore lint/suspicious/noExplicitAny: Hono client の型定義が param と json の同時指定に対応していない
-      // biome-ignore lint/plugin: 上記 Hono client の型制約を回避するためのアサーションで、静的型では表現できないため許可する
-      const res = await (client.articles[':article_id'].read.$post as any)(
+      const res = await client.articles[':article_id'].read.$post(
         {
           param: { article_id: articleId },
           json: { read_at: new Date().toISOString() },

--- a/application/packages/web/src/middleware/zod-validator.ts
+++ b/application/packages/web/src/middleware/zod-validator.ts
@@ -49,17 +49,23 @@ export type ZodValidatedParamContext<T, P extends string = ''> = ZodValidatedCon
   P
 >
 
-export type ZodValidatedParamJsonContext<ParamType, JsonType, P extends string = ''> = Context<
+// param は transform でリクエスト時の型（z.input）と検証後の型（z.output）が異なりうるため、
+// Hono client の RPC 型推論にはスキーマから in / out を別々に導く必要がある
+export type ZodValidatedParamJsonContext<
+  ParamSchema extends ZodSchema,
+  JsonSchema extends ZodSchema,
+  P extends string = '',
+> = Context<
   Env,
   P,
   {
     in: {
-      param: ParamType
-      json: JsonType
+      param: z.input<ParamSchema>
+      json: z.input<JsonSchema>
     }
     out: {
-      param: ParamType
-      json: JsonType
+      param: z.output<ParamSchema>
+      json: z.output<JsonSchema>
     }
   }
 >

--- a/application/packages/web/src/server/article/handler/read-article.ts
+++ b/application/packages/web/src/server/article/handler/read-article.ts
@@ -1,9 +1,9 @@
+import { handleError } from '@trend-diary/common/errors'
+import getRdbClient from '@trend-diary/datastore/rdb'
 import { createArticleUseCase } from '@trend-diary/domain/article'
 import { z } from 'zod'
-import {
-  type AuthenticatedRequestContext,
-  createAuthenticatedApiHandler,
-} from '@/server/handler/factory'
+import CONTEXT_KEY from '@/middleware/context'
+import { ZodValidatedParamJsonContext } from '@/middleware/zod-validator'
 
 // API用スキーマ
 export const createReadHistoryApiSchema = z.object({
@@ -18,26 +18,31 @@ export const articleIdParamSchema = z.object({
     .transform((val) => BigInt(val)),
 })
 
-export type CreateReadHistoryApiInput = z.input<typeof createReadHistoryApiSchema>
 export type ArticleIdParam = z.output<typeof articleIdParamSchema>
 
-export default createAuthenticatedApiHandler({
-  createUseCase: createArticleUseCase,
-  execute: async (
-    useCase,
-    context: AuthenticatedRequestContext<ArticleIdParam, CreateReadHistoryApiInput>,
-  ) => {
-    return useCase.createReadHistory(
-      context.user.activeUserId,
-      context.param.article_id,
-      new Date(context.json.read_at),
-    )
-  },
-  transform: () => ({ message: '記事を既読にしました' }),
-  logMessage: 'Read history created successfully',
-  logPayload: (_result, context) => ({
-    activeUserId: context.user.activeUserId,
-    articleId: context.param.article_id,
-  }),
-  statusCode: 201,
-})
+// param + json の同時指定ではファクトリーの戻り値型を Hono client が解決できず json が欠落するため、
+// 従来パターンで検証済みコンテキストを明示し、c.json の TypedResponse で RPC 型推論を保つ
+export default async function readArticle(
+  c: ZodValidatedParamJsonContext<typeof articleIdParamSchema, typeof createReadHistoryApiSchema>,
+) {
+  const logger = c.get(CONTEXT_KEY.APP_LOG)
+  const user = c.get(CONTEXT_KEY.SESSION_USER)
+  const { article_id } = c.req.valid('param')
+  const { read_at } = c.req.valid('json')
+
+  const rdb = getRdbClient(c.env.DB)
+  const useCase = createArticleUseCase(rdb)
+
+  const result = await useCase.createReadHistory(user.activeUserId, article_id, new Date(read_at))
+  if (result.isErr()) {
+    throw handleError(result.error, logger)
+  }
+
+  logger.info({
+    msg: 'Read history created successfully',
+    activeUserId: user.activeUserId,
+    articleId: article_id,
+  })
+
+  return c.json({ message: '記事を既読にしました' }, 201)
+}


### PR DESCRIPTION
## 概要

#736 で追跡していた `as any` キャスト（`use-read-article.ts`）を解消します。

Issue では「Hono のバージョンアップ待ち」とされていましたが、調査の結果 **現行 Hono 4.12.23 のまま、コードベースが既にドキュメント化している従来パターンで解消可能**だと分かったため対応しました。

## 原因

`as any` が必要だった原因は次の2点でした。

1. **ファクトリーパターンが検証スキーマの型を消していた**
   `readArticle` は `createAuthenticatedApiHandler` 経由で生成され、戻り値型が `(c: Context<Env>) => Promise<Response>` に潰れます。これにより RPC クライアントは `param` しか見えず `json` が欠落し、`'json' does not exist in type '{ param: {...} }'` になります。`factory.ts` の docstring 自体が、この制限と従来パターン（`ZodValidatedParamJsonContext`）での回避を明記していますが、`read` だけはファクトリー＋`as any` のままでした。

2. **`ZodValidatedParamJsonContext` が `in`/`out` を同一型にしていた**
   `articleIdParamSchema` が `.transform(BigInt)` するため、リクエスト入力（`string`）と検証後の出力（`bigint`）が衝突し、従来パターンに変えても `string` is not assignable to `bigint` が発生します。

## 変更内容

- `read-article.ts`: ファクトリー生成から従来パターン（`ZodValidatedParamJsonContext` を受け取り `c.json(..., 201)` を返す）へ変換。挙動（201 / 422 / 404、認可）は維持。
- `zod-validator.ts`: `ZodValidatedParamJsonContext` を Zod スキーマから `in`(`z.input`)/`out`(`z.output`) を分離して導く形に修正。transform による入力/出力の型差を表現できるようにした。
- `use-read-article.ts`: `as any` と `biome-ignore` を削除。
- 未使用になった `CreateReadHistoryApiInput` 型を削除。

`unread` の `$delete`（param 単独）は従来どおりファクトリーで型が通るため対象外です。テストファイル側のモック用 `as any` はモック簡略化のための別件であり、本 PR の対象外としています。

## 確認

- `pnpm -r typecheck`: 全パッケージ green
- `biome ci src`（web）: green
- `use-read-article.test.ts`（client hook）: 4 passed
- `read-article.test.ts` のスキーマ単体テスト: 6 passed
  - ※ 同ファイルの統合テスト（`app.request`）は Supabase Auth / D1 を要し、本サンドボックスでは起動できないため未実行（既存コードでも同様に失敗する環境要因）

refs #736

https://claude.ai/code/session_01FhpBe59ADJteAhPqMPBpMY

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhpBe59ADJteAhPqMPBpMY)_