### PR TITLE
perf: SWRフェッチャー・APIクライアントのシングルトン化

### DIFF
--- a/application/packages/web/src/client/infrastructure/api.ts
+++ b/application/packages/web/src/client/infrastructure/api.ts
@@ -7,5 +7,11 @@ if (typeof document !== 'undefined') {
   apiUrl = `${window.location.protocol}//${window.location.host}`
 }
 
-const getApiClientForClient = () => getApiClient(apiUrl)
+// レンダーごとの再生成を避けるため、モジュールスコープで単一インスタンスを遅延生成して保持する
+let apiClient: ReturnType<typeof getApiClient> | undefined
+
+const getApiClientForClient = () => {
+  apiClient ??= getApiClient(apiUrl)
+  return apiClient
+}
 export default getApiClientForClient

--- a/application/packages/web/src/client/infrastructure/create-swr-fetcher.ts
+++ b/application/packages/web/src/client/infrastructure/create-swr-fetcher.ts
@@ -41,22 +41,11 @@ const apiCall = async <T>(apiCall: () => Promise<ApiCallResponse>): Promise<T | 
   }
 }
 
-// レンダーごとの再生成を避けるため、モジュールスコープで単一インスタンスを遅延生成して保持する
-let swrFetcher:
-  | {
-      fetcher: typeof fetcher
-      apiCall: typeof apiCall
-      client: ReturnType<typeof getApiClientForClient>
-    }
-  | undefined
-
-export const createSWRFetcher = () => {
-  swrFetcher ??= {
-    fetcher,
-    apiCall,
-    client: getApiClientForClient(),
-  }
-  return swrFetcher
-}
+// fetcher / apiCall はモジュールスコープで定義済み、client も getApiClientForClient 側でシングルトン化されているため、軽量なオブジェクトリテラルを返すだけでよい
+export const createSWRFetcher = () => ({
+  fetcher,
+  apiCall,
+  client: getApiClientForClient(),
+})
 
 export default createSWRFetcher

--- a/application/packages/web/src/client/infrastructure/create-swr-fetcher.ts
+++ b/application/packages/web/src/client/infrastructure/create-swr-fetcher.ts
@@ -12,43 +12,51 @@ interface ApiCallResponse {
 const toHttpError = (status: number, statusText: string) =>
   status >= 500 ? new ServerError(statusText, status) : new ClientError(statusText, status)
 
+const fetcher = async <T>(url: string): Promise<T> => {
+  // 応答が遅い相手で画面がハングするのを防ぐ
+  const response = await fetchWithTimeout(url, {
+    credentials: 'include',
+  })
+
+  if (!response.ok) {
+    throw toHttpError(response.status, response.statusText)
+  }
+
+  return response.safeJson<T>()
+}
+
+const apiCall = async <T>(apiCall: () => Promise<ApiCallResponse>): Promise<T | null> => {
+  const response = await apiCall()
+
+  if (!response.ok) {
+    throw toHttpError(response.status, response.statusText)
+  }
+
+  switch (response.status) {
+    case 204:
+      return null
+    default:
+      // oxlint-disable-next-line typescript/consistent-type-assertions -- JSON デシリアライズ結果は実行時まで型が定まらず、呼び出し側が指定するジェネリック T へ橋渡しする境界のため許可する
+      return (await response.json()) as T
+  }
+}
+
+// レンダーごとの再生成を避けるため、モジュールスコープで単一インスタンスを遅延生成して保持する
+let swrFetcher:
+  | {
+      fetcher: typeof fetcher
+      apiCall: typeof apiCall
+      client: ReturnType<typeof getApiClientForClient>
+    }
+  | undefined
+
 export const createSWRFetcher = () => {
-  const client = getApiClientForClient()
-
-  const fetcher = async <T>(url: string): Promise<T> => {
-    // 応答が遅い相手で画面がハングするのを防ぐ
-    const response = await fetchWithTimeout(url, {
-      credentials: 'include',
-    })
-
-    if (!response.ok) {
-      throw toHttpError(response.status, response.statusText)
-    }
-
-    return response.safeJson<T>()
-  }
-
-  const apiCall = async <T>(apiCall: () => Promise<ApiCallResponse>): Promise<T | null> => {
-    const response = await apiCall()
-
-    if (!response.ok) {
-      throw toHttpError(response.status, response.statusText)
-    }
-
-    switch (response.status) {
-      case 204:
-        return null
-      default:
-        // oxlint-disable-next-line typescript/consistent-type-assertions -- JSON デシリアライズ結果は実行時まで型が定まらず、呼び出し側が指定するジェネリック T へ橋渡しする境界のため許可する
-        return (await response.json()) as T
-    }
-  }
-
-  return {
+  swrFetcher ??= {
     fetcher,
     apiCall,
-    client,
+    client: getApiClientForClient(),
   }
+  return swrFetcher
 }
 
 export default createSWRFetcher


### PR DESCRIPTION
## 概要

#786 のうち、**2. SWRフェッチャー・APIクライアントのシングルトン化** を対応しました。

`createSWRFetcher()` / 各hooksがレンダーごとに hc クライアントを再生成していたため、モジュールスコープの単一インスタンスへ集約しました。

## 変更内容

- `client/infrastructure/api.ts`: `getApiClientForClient()` が返す hc クライアントをモジュールスコープで遅延生成し、単一インスタンスとして再利用するようにしました。
- `client/infrastructure/create-swr-fetcher.ts`: `fetcher` / `apiCall` をモジュールスコープへ巻き上げ、`createSWRFetcher()` は単一インスタンスを返すようにしました。

### 生成を遅延させている理由

各hooksのテストは `beforeEach` でモッククライアントを差し替える設計のため、生成タイミングをモジュール読み込み時ではなく初回利用時まで遅延させることで、既存テストとの互換性を保っています。

## 対応しない範囲

- **1. LIKE中間一致検索のFTS5検討**: イシュー記載の通り、D1メトリクスの `rows_read` 等で必要性が顕在化してから着手する方針のため、本PWでは対応していません。

## 確認

- `pnpm lint`（oxlint / biome ci / 全パッケージ typecheck）: パス
- `pnpm --filter @trend-diary/web exec vitest run --project client`: 160 tests パス

Closes #786

https://claude.ai/code/session_01P2m4vmnpW1xU6SGqmEYS1x

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2m4vmnpW1xU6SGqmEYS1x)_