### PR TITLE
fix(datastore): Drizzleクエリログのparams文字列をマスクしPII流出を防ぐ

### DIFF
--- a/application/packages/datastore/src/rdb/logger.ts
+++ b/application/packages/datastore/src/rdb/logger.ts
@@ -1,5 +1,6 @@
 import AppLogger, { type LogLevel } from '@trend-diary/common/logger'
 import type { Logger as DrizzleLogger } from 'drizzle-orm'
+import { maskQueryParams } from './mask'
 
 const VALID_LOG_LEVELS: ReadonlyArray<LogLevel> = [
   'trace',
@@ -32,11 +33,12 @@ function getDrizzleLogger(): AppLogger {
   return drizzleLogger
 }
 
-// クエリの params には email 等の PII が含まれ得るため、出力ゲートを AppLogger(pino) の
-// レベルフィルタに委譲し、debug ログは LOG_LEVEL=debug/trace のときだけ実出力させる。
+// クエリの params には email 等の PII が含まれ得るため、(1)出力ゲートを AppLogger(pino) の
+// レベルフィルタに委譲して debug ログを LOG_LEVEL=debug/trace のときだけ実出力させ、
+// (2)さらに文字列の bind 値をマスクして、debug 出力時にも PII がログ基盤へ流出しないようにする。
 class DrizzleQueryLogger implements DrizzleLogger {
   logQuery(query: string, params: unknown[]): void {
-    getDrizzleLogger().debug({ msg: 'drizzle query', query, params })
+    getDrizzleLogger().debug({ msg: 'drizzle query', query, params: maskQueryParams(params) })
   }
 }
 

--- a/application/packages/datastore/src/rdb/mask.test.ts
+++ b/application/packages/datastore/src/rdb/mask.test.ts
@@ -29,5 +29,12 @@ describe('maskQueryParams', () => {
     it('空文字列もマスクすること', () => {
       expect(maskQueryParams([''])).toEqual(['***'])
     })
+
+    it('ネストされた配列内の文字列も再帰的にマスクすること', () => {
+      expect(maskQueryParams([['user@example.com', 123], 'normal-string'])).toEqual([
+        ['***', 123],
+        '***',
+      ])
+    })
   })
 })

--- a/application/packages/datastore/src/rdb/mask.test.ts
+++ b/application/packages/datastore/src/rdb/mask.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { maskQueryParams } from './mask'
+
+describe('maskQueryParams', () => {
+  describe('正常系', () => {
+    it('文字列の bind 値(email等のPII)をマスクすること', () => {
+      expect(maskQueryParams(['user@example.com'])).toEqual(['***'])
+    })
+
+    it('非PIIの数値・真偽値・nullは調査用に残すこと', () => {
+      expect(maskQueryParams([1, 2n, true, false, null])).toEqual([1, 2n, true, false, null])
+    })
+
+    it('文字列のみをマスクし、その他の型は残すこと', () => {
+      expect(maskQueryParams(['user@example.com', 123, '表示名', null])).toEqual([
+        '***',
+        123,
+        '***',
+        null,
+      ])
+    })
+  })
+
+  describe('準正常系（境界値）', () => {
+    it('空配列を空配列のまま返すこと', () => {
+      expect(maskQueryParams([])).toEqual([])
+    })
+
+    it('空文字列もマスクすること', () => {
+      expect(maskQueryParams([''])).toEqual(['***'])
+    })
+  })
+})

