### PR TITLE
refactor(web): 認証エラーメッセージ解決をswitch文に置き換える

### DIFF
--- a/application/packages/web/src/client/features/authenticate/error-message.ts
+++ b/application/packages/web/src/client/features/authenticate/error-message.ts
@@ -17,38 +17,33 @@ const getStatusCode = (error: unknown): number | null => {
 
 export const resolveLoginErrorMessage = (error: unknown): string => {
   const statusCode = getStatusCode(error)
-  if (statusCode === 401 || statusCode === 404) {
-    return INVALID_LOGIN_CREDENTIALS_ERROR_MESSAGE
+  switch (statusCode) {
+    case 401:
+    case 404:
+      return INVALID_LOGIN_CREDENTIALS_ERROR_MESSAGE
+    // CAPTCHA検証失敗はサーバーが403で返す
+    case 403:
+      return CAPTCHA_REQUIRED_ERROR_MESSAGE
+    case 500:
+      return AUTH_SERVER_ERROR_MESSAGE
+    default:
+      return UNEXPECTED_AUTH_ERROR_MESSAGE
   }
-
-  // CAPTCHA検証失敗はサーバーが403で返す
-  if (statusCode === 403) {
-    return CAPTCHA_REQUIRED_ERROR_MESSAGE
-  }
-
-  if (statusCode === 500) {
-    return AUTH_SERVER_ERROR_MESSAGE
-  }
-
-  return UNEXPECTED_AUTH_ERROR_MESSAGE
 }
 
 export const resolveSignupErrorMessage = (error: unknown): string => {
   const statusCode = getStatusCode(error)
-  if (statusCode === 409) {
-    return SIGNUP_ALREADY_EXISTS_ERROR_MESSAGE
+  switch (statusCode) {
+    case 409:
+      return SIGNUP_ALREADY_EXISTS_ERROR_MESSAGE
+    // CAPTCHA検証失敗はサーバーが403で返す
+    case 403:
+      return CAPTCHA_REQUIRED_ERROR_MESSAGE
+    case 500:
+      return AUTH_SERVER_ERROR_MESSAGE
+    default:
+      return UNEXPECTED_AUTH_ERROR_MESSAGE
   }
-
-  // CAPTCHA検証失敗はサーバーが403で返す
-  if (statusCode === 403) {
-    return CAPTCHA_REQUIRED_ERROR_MESSAGE
-  }
-
-  if (statusCode === 500) {
-    return AUTH_SERVER_ERROR_MESSAGE
-  }
-
-  return UNEXPECTED_AUTH_ERROR_MESSAGE
 }
 
 export const AUTH_ERROR_MESSAGES = {


### PR DESCRIPTION
main ベースで作成したため取り下げます。switch化のリファクタは #788 のブランチ（`claude/architecture-review-ghq2ey`）へ直接コミット済みです。

https://claude.ai/code/session_01VKxbExkRPBZfmdo79hm4u6