### PR TITLE
ci: SupabaseのDockerイメージをキャッシュしてE2Eを高速化

### DIFF
--- a/.github/actions/setup_supabase/action.yaml
+++ b/.github/actions/setup_supabase/action.yaml
@@ -1,11 +1,34 @@
 name: Setup Supabase Composite Action
 description: 'SupabaseをセットアップするComposite Action'
 
+inputs:
+  cli-version:
+    description: 'pinするSupabase CLIのバージョン（Dockerイメージのtagもこれで決まるためキャッシュキーにもなるよう単一の真実源として扱う）'
+    required: false
+    default: '2.105.0'
+
 runs:
   using: 'composite'
   steps:
     - name: Supabase CLIのセットアップ
+      # versionをpinしないとlatestが浮動で入りDockerイメージのtagも変わってキャッシュが安定しないため明示的に固定する
       uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1
+      with:
+        version: ${{ inputs.cli-version }}
+
+    - name: Dockerイメージキャッシュの復元
+      id: image-cache
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ~/.cache/supabase-docker-images.tar
+        # CLIバージョンが同じならtagも同一でリポジトリ全体（mainのキャッシュ）を共有できるため、ブランチ非依存の静的キーにする
+        key: supabase-docker-images-${{ runner.os }}-${{ inputs.cli-version }}
+
+    - name: キャッシュ済みDockerイメージの読み込み
+      # ヒット時はここで読み込んでおくとsupabase startがECRからpullせず起動が速くなる
+      if: steps.image-cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: docker load -i ~/.cache/supabase-docker-images.tar
 
     - name: Supabaseの起動
       shell: bash
@@ -13,6 +36,21 @@ runs:
       # INFO: 認証のみ起動
       # link: https://supabase.com/docs/reference/cli/supabase-start
       run: supabase start -x realtime,storage-api,imgproxy,mailpit,postgrest,postgres-meta,studio,edge-runtime,logflare,vector,supavisor
+
+    - name: Dockerイメージキャッシュの保存
+      # ミス時のみtarを書き出す。actions/cacheのpostステップがこのtarをアップロードする
+      if: steps.image-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p ~/.cache
+        images="$(docker images --filter 'reference=public.ecr.aws/supabase/*' --format '{{.Repository}}:{{.Tag}}')"
+        if [[ -z "$images" ]]; then
+          echo "::warning::キャッシュ対象のSupabaseイメージが見つかりませんでした"
+          exit 0
+        fi
+        # shellcheck disable=SC2086
+        docker save $images -o ~/.cache/supabase-docker-images.tar
 
     - name: Supabaseのキーを環境変数に設定
       id: get-keys

--- a/.github/actions/setup_supabase/action.yaml
+++ b/.github/actions/setup_supabase/action.yaml
@@ -44,13 +44,12 @@ runs:
       run: |
         set -euo pipefail
         mkdir -p ~/.cache
-        images="$(docker images --filter 'reference=public.ecr.aws/supabase/*' --format '{{.Repository}}:{{.Tag}}')"
-        if [[ -z "$images" ]]; then
+        mapfile -t images < <(docker images --filter 'reference=public.ecr.aws/supabase/*' --format '{{.Repository}}:{{.Tag}}')
+        if [[ ${#images[@]} -eq 0 ]]; then
           echo "::warning::キャッシュ対象のSupabaseイメージが見つかりませんでした"
           exit 0
         fi
-        # shellcheck disable=SC2086
-        docker save $images -o ~/.cache/supabase-docker-images.tar
+        docker save -o ~/.cache/supabase-docker-images.tar "${images[@]}"
 
     - name: Supabaseのキーを環境変数に設定
       id: get-keys


### PR DESCRIPTION
## 概要

E2E（`e2e` / `e2e-diff`）で使う `setup_supabase` composite action のボトルネックは `supabase start` 時の Docker イメージ pull でした。毎回 `public.ecr.aws/supabase/*`（postgres / auth(gotrue) / kong）を ECR から取得しており、遅く・たまに ECR 詰まりで不安定でした。

イメージ tar を `actions/cache` に載せて再利用することで、起動を高速化＆安定化します。

## 変更点

- `supabase/setup-cli` の `version` を `2.105.0` に明示 pin
  - 未指定だと latest が浮動で入り、Docker イメージの tag も変わってキャッシュが安定しないため
  - バージョンを `cli-version` 入力（デフォルト `2.105.0`）に集約し、**setup-cli の version 指定**と**キャッシュキー**の単一の真実源にした
- `supabase start` 前後で Docker イメージをキャッシュ
  - 復元 → ヒット時は `docker load`（ECR pull を回避）
  - ミス時のみ `docker save` で tar 化し、`actions/cache` の post ステップでアップロード

## キャッシュ共有の仕組み

キャッシュキーは `supabase-docker-images-${runner.os}-${cli-version}` のブランチ非依存な静的キー。GitHub Actions のキャッシュは default ブランチ（main）で作成したものを全ブランチ/PR から復元できるため、main の push で走る `e2e` ジョブがキャッシュを populate すれば、各 PR の `e2e-diff` で共有できます（リポジトリ全体で 1 つを使い回し）。

CLI バージョンを上げる際は `cli-version` を更新すればキーが変わり、自動でキャッシュが貼り直されます。

## 確認

- [ ] main で `e2e` が走りキャッシュが作成される
- [ ] 以降の PR `e2e-diff` で cache hit し起動が短縮される

https://claude.ai/code/session_01WdKb3Vg1HxMRitzdeTaght

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdKb3Vg1HxMRitzdeTaght)_