### PR TITLE
perf: 日時絞り込みをVIRTUAL生成列＋インデックスでサーガブル化 (#781)

### DIFF
--- a/application/packages/datastore/migrations/0006_flowery_luke_cage.sql
+++ b/application/packages/datastore/migrations/0006_flowery_luke_cage.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `articles` ADD `created_at_norm` text GENERATED ALWAYS AS (CASE WHEN typeof("created_at") = 'integer' THEN datetime("created_at" / 1000, 'unixepoch') ELSE datetime("created_at") END) VIRTUAL;--> statement-breakpoint
+CREATE INDEX `idx_articles_created_at_norm` ON `articles` (`created_at_norm`);--> statement-breakpoint
+ALTER TABLE `read_histories` ADD `read_at_norm` text GENERATED ALWAYS AS (CASE WHEN typeof("read_at") = 'integer' THEN datetime("read_at" / 1000, 'unixepoch') ELSE datetime("read_at") END) VIRTUAL;--> statement-breakpoint
+CREATE INDEX `idx_read_histories_user_read_at_norm` ON `read_histories` (`active_user_id`,`read_at_norm`);--> statement-breakpoint
+ALTER TABLE `skipped_articles` ADD `created_at_norm` text GENERATED ALWAYS AS (CASE WHEN typeof("created_at") = 'integer' THEN datetime("created_at" / 1000, 'unixepoch') ELSE datetime("created_at") END) VIRTUAL;--> statement-breakpoint
+CREATE INDEX `idx_skipped_articles_user_created_at_norm` ON `skipped_articles` (`active_user_id`,`created_at_norm`);

--- a/application/packages/datastore/migrations/meta/0006_snapshot.json
+++ b/application/packages/datastore/migrations/meta/0006_snapshot.json
@@ -1,0 +1,510 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "e91a136e-4e8a-4e81-9937-a42b6e5c51b6",
+  "prevId": "f82c061c-9dc4-4f76-90fb-813a6c5d63c3",
+  "tables": {
+    "articles": {
+      "name": "articles",
+      "columns": {
+        "article_id": {
+          "name": "article_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media": {
+          "name": "media",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "created_at_norm": {
+          "name": "created_at_norm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(CASE WHEN typeof(\"created_at\") = 'integer' THEN datetime(\"created_at\" / 1000, 'unixepoch') ELSE datetime(\"created_at\") END)",
+            "type": "virtual"
+          }
+        }
+      },
+      "indexes": {
+        "articles_url_key": {
+          "name": "articles_url_key",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "idx_articles_created_at_norm": {
+          "name": "idx_articles_created_at_norm",
+          "columns": [
+            "created_at_norm"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "read_histories": {
+      "name": "read_histories",
+      "columns": {
+        "read_history_id": {
+          "name": "read_history_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_user_id": {
+          "name": "active_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_at_norm": {
+          "name": "read_at_norm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(CASE WHEN typeof(\"read_at\") = 'integer' THEN datetime(\"read_at\" / 1000, 'unixepoch') ELSE datetime(\"read_at\") END)",
+            "type": "virtual"
+          }
+        }
+      },
+      "indexes": {
+        "idx_read_histories_article_user": {
+          "name": "idx_read_histories_article_user",
+          "columns": [
+            "article_id",
+            "active_user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_read_histories_user_read_at_norm": {
+          "name": "idx_read_histories_user_read_at_norm",
+          "columns": [
+            "active_user_id",
+            "read_at_norm"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "read_histories_active_user_id_active_users_active_user_id_fk": {
+          "name": "read_histories_active_user_id_active_users_active_user_id_fk",
+          "tableFrom": "read_histories",
+          "tableTo": "active_users",
+          "columnsFrom": [
+            "active_user_id"
+          ],
+          "columnsTo": [
+            "active_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skipped_articles": {
+      "name": "skipped_articles",
+      "columns": {
+        "skipped_article_id": {
+          "name": "skipped_article_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_user_id": {
+          "name": "active_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at_norm": {
+          "name": "created_at_norm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(CASE WHEN typeof(\"created_at\") = 'integer' THEN datetime(\"created_at\" / 1000, 'unixepoch') ELSE datetime(\"created_at\") END)",
+            "type": "virtual"
+          }
+        }
+      },
+      "indexes": {
+        "uq_skipped_articles_article_user": {
+          "name": "uq_skipped_articles_article_user",
+          "columns": [
+            "article_id",
+            "active_user_id"
+          ],
+          "isUnique": true
+        },
+        "idx_skipped_articles_user_created_at_norm": {
+          "name": "idx_skipped_articles_user_created_at_norm",
+          "columns": [
+            "active_user_id",
+            "created_at_norm"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "skipped_articles_active_user_id_active_users_active_user_id_fk": {
+          "name": "skipped_articles_active_user_id_active_users_active_user_id_fk",
+          "tableFrom": "skipped_articles",
+          "tableTo": "active_users",
+          "columnsFrom": [
+            "active_user_id"
+          ],
+          "columnsTo": [
+            "active_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "active_users": {
+      "name": "active_users",
+      "columns": {
+        "active_user_id": {
+          "name": "active_user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "authentication_id": {
+          "name": "authentication_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "active_users_email_key": {
+          "name": "active_users_email_key",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "active_users_authentication_id_key": {
+          "name": "active_users_authentication_id_key",
+          "columns": [
+            "authentication_id"
+          ],
+          "isUnique": true
+        },
+        "active_users_user_id_key": {
+          "name": "active_users_user_id_key",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "active_users_user_id_users_user_id_fk": {
+          "name": "active_users_user_id_users_user_id_fk",
+          "tableFrom": "active_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banned_users": {
+      "name": "banned_users",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "banned_users_user_id_key": {
+          "name": "banned_users_user_id_key",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "banned_users_user_id_users_user_id_fk": {
+          "name": "banned_users_user_id_users_user_id_fk",
+          "tableFrom": "banned_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "leaved_users": {
+      "name": "leaved_users",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "leaved_users_user_id_key": {
+          "name": "leaved_users_user_id_key",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "leaved_users_user_id_users_user_id_fk": {
+          "name": "leaved_users_user_id_users_user_id_fk",
+          "tableFrom": "leaved_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/application/packages/datastore/migrations/meta/_journal.json
+++ b/application/packages/datastore/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1781082015667,
       "tag": "0005_silent_wolfsbane",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1781172119772,
+      "tag": "0006_flowery_luke_cage",
+      "breakpoints": true
     }
   ]
 }

--- a/application/packages/datastore/src/drizzle-orm/schema/article.ts
+++ b/application/packages/datastore/src/drizzle-orm/schema/article.ts
@@ -22,8 +22,6 @@ export const articles = sqliteTable(
     description: text('description').notNull(),
     url: text('url').notNull(),
     createdAt: dateTime('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
-    // ISO-8601 / CURRENT_TIMESTAMP由来の空白区切り / epochミリ秒が混在するcreated_atを
-    // datetime()で正規化し、インデックスで日時絞り込みをサーガブルにするための生成列
     createdAtNorm: text('created_at_norm').generatedAlwaysAs(normalizedDateTimeSql('created_at'), {
       mode: 'virtual',
     }),

--- a/application/packages/datastore/src/drizzle-orm/schema/article.ts
+++ b/application/packages/datastore/src/drizzle-orm/schema/article.ts
@@ -3,6 +3,15 @@ import { index, integer, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqli
 import { dateTime } from './datetime'
 import { activeUsers } from './user'
 
+// 日時カラムは ISO-8601 文字列・CURRENT_TIMESTAMP由来の空白区切りUTC・epochミリ秒(integer) が
+// 混在しうる。クエリ側のCASE正規化はインデックスを使えずフルスキャンになるため、
+// 同一の正規化を生成列として保持しインデックス対象にする。'now'/'localtime'を含まないため決定的。
+function normalizedDateTimeSql(column: string) {
+  return sql.raw(
+    `CASE WHEN typeof("${column}") = 'integer' THEN datetime("${column}" / 1000, 'unixepoch') ELSE datetime("${column}") END`,
+  )
+}
+
 export const articles = sqliteTable(
   'articles',
   {
@@ -13,8 +22,16 @@ export const articles = sqliteTable(
     description: text('description').notNull(),
     url: text('url').notNull(),
     createdAt: dateTime('created_at').notNull().default(sql`CURRENT_TIMESTAMP`),
+    // ISO-8601 / CURRENT_TIMESTAMP由来の空白区切り / epochミリ秒が混在するcreated_atを
+    // datetime()で正規化し、インデックスで日時絞り込みをサーガブルにするための生成列
+    createdAtNorm: text('created_at_norm').generatedAlwaysAs(normalizedDateTimeSql('created_at'), {
+      mode: 'virtual',
+    }),
   },
-  (table) => [uniqueIndex('articles_url_key').on(table.url)],
+  (table) => [
+    uniqueIndex('articles_url_key').on(table.url),
+    index('idx_articles_created_at_norm').on(table.createdAtNorm),
+  ],
 )
 
 export const readHistories = sqliteTable(
@@ -28,8 +45,15 @@ export const readHistories = sqliteTable(
     activeUserId: integer('active_user_id')
       .notNull()
       .references(() => activeUsers.activeUserId, { onDelete: 'cascade', onUpdate: 'cascade' }),
+    readAtNorm: text('read_at_norm').generatedAlwaysAs(normalizedDateTimeSql('read_at'), {
+      mode: 'virtual',
+    }),
   },
-  (table) => [index('idx_read_histories_article_user').on(table.articleId, table.activeUserId)],
+  (table) => [
+    index('idx_read_histories_article_user').on(table.articleId, table.activeUserId),
+    // ダイアリー集計は active_user_id 絞り込み＋read_at 範囲のため複合インデックスにする
+    index('idx_read_histories_user_read_at_norm').on(table.activeUserId, table.readAtNorm),
+  ],
 )
 
 export const skippedArticles = sqliteTable(
@@ -42,9 +66,14 @@ export const skippedArticles = sqliteTable(
     activeUserId: integer('active_user_id')
       .notNull()
       .references(() => activeUsers.activeUserId, { onDelete: 'cascade', onUpdate: 'cascade' }),
+    createdAtNorm: text('created_at_norm').generatedAlwaysAs(normalizedDateTimeSql('created_at'), {
+      mode: 'virtual',
+    }),
   },
   (table) => [
     uniqueIndex('uq_skipped_articles_article_user').on(table.articleId, table.activeUserId),
+    // ダイアリー集計は active_user_id 絞り込み＋created_at 範囲のため複合インデックスにする
+    index('idx_skipped_articles_user_created_at_norm').on(table.activeUserId, table.createdAtNorm),
   ],
 )
 

--- a/application/packages/domain/src/article/infrastructure/query-impl.test.ts
+++ b/application/packages/domain/src/article/infrastructure/query-impl.test.ts
@@ -129,6 +129,21 @@ describe('QueryImpl', () => {
       expect(articleSql).not.toContain('unixepoch')
     })
 
+    it('from/to指定時はインデックス付き生成列(created_at_norm)で範囲比較する', async () => {
+      mockRdbExecutor
+        .mockResolvedValueOnce({ rows: [{ total: 0 }] })
+        .mockResolvedValueOnce({ rows: [] })
+
+      await queryImpl.searchArticles({ page: 1, limit: 20, from: '2026-03-05', to: '2026-03-05' })
+
+      // フルスキャンを招くCASE正規化ではなく、サーガブルな生成列比較になっていること
+      for (const call of mockRdbExecutor.mock.calls) {
+        const rawSql = String(call[0] ?? '')
+        expect(rawSql).toContain('created_at_norm')
+        expect(rawSql).not.toContain('unixepoch')
+      }
+    })
+
     it('件数取得失敗時はエラーを返す', async () => {
       mockRdbExecutor.mockRejectedValue(new Error('count failed'))
 
@@ -334,6 +349,17 @@ describe('QueryImpl', () => {
         expect(result.value.reads.data[0].url).toBe('https://example.com/go-error-handling')
         expect(result.value.reads.data[1].readHistoryId).toBe(9n)
       }
+    })
+
+    it('インデックス付き生成列(read_at_norm)で範囲比較・並び替えする', async () => {
+      mockRdbExecutor.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: [] })
+
+      await queryImpl.getDailyDiary(10n, '2026-03-07', 1, 10)
+
+      const readsSql = String(mockRdbExecutor.mock.calls[1]?.[0] ?? '')
+      expect(readsSql).toContain('read_at_norm')
+      expect(readsSql).toContain('ORDER BY rh.read_at_norm DESC')
+      expect(readsSql).not.toContain('unixepoch')
     })
 
     it('DB取得失敗時はエラーを返す', async () => {

--- a/application/packages/domain/src/article/infrastructure/query-impl.ts
+++ b/application/packages/domain/src/article/infrastructure/query-impl.ts
@@ -73,6 +73,14 @@ interface DateRange {
 
 type NormalizedDateTimeColumn = 'created_at' | 'rh.read_at' | 'sa.created_at'
 
+// 正規化済みの値はインデックス付きVIRTUAL生成列(*_norm)に保持済みのため、
+// 比較・並び替え・集計は生成列を直接参照してサーガブルにする
+const NORMALIZED_DATETIME_COLUMN: Record<NormalizedDateTimeColumn, string> = {
+  created_at: 'created_at_norm',
+  'rh.read_at': 'rh.read_at_norm',
+  'sa.created_at': 'sa.created_at_norm',
+}
+
 export default class QueryImpl implements Query {
   constructor(private readonly db: RdbClient) {}
 
@@ -396,13 +404,7 @@ export default class QueryImpl implements Query {
   }
 
   private static getNormalizedDateTimeSql(columnName: NormalizedDateTimeColumn) {
-    const column = sql.raw(columnName)
-    return sql`
-      CASE
-        WHEN typeof(${column}) = 'integer' THEN datetime(${column} / 1000, 'unixepoch')
-        ELSE datetime(${column})
-      END
-    `
+    return sql.raw(NORMALIZED_DATETIME_COLUMN[columnName])
   }
 
   private static getJstDateSql(columnName: NormalizedDateTimeColumn) {


### PR DESCRIPTION
## 概要

Closes #781

パフォーマンスレビューで挙がった中で最も効果の大きい、**日時絞り込みのフルスキャン解消**を実施しました。

トレンド一覧（`searchArticles`）・未読消化（`getUnreadDigestionArticles`）・ダイアリー（`getDailyDiary` / `getDailyDiaryRange`）は、`getNormalizedDateTimeSql` の `CASE WHEN typeof(...) ...` 正規化を WHERE / ORDER BY / GROUP BY で評価しており、SQLite(D1) がインデックスを使えず**毎回フルスキャン＋全行で関数評価**になっていました。データ量は単調増加するため劣化が進行します。

## 変更内容

既存データを書き換えず（UPDATE なし）、同一の正規化を **VIRTUAL 生成列 (`*_norm`)** として保持し、インデックス対象にすることでサーガブルにしました。

### マイグレーション（`0006_flowery_luke_cage.sql`・追加のみ）

| テーブル | 生成列 | インデックス |
|---|---|---|
| `articles` | `created_at_norm` | `idx_articles_created_at_norm(created_at_norm)` |
| `read_histories` | `read_at_norm` | `idx_read_histories_user_read_at_norm(active_user_id, read_at_norm)` |
| `skipped_articles` | `created_at_norm` | `idx_skipped_articles_user_created_at_norm(active_user_id, created_at_norm)` |

履歴系の複合インデックスは先頭を `active_user_id` にし、ダイアリー集計の `active_user_id = ?` 絞り込み＋日時範囲の両方に効くようにしています。

### クエリ側（`query-impl.ts`）

`getNormalizedDateTimeSql` を CASE 式から生成列参照へ置き換え。WHERE / ORDER BY / GROUP BY の評価対象がインデックス済みの素の列比較になります。返却する `createdAt` / `readAt` は従来どおり生の値を `normalizeDateTime` で変換するため、精度・挙動は不変です。

## 設計上のポイント

- 生成列の式は `'now'` / `'localtime'` を含まず**決定的**なため、`ALTER TABLE ADD COLUMN ... GENERATED ALWAYS AS (...) VIRTUAL` で追加可能（既存行の書き換えなし）。
- 正規化値は `datetime()` 出力の `YYYY-MM-DD HH:MM:SS` 形式で固定幅のため、辞書順＝時系列順となりインデックス範囲スキャンが成立。
- スキーマ（drizzle）を真実とし `drizzle-kit check` も green。

## 検証

- `pnpm -r typecheck` ✅（全7パッケージ）
- `domain` テスト ✅ 310 passed / `datastore` テスト ✅ 24 passed
- `drizzle-kit check` ✅ Everything's fine
- `node:sqlite` で全マイグレーション適用＋3形式混在データ（ISO-8601 / 空白区切りUTC / epochミリ秒）を投入し、正規化と日付範囲フィルタが正しいことを確認
- `EXPLAIN QUERY PLAN` で **`SEARCH articles USING INDEX idx_articles_created_at_norm`** を確認（フルスキャン→インデックス範囲スキャン）

> [!NOTE]
> `web` の server 統合テストはこのブランチ作成時点で本変更と無関係に環境起因で失敗しています（変更前 `main` 相当でも同一の 49 failed / 37 passed を確認済み）。本変更による新規失敗はありません。

## 補足

関連 issue #782（日時形式混在の止血）は本 PR の前提ではありません。生成列の CASE が3形式すべてを正規化するため単独で機能します。#782 を後続で実施すると将来の正規化対象を「過去の固定範囲」に閉じられます。

https://claude.ai/code/session_01Y3xkg4Np3xjFq8p5h1w4ar

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3xkg4Np3xjFq8p5h1w4ar)_