### PR TITLE
fix(ci): Supabaseイメージキャッシュが保存されない問題を修正

### DIFF
--- a/.github/actions/setup_supabase/action.yaml
+++ b/.github/actions/setup_supabase/action.yaml
@@ -16,13 +16,19 @@ runs:
       with:
         version: ${{ inputs.cli-version }}
 
+    - name: Dockerイメージレジストリの解決
+      id: registry
+      shell: bash
+      # キャッシュキーと保存フィルタで同一レジストリを使うための単一の真実源。SUPABASE_INTERNAL_IMAGE_REGISTRYはworkflowでenv宣言されずenvコンテキストでは解決できないため、実際のOS環境変数を読むbashで解決する
+      run: echo "value=${SUPABASE_INTERNAL_IMAGE_REGISTRY:-public.ecr.aws}" >> "$GITHUB_OUTPUT"
+
     - name: Dockerイメージキャッシュの復元
       id: image-cache
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ~/.cache/supabase-docker-images.tar
-        # CLIバージョンが同じならtagも同一でリポジトリ全体（mainのキャッシュ）を共有できるため、ブランチ非依存の静的キーにする
-        key: supabase-docker-images-${{ runner.os }}-${{ inputs.cli-version }}
+        # CLIバージョンが同じならtagも同一でリポジトリ全体（mainのキャッシュ）を共有できるため、ブランチ非依存の静的キーにする。レジストリが異なるとtarのイメージtagも変わり復元しても使えないためキーに含めて分離する
+        key: supabase-docker-images-${{ runner.os }}-${{ inputs.cli-version }}-${{ steps.registry.outputs.value }}
 
     - name: キャッシュ済みDockerイメージの読み込み
       # ヒット時はここで読み込んでおくとsupabase startがレジストリからpullせず起動が速くなる
@@ -45,8 +51,7 @@ runs:
         set -euo pipefail
         mkdir -p ~/.cache
         # SUPABASE_INTERNAL_IMAGE_REGISTRYでレジストリを上書きしている場合（このリポジトリはghcr.io）はそのprefixでpullされるため、フィルタも同じレジストリに揃えないと保存対象が空になりキャッシュが一切保存されない
-        registry="${SUPABASE_INTERNAL_IMAGE_REGISTRY:-public.ecr.aws}"
-        mapfile -t images < <(docker images --filter "reference=${registry}/supabase/*" --format '{{.Repository}}:{{.Tag}}')
+        mapfile -t images < <(docker images --filter "reference=${{ steps.registry.outputs.value }}/supabase/*" --format '{{.Repository}}:{{.Tag}}')
         if [[ ${#images[@]} -eq 0 ]]; then
           echo "::warning::キャッシュ対象のSupabaseイメージが見つかりませんでした"
           exit 0

--- a/.github/actions/setup_supabase/action.yaml
+++ b/.github/actions/setup_supabase/action.yaml
@@ -25,7 +25,7 @@ runs:
         key: supabase-docker-images-${{ runner.os }}-${{ inputs.cli-version }}
 
     - name: キャッシュ済みDockerイメージの読み込み
-      # ヒット時はここで読み込んでおくとsupabase startがECRからpullせず起動が速くなる
+      # ヒット時はここで読み込んでおくとsupabase startがレジストリからpullせず起動が速くなる
       if: steps.image-cache.outputs.cache-hit == 'true'
       shell: bash
       run: docker load -i ~/.cache/supabase-docker-images.tar
@@ -44,7 +44,9 @@ runs:
       run: |
         set -euo pipefail
         mkdir -p ~/.cache
-        mapfile -t images < <(docker images --filter 'reference=public.ecr.aws/supabase/*' --format '{{.Repository}}:{{.Tag}}')
+        # SUPABASE_INTERNAL_IMAGE_REGISTRYでレジストリを上書きしている場合（このリポジトリはghcr.io）はそのprefixでpullされるため、フィルタも同じレジストリに揃えないと保存対象が空になりキャッシュが一切保存されない
+        registry="${SUPABASE_INTERNAL_IMAGE_REGISTRY:-public.ecr.aws}"
+        mapfile -t images < <(docker images --filter "reference=${registry}/supabase/*" --format '{{.Repository}}:{{.Tag}}')
         if [[ ${#images[@]} -eq 0 ]]; then
           echo "::warning::キャッシュ対象のSupabaseイメージが見つかりませんでした"
           exit 0


### PR DESCRIPTION
## 背景・確認結果

「Supabase起動のDockerイメージキャッシュを入れて速くなったか」を確認したところ、**全く速くなっておらず、キャッシュが一度も保存されていない**ことが判明しました。

### 計測（E2E (Diff) の「Supabaseのセットアップ」ステップ）

連続する2回のrunで所要時間がほぼ同一でした。

| Run | Supabase起動所要 | キャッシュ |
|-----|------------------|-----------|
| #727 | 約132秒 | miss |
| #728 | 約130秒 | miss |

### 原因

run #728 のログに決定的な証跡:

1. 復元: `Cache not found for input keys: supabase-docker-images-Linux-2.105.0`（毎回ミス）
2. `supabase start` は **`ghcr.io/supabase/*`** から都度pull（`SUPABASE_INTERNAL_IMAGE_REGISTRY=ghcr.io` でレジストリを上書きしているため）
3. 保存ステップのフィルタは Supabase CLI デフォルトの **`public.ecr.aws/supabase/*`** を見ており、1件もマッチせず `##[warning]キャッシュ対象のSupabaseイメージが見つかりませんでした`
4. tarが作られず `actions/cache` post で `Path Validation Error ... no cache is being saved`

→ 保存されない → 次回も必ずミス → 毎回フルpull、というループでした。キャッシュキーの設計（CLIバージョン単位・ブランチ非依存の静的キー）自体は妥当で、壊れていたのは保存側のフィルタ1点のみです。

## 変更内容

`docker images` のフィルタを `SUPABASE_INTERNAL_IMAGE_REGISTRY` 由来（未設定時はCLIデフォルトの `public.ecr.aws`）に揃え、レジストリ上書きの有無どちらでも保存対象を拾えるようにしました。`docker load` はタグを保持するため、復元後の `supabase start` はローカルイメージを使ってpullをスキップできる見込みです。

## 確認方法

このPRのCIで1回目（miss→保存成功・警告が出ないこと）、2回目以降の同系列runで `Cache restored` のヒット＋Supabase起動時間の短縮を確認します。

https://claude.ai/code/session_018VMRnkCWkXksVbmtL9mdRc

---
_Generated by [Claude Code](https://claude.ai/code/session_018VMRnkCWkXksVbmtL9mdRc)_