--- a/application/packages/datastore/src/rdb/mask.test.ts
+++ b/application/packages/datastore/src/rdb/mask.test.ts
@@ -2,39 +2,30 @@ import { describe, expect, it } from 'vitest'
 import { maskQueryParams } from './mask'
 
 describe('maskQueryParams', () => {
-  describe('正常系', () => {
-    it('文字列の bind 値(email等のPII)をマスクすること', () => {
-      expect(maskQueryParams(['user@example.com'])).toEqual(['***'])
-    })
-
-    it('非PIIの数値・真偽値・nullは調査用に残すこと', () => {
-      expect(maskQueryParams([1, 2n, true, false, null])).toEqual([1, 2n, true, false, null])
-    })
-
-    it('文字列のみをマスクし、その他の型は残すこと', () => {
-      expect(maskQueryParams(['user@example.com', 123, '表示名', null])).toEqual([
-        '***',
-        123,
-        '***',
-        null,
-      ])
-    })
-  })
-
-  describe('準正常系（境界値）', () => {
-    it('空配列を空配列のまま返すこと', () => {
-      expect(maskQueryParams([])).toEqual([])
-    })
-
-    it('空文字列もマスクすること', () => {
-      expect(maskQueryParams([''])).toEqual(['***'])
-    })
-
-    it('ネストされた配列内の文字列も再帰的にマスクすること', () => {
-      expect(maskQueryParams([['user@example.com', 123], 'normal-string'])).toEqual([
-        ['***', 123],
-        '***',
-      ])
-    })
+  it.each([
+    {
+      name: '文字列の bind 値(email等のPII)をマスクする',
+      input: ['user@example.com'],
+      expected: ['***'],
+    },
+    {
+      name: '非PIIの数値・真偽値・nullは調査用に残す',
+      input: [1, 2n, true, false, null],
+      expected: [1, 2n, true, false, null],
+    },
+    {
+      name: '文字列のみをマスクし、その他の型は残す',
+      input: ['user@example.com', 123, '表示名', null],
+      expected: ['***', 123, '***', null],
+    },
+    { name: '空配列を空配列のまま返す', input: [], expected: [] },
+    { name: '空文字列もマスクする', input: [''], expected: ['***'] },
+    {
+      name: 'ネストされた配列内の文字列も再帰的にマスクする',
+      input: [['user@example.com', 123], 'normal-string'],
+      expected: [['***', 123], '***'],
+    },
+  ])('$name', ({ input, expected }) => {
+    expect(maskQueryParams(input)).toEqual(expected)
   })
 })

--- a/application/packages/datastore/src/rdb/mask.ts
+++ b/application/packages/datastore/src/rdb/mask.ts
@@ -1,0 +1,9 @@
+const MASKED = '***'
+
+// Drizzle の logQuery はカラム情報を持たない順序付き params のみを渡すため、
+// どの値が PII(email / display_name 等の text 列)かを判別できない。
+// よって文字列の bind 値は一律マスクし、ID やタイムスタンプ等の非 PII
+// （number / bigint / boolean / null）はクエリ調査に有用なため残す。
+export function maskQueryParams(params: unknown[]): unknown[] {
+  return params.map((param) => (typeof param === 'string' ? MASKED : param))
+}

--- a/application/packages/datastore/src/rdb/mask.ts
+++ b/application/packages/datastore/src/rdb/mask.ts
@@ -4,6 +4,18 @@ const MASKED = '***'
 // どの値が PII(email / display_name 等の text 列)かを判別できない。
 // よって文字列の bind 値は一律マスクし、ID やタイムスタンプ等の非 PII
 // （number / bigint / boolean / null）はクエリ調査に有用なため残す。
+// 配列要素(例: IN 句や PostgreSQL 配列カラム)の中に文字列が含まれる場合も
+// PII を取りこぼさないよう、ネストした配列は再帰的にマスクする。
 export function maskQueryParams(params: unknown[]): unknown[] {
-  return params.map((param) => (typeof param === 'string' ? MASKED : param))
+  const mask = (value: unknown): unknown => {
+    if (typeof value === 'string') {
+      return MASKED
+    }
+    if (Array.isArray(value)) {
+      return value.map(mask)
+    }
+    return value
+  }
+
+  return params.map(mask)
 }


### PR DESCRIPTION
## 概要

Closes #775

セキュリティレビュー指摘事項への対応です。`LOG_LEVEL=debug/trace` 時に Drizzle のクエリ params がそのままログ出力され、email / display_name 等の PII がログ基盤へ流出しうる問題を修正します。

## 対応内容（Issue 対応案の 1 を採用）

`logQuery(query, params)` はカラム情報を持たない順序付き params 配列のみを渡すため、どの値が PII 列（`active_users.email` / `display_name`、いずれも `text`）かを判別できません。よって以下の方針でマスクします。

- **文字列の bind 値は一律 `***` にマスク**（email / display_name 等の PII テキストを確実に除去）
- **number / bigint / boolean / null 等の非 PII は調査用に残す**（ID・timestamp 等）

これにより、既存の「出力ゲートを pino のレベルフィルタへ委譲」する防御に加え、万一 `LOG_LEVEL=debug` へ変更しても PII がログ出力されなくなります。クエリ構造（SQL 文字列）と params の位置・型は維持されるため、デバッグ用途は概ね保てます。

## 変更ファイル

- `packages/datastore/src/rdb/mask.ts` — `maskQueryParams` を追加
- `packages/datastore/src/rdb/logger.ts` — `logQuery` でマスクを適用
- `packages/datastore/src/rdb/mask.test.ts` — テスト追加

## 確認

- [x] `pnpm --filter @trend-diary/datastore test`（23 passed）
- [x] `pnpm --filter @trend-diary/datastore typecheck`
- [x] `pnpm check:fix`（biome）


---
_Generated by [Claude Code](https://claude.ai/code/session_01KLP6Tp7ipWwVHE6F1UJHZp)_