### PR TITLE
fix(ci): E2EでTurnstileテスト用sitekeyを使いCI失敗を修正する

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -227,6 +227,8 @@ jobs:
           DISCORD_WEBHOOK_URL=${{ secrets.DISCORD_WEBHOOK_URL || '' }}
           SUPABASE_URL=${{ env.SUPABASE_URL || 'http://127.0.0.1:54321' }}
           SUPABASE_ANON_KEY=${{ env.SUPABASE_ANON_KEY || '' }}
+          # wrangler.tomlの本番sitekeyはlocalhost/ヘッドレスで解けずトークンが得られないため、常にpassするテスト用sitekeyで上書きする
+          TURNSTILE_SITE_KEY=1x00000000000000000000AA
           EOF
 
       - name: E2Eテストの実行
@@ -275,6 +277,8 @@ jobs:
           DISCORD_WEBHOOK_URL=${{ secrets.DISCORD_WEBHOOK_URL || '' }}
           SUPABASE_URL=${{ env.SUPABASE_URL || 'http://127.0.0.1:54321' }}
           SUPABASE_ANON_KEY=${{ env.SUPABASE_ANON_KEY || '' }}
+          # wrangler.tomlの本番sitekeyはlocalhost/ヘッドレスで解けずトークンが得られないため、常にpassするテスト用sitekeyで上書きする
+          TURNSTILE_SITE_KEY=1x00000000000000000000AA
           EOF
 
       - name: E2Eテストの差分実行


### PR DESCRIPTION
## 概要

`main` の CI（E2E ジョブ）が失敗していたため修正します。

## 原因

PR #779（Turnstile 導入）のマージ後、`main` の E2E `signup-basic.test.ts` が「ログイン後にトレンド記事の詳細を開ける」で `page.waitForURL` タイムアウトにより失敗していました。

- `wrangler.toml` の `[vars]` に**本番の** `TURNSTILE_SITE_KEY`（`0x4AAAAAAD...`）がコミットされている
- E2E は `wrangler dev` で配信するため、この本番 sitekey が読み込まれる
- CI の `.dev.vars` は Supabase/Discord のみ上書きしており、Turnstile sitekey を上書きしていなかった
- 本番 sitekey は `localhost`/ヘッドレスでは解けず `cf-turnstile-response` トークンが得られない
- その結果、サインアップの action ガード（`signup/route.tsx`）が `captchaRequired` を返して `/login` へリダイレクトせず、テストがタイムアウト

PR #779 自体の CI が緑だったのは、PR の E2E が `--only-changed` で実行され、変更のない `signup-basic.test.ts` が走らなかったためです。フル E2E は `main` マージ時のみ実行されます。

## 修正

CI の `.dev.vars`（E2E / E2E(Diff) の両方）に、常に pass する Cloudflare のテスト用 sitekey `1x00000000000000000000AA` を追加し、`wrangler.toml` の本番値を上書きします。`.dev.vars.example` に記載済みの想定どおりの方法です。

- `TURNSTILE_SECRET_KEY` は未設定のままなのでサーバー側検証はスキップされ（`TurnstileCaptchaVerifier` は secret 未設定時に許可）、ウィジェットが注入するダミートークンでサインアップが正常にリダイレクトします。

https://claude.ai/code/session_014Ac7gzfTN6YCJfLajH7GZM

---
_Generated by [Claude Code](https://claude.ai/code/session_014Ac7gzfTN6YCJfLajH7GZM)_