### PR TITLE
React useEffect 規約の追加と trends の不要 Effect 削減（issue #809）

### DIFF
--- a/.claude/rules/react.md
+++ b/.claude/rules/react.md
@@ -1,6 +1,6 @@
 ---
 paths:
-  - "**/web/src/client/**/*.tsx"
+  - "**/web/src/client/**/*.{ts,tsx}"
 ---
 
 # React規約
@@ -22,4 +22,6 @@ React 19.2 + React Compiler 有効（`packages/web` の Vite で `babel-plugin-r
 
 外部システムとの同期は Effect が本来の用途のため、無理に置き換えない。
 
-- 外部スクリプトの読込・描画、`matchMedia` 等の購読、`visibilitychange` の購読、`setTimeout` タイマー、キーボードショートカットの購読など
+- 外部スクリプトの読込・描画、`setTimeout` タイマー、キーボードショートカットの購読など
+- 外部ストアの値を購読するだけのもの（`matchMedia` や `visibilitychange` 等）は、可能なら `useSyncExternalStore` を優先する
+  - 理由: SSR との整合が取れ、初回レンダー後のちらつきを避けられる。Effect での購読は描画後に値が確定するため一瞬ずれる余地がある

--- a/.claude/rules/react.md
+++ b/.claude/rules/react.md
@@ -1,0 +1,25 @@
+---
+paths:
+  - "**/web/src/client/**/*.tsx"
+---
+
+# React規約
+
+React 19.2 + React Compiler 有効（`packages/web` の Vite で `babel-plugin-react-compiler` を適用済み）を前提とする。
+
+## useEffect
+
+`useEffect` は「外部システムとの同期」のための仕組みであり、それ以外の用途に使わない。レンダー中の派生計算やイベント起因の処理を Effect に載せると、再レンダーの往復や状態の二重管理を生み、バグの温床になる。判断に迷う場合は React 公式「[You Might Not Need an Effect](https://react.dev/learn/you-might-not-need-an-effect)」を参照する。
+
+- props や他の state から計算できる値は、Effect で state に同期せずレンダー中に算出する
+  - 理由: 同期 Effect は派生値を二重に持つことになり、元の値と state がずれる余地を生む。レンダー中の計算なら常に最新で一貫する
+- props の変化に応じて子の内部 state をリセットしたいときは、Effect ではなく `key` で再マウントする
+  - 理由: `key` を渡せばリセットの意図が宣言的に表れ、リセット漏れや余計な再レンダーを避けられる
+- 「特定の操作の結果起きること」（スクロール・演出の発火・mutate 等）は Effect ではなくイベントハンドラに置く
+  - 理由: イベント起因の処理を Effect に載せると、何の操作で発火したのか追えなくなり、依存配列や追跡用 ref で状態を補う複雑さが生じる。ハンドラ内に置けば因果が明確で二重実行も防げる
+
+### 残してよい useEffect
+
+外部システムとの同期は Effect が本来の用途のため、無理に置き換えない。
+
+- 外部スクリプトの読込・描画、`matchMedia` 等の購読、`visibilitychange` の購読、`setTimeout` タイマー、キーボードショートカットの購読など

--- a/application/packages/web/src/client/routes/trends._index/components/article-drawer.tsx
+++ b/application/packages/web/src/client/routes/trends._index/components/article-drawer.tsx
@@ -34,7 +34,6 @@ export default function ArticleDrawer({
   isLoggedIn = false,
 }: Props) {
   const isMobile = useIsMobile()
-  // 記事ごとの開閉状態リセットは親の key={article.articleId} による再マウントで行う
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
 
   const handleOpenChange = (open: boolean) => {

--- a/application/packages/web/src/client/routes/trends._index/components/article-drawer.tsx
+++ b/application/packages/web/src/client/routes/trends._index/components/article-drawer.tsx
@@ -1,7 +1,7 @@
 import { toJaDateString } from '@trend-diary/common/locale'
 import { isArticleMedia } from '@trend-diary/domain/article/media'
 import { Calendar, Check, ExternalLink, User, X } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { createPortal } from 'react-dom'
 import {
   Drawer,
@@ -34,13 +34,8 @@ export default function ArticleDrawer({
   isLoggedIn = false,
 }: Props) {
   const isMobile = useIsMobile()
+  // 記事ごとの開閉状態リセットは親の key={article.articleId} による再マウントで行う
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
-
-  useEffect(() => {
-    if (isOpen) {
-      setIsDescriptionExpanded(false)
-    }
-  }, [article.articleId, isOpen])
 
   const handleOpenChange = (open: boolean) => {
     if (!open) onClose()

--- a/application/packages/web/src/client/routes/trends._index/page.tsx
+++ b/application/packages/web/src/client/routes/trends._index/page.tsx
@@ -1,7 +1,6 @@
 import { toJaDateString } from '@trend-diary/common/locale'
 import { ChevronDown, Funnel } from 'lucide-react'
-import { useCallback, useEffect, useState } from 'react'
-import { useSearchParams } from 'react-router'
+import { useCallback, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { Button } from '@/client/components/shadcn/button'
 import { useIsMobile } from '@/client/components/shadcn/hooks/use-mobile'
@@ -18,6 +17,10 @@ import DatePresetFilter from './components/date-preset-filter'
 import MediaFilter, { type MediaType } from './components/media-filter'
 import ReadStatusFilter, { type ReadStatusType } from './components/read-status-filter'
 import type { Article, DatePresetType } from './hooks/use-articles'
+
+const scrollToTop = () => {
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+}
 
 interface Props {
   date: Date
@@ -56,12 +59,33 @@ export default function TrendsPage({
   onToggleRead,
   isLoggedIn,
 }: Props) {
-  const [searchParams] = useSearchParams()
   const isMobile = useIsMobile()
   const [isFilterOpen, setIsFilterOpen] = useState(false)
   const [draftMedia, setDraftMedia] = useState<MediaType>(selectedMedia)
   const [draftReadStatus, setDraftReadStatus] = useState<ReadStatusType>(selectedReadStatus)
   const [draftDatePreset, setDraftDatePreset] = useState<DatePresetType>(selectedDatePreset)
+
+  // 適用済みフィルタが外部要因（戻る/進む等）で変わったらドラフトを追従させる。
+  // props→state の同期 Effect ではなくレンダー中調整で行い、描画後のちらつきを避ける
+  const [appliedFilters, setAppliedFilters] = useState({
+    media: selectedMedia,
+    readStatus: selectedReadStatus,
+    datePreset: selectedDatePreset,
+  })
+  if (
+    appliedFilters.media !== selectedMedia ||
+    appliedFilters.readStatus !== selectedReadStatus ||
+    appliedFilters.datePreset !== selectedDatePreset
+  ) {
+    setAppliedFilters({
+      media: selectedMedia,
+      readStatus: selectedReadStatus,
+      datePreset: selectedDatePreset,
+    })
+    setDraftMedia(selectedMedia)
+    setDraftReadStatus(selectedReadStatus)
+    setDraftDatePreset(selectedDatePreset)
+  }
 
   const isPrevDisabled = page <= 1
   const isNextDisabled = page >= totalPages
@@ -76,12 +100,14 @@ export default function TrendsPage({
   const handlePrevPageClick = () => {
     if (!isPrevDisabled) {
       toPreviousPage(page)
+      scrollToTop()
     }
   }
 
   const handleNextPageClick = () => {
     if (!isNextDisabled) {
       toNextPage(page)
+      scrollToTop()
     }
   }
 
@@ -89,17 +115,6 @@ export default function TrendsPage({
     const baseClass = 'border-solid border border-b-slate-400 cursor-pointer'
     return twMerge(baseClass, isDisabled ? 'opacity-50 cursor-not-allowed' : '')
   }
-
-  // URLパラメータ変更時にページトップへスクロール
-  useEffect(() => {
-    window.scrollTo({ top: 0, behavior: 'smooth' })
-  }, [searchParams])
-
-  useEffect(() => {
-    setDraftMedia(selectedMedia)
-    setDraftReadStatus(selectedReadStatus)
-    setDraftDatePreset(selectedDatePreset)
-  }, [selectedMedia, selectedReadStatus, selectedDatePreset])
 
   const appliedFilterCount =
     (selectedMedia ? 1 : 0) +
@@ -130,7 +145,7 @@ export default function TrendsPage({
     if (isMobile) {
       setIsFilterOpen(false)
     }
-    window.scrollTo({ top: 0, behavior: 'smooth' })
+    scrollToTop()
   }
 
   const handleApplyFilter = () => {
@@ -138,22 +153,25 @@ export default function TrendsPage({
     if (isMobile) {
       setIsFilterOpen(false)
     }
-    window.scrollTo({ top: 0, behavior: 'smooth' })
+    scrollToTop()
   }
 
   const handleDesktopMediaChange = (media: MediaType) => {
     setDraftMedia(media)
     onApplyFilters({ media, readStatus: draftReadStatus, datePreset: draftDatePreset })
+    scrollToTop()
   }
 
   const handleDesktopReadStatusChange = (readStatus: ReadStatusType) => {
     setDraftReadStatus(readStatus)
     onApplyFilters({ media: draftMedia, readStatus, datePreset: draftDatePreset })
+    scrollToTop()
   }
 
   const handleDesktopDatePresetChange = (datePreset: DatePresetType) => {
     setDraftDatePreset(datePreset)
     onApplyFilters({ media: draftMedia, readStatus: draftReadStatus, datePreset })
+    scrollToTop()
   }
 
   return (

--- a/application/packages/web/src/client/routes/trends._index/page.tsx
+++ b/application/packages/web/src/client/routes/trends._index/page.tsx
@@ -65,8 +65,7 @@ export default function TrendsPage({
   const [draftReadStatus, setDraftReadStatus] = useState<ReadStatusType>(selectedReadStatus)
   const [draftDatePreset, setDraftDatePreset] = useState<DatePresetType>(selectedDatePreset)
 
-  // 適用済みフィルタが外部要因（戻る/進む等）で変わったらドラフトを追従させる。
-  // props→state の同期 Effect ではなくレンダー中調整で行い、描画後のちらつきを避ける
+  // props→state の同期 Effect ではなくレンダー中調整にするのは、描画後のちらつきを避けるため
   const [appliedFilters, setAppliedFilters] = useState({
     media: selectedMedia,
     readStatus: selectedReadStatus,

--- a/application/packages/web/src/client/routes/trends._index/route.tsx
+++ b/application/packages/web/src/client/routes/trends._index/route.tsx
@@ -68,6 +68,7 @@ export default function Trends() {
       />
       {selectedArticle && (
         <ArticleDrawer
+          key={selectedArticle.articleId}
           article={selectedArticle}
           isOpen={isDrawerOpen}
           onClose={closeDrawer}


### PR DESCRIPTION
## 概要

issue #809 を踏まえ、(1) React 用のプロジェクトルールを新設し、(2) その規約に沿って `trends` 配下の不要な `useEffect`（類型A・B）を削減します。

手動メモ化（`useCallback` / `useMemo`）の削除、および類型C〜F（`forwardRef` 廃止・`useActionState` 化・Context 新記法）は本 PR の対象外とし、別 PR で扱います。

## 変更内容

### 1. ルール追加: `.claude/rules/react.md`

- `useEffect` は「外部システムとの同期」用途に限定する方針を理由付きで明文化
  - props・他 state から計算できる値はレンダー中に算出（同期 Effect を持たない）
  - props 変化による子の state リセットは `key` での再マウントで行う
  - 操作起因の処理（スクロール・演出・mutate 等）はイベントハンドラに置く
  - 残してよい正当な用途（外部スクリプト・タイマー・ショートカット購読等）も明記。`matchMedia` / `visibilitychange` 等の外部ストア購読は `useSyncExternalStore` を優先（SSRちらつき回避）
- パススコープは `**/web/src/client/**/*.{ts,tsx}`（client 配下の hooks も対象）

### 2. リファクタ: `routes/trends._index/`

| 箇所 | 類型 | 対応 |
|---|---|---|
| `article-drawer.tsx` | A | 記事変化時の開閉リセット Effect を廃止し、親 `route.tsx` で `key={article.articleId}` を渡して再マウントで初期化 |
| `page.tsx`（draft 同期） | A | props→draft の同期 Effect をレンダー中調整へ置換。戻る/進む等の外部要因による追従は維持 |
| `page.tsx`（scroll） | B | `searchParams` 変化で発火していたスクロール Effect を廃し、ページ送り/フィルタ操作の各ハンドラへ集約。適用時の二重スクロールも解消 |

## 対象外（別 PR）

- `routes/inbox/hooks/use-unread-digestion.ts`（類型A・B）: `queue` がローカルで加工される状態（skip/read で `slice`）で、issue でも「要設計」とされているため、テスト整備とあわせて別 PR で対応します。
- 類型C（`forwardRef` 廃止）・D（フォームの `useActionState` 化）・F（Context 新記法）

## 確認

- `oxlint` / `oxfmt --check` / `tsgo --noEmit`: パス（新規警告なし）
- client(jsdom) テスト: 160 passed
- Storybook ブラウザテスト: 本環境はブラウザバイナリ取得がネットワークポリシーで不可のため未実行（CI で実行）。変更は各ストーリーの単体マウントに影響しません

Closes #809 ではなく、issue のうち useEffect 類型A・B のみを対象としています。

https://claude.ai/code/session_01Dhdcsqsx5zwmDGhH3FfJY4