### PR TITLE
feat(web): useCallback/useMemo/memo を lint で禁止する

### DIFF
--- a/application/packages/web/.oxlintrc.json
+++ b/application/packages/web/.oxlintrc.json
@@ -19,6 +19,13 @@
         "no-restricted-imports": [
           "error",
           {
+            "paths": [
+              {
+                "name": "react",
+                "importNames": ["useCallback", "useMemo", "memo"],
+                "message": "Manual memoization is unnecessary because React Compiler applies it automatically. Remove useCallback/useMemo/memo and let the compiler optimize."
+              }
+            ],
             "patterns": [
               {
                 "group": [

--- a/application/packages/web/.oxlintrc.json
+++ b/application/packages/web/.oxlintrc.json
@@ -16,6 +16,24 @@
     {
       "files": ["src/client/**/*.{ts,tsx}"],
       "rules": {
+        "no-restricted-properties": [
+          "error",
+          {
+            "object": "React",
+            "property": "useCallback",
+            "message": "Manual memoization is unnecessary because React Compiler applies it automatically. Remove React.useCallback and let the compiler optimize."
+          },
+          {
+            "object": "React",
+            "property": "useMemo",
+            "message": "Manual memoization is unnecessary because React Compiler applies it automatically. Remove React.useMemo and let the compiler optimize."
+          },
+          {
+            "object": "React",
+            "property": "memo",
+            "message": "Manual memoization is unnecessary because React Compiler applies it automatically. Remove React.memo and let the compiler optimize."
+          }
+        ],
         "no-restricted-imports": [
           "error",
           {

--- a/application/packages/web/src/client/routes/diary/hooks/use-analytics.ts
+++ b/application/packages/web/src/client/routes/diary/hooks/use-analytics.ts
@@ -2,7 +2,6 @@ import { addJstDays } from '@trend-diary/common/locale/date'
 import { DEFAULT_PAGE, offsetPaginationSchema } from '@trend-diary/common/pagination/schema'
 import { DIARY_DAYS, DIARY_READ_LIMIT } from '@trend-diary/domain/article/diary'
 import { ARTICLE_MEDIA, type ArticleMedia } from '@trend-diary/domain/article/media'
-import { useMemo } from 'react'
 import { useSearchParams } from 'react-router'
 import useSWR from 'swr'
 import { getTodayJst, sumSourceSummary } from '@/client/features/diary/daily-summary'
@@ -36,7 +35,7 @@ export default function useAnalytics(enabled: boolean) {
 
   const todayJst = getTodayJst()
   const hasDateResolveError = todayJst === null
-  const availableDates = useMemo(() => (todayJst ? buildAvailableDates(todayJst) : []), [todayJst])
+  const availableDates = todayJst ? buildAvailableDates(todayJst) : []
   const dateParam = searchParams.get('date')
   const pageParam = searchParams.get('page')
 

--- a/application/packages/web/src/client/routes/inbox/hooks/use-unread-digestion.ts
+++ b/application/packages/web/src/client/routes/inbox/hooks/use-unread-digestion.ts
@@ -1,5 +1,5 @@
 import type { ArticleOutput } from '@trend-diary/domain/article/schema/article-schema'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import useSWR from 'swr'
 import createSWRFetcher from '@/client/infrastructure/create-swr-fetcher'
@@ -122,7 +122,7 @@ export default function useUnreadDigestion(enabled: boolean, selectedMedia: Medi
 
   const currentArticle = queue[0] ?? null
 
-  const handleSkip = useCallback(async () => {
+  const handleSkip = async () => {
     if (!currentArticle) return
     setIsActionLoading(true)
 
@@ -145,9 +145,9 @@ export default function useUnreadDigestion(enabled: boolean, selectedMedia: Medi
     } finally {
       setIsActionLoading(false)
     }
-  }, [client.articles, currentArticle])
+  }
 
-  const handleRead = useCallback(async () => {
+  const handleRead = async () => {
     if (!currentArticle) return
     setIsActionLoading(true)
 
@@ -166,15 +166,15 @@ export default function useUnreadDigestion(enabled: boolean, selectedMedia: Medi
     } finally {
       setIsActionLoading(false)
     }
-  }, [currentArticle, markAsRead, queue.length])
+  }
 
-  const handleLater = useCallback(() => {
+  const handleLater = () => {
     setQueue((prev) => {
       if (prev.length <= 1) return prev
       const [head, ...rest] = prev
       return [...rest, head]
     })
-  }, [])
+  }
 
   return {
     isLoading: isLoading || isActionLoading,

--- a/application/packages/web/src/client/routes/trends._index/hooks/use-read-article.ts
+++ b/application/packages/web/src/client/routes/trends._index/hooks/use-read-article.ts
@@ -1,5 +1,5 @@
 import { wrapAsyncCall } from '@trend-diary/common/result'
-import { useCallback, useState } from 'react'
+import { useState } from 'react'
 import { toast } from 'sonner'
 import getApiClientForClient from '../../../infrastructure/api'
 
@@ -9,7 +9,7 @@ const MarkAsUnreadErrorMessage = '未読に失敗しました'
 export default function useReadArticle() {
   const [isLoading, setIsLoading] = useState(false)
 
-  const markAsRead = useCallback(async (articleId: string): Promise<boolean> => {
+  const markAsRead = async (articleId: string): Promise<boolean> => {
     setIsLoading(true)
 
     const result = await wrapAsyncCall(async () => {
@@ -35,9 +35,9 @@ export default function useReadArticle() {
     }
 
     return true
-  }, [])
+  }
 
-  const markAsUnread = useCallback(async (articleId: string): Promise<boolean> => {
+  const markAsUnread = async (articleId: string): Promise<boolean> => {
     setIsLoading(true)
 
     const result = await wrapAsyncCall(async () => {
@@ -62,7 +62,7 @@ export default function useReadArticle() {
     }
 
     return true
-  }, [])
+  }
 
   return {
     markAsRead,

--- a/application/packages/web/src/client/routes/trends._index/page.tsx
+++ b/application/packages/web/src/client/routes/trends._index/page.tsx
@@ -1,6 +1,6 @@
 import { toJaDateString } from '@trend-diary/common/locale'
 import { ChevronDown, Funnel } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router'
 import { twMerge } from 'tailwind-merge'
 import { Button } from '@/client/components/shadcn/button'
@@ -66,12 +66,9 @@ export default function TrendsPage({
   const isPrevDisabled = page <= 1
   const isNextDisabled = page >= totalPages
 
-  const handleCardClick = useCallback(
-    (article: Article) => {
-      openDrawer(article)
-    },
-    [openDrawer],
-  )
+  const handleCardClick = (article: Article) => {
+    openDrawer(article)
+  }
 
   const handlePrevPageClick = () => {
     if (!isPrevDisabled) {


### PR DESCRIPTION
## 概要

React Compiler が必要なメモ化を自動付与するため、手動のメモ化（`useCallback` / `useMemo` / `memo`）は冗長になります。これらを lint で禁止します。

## 変更内容

- `application/packages/web/.oxlintrc.json` の `no-restricted-imports`（`src/client/**` 向け override）に、`react` からの `useCallback` / `useMemo` / `memo` の import を禁止する `paths` を追加
  - エラーメッセージは既存方針（`lint-config.md`）に従い英語で記述
- ルール追加に伴い違反していた既存の手動メモ化を除去
  - `routes/diary/hooks/use-analytics.ts`（`useMemo`）
  - `routes/trends._index/page.tsx`（`useCallback`）
  - `routes/trends._index/hooks/use-read-article.ts`（`useCallback`）
  - `routes/inbox/hooks/use-unread-digestion.ts`（`useCallback`）

## 確認

- `pnpm check`（oxlint + oxfmt）: エラーなし（残るのは既存の warning のみ）
- `pnpm -r typecheck`: 全パッケージ通過
- 変更ファイルに対応する client プロジェクトのユニットテスト: 46 件通過
  - storybook（ブラウザ）テストはサンドボックス環境で chromium を起動できないため未実行（変更とは無関係）

https://claude.ai/code/session_01VXXe8hmUvgj3VMAjGk4Xn8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXXe8hmUvgj3VMAjGk4Xn8)_