### PR TITLE
ci: mainブランチのCI失敗時にDiscord通知を追加

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -313,3 +313,28 @@ jobs:
             echo "::error::失敗またはタイムアウトしたジョブがあります"
             exit 1
           fi
+
+  notify-failure:
+    # mainへのpushでCIが失敗した時のみ通知する(PRのCI失敗はGitHub上で気づけるため対象外)
+    needs: gate
+    if: ${{ failure() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    environment: develop
+    steps:
+      - name: CI失敗をDiscordへ通知
+        working-directory: ${{ github.workspace }}
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${DISCORD_WEBHOOK_URL}" ]]; then
+            echo "DISCORD_WEBHOOK_URLが未設定のため通知をスキップします"
+            exit 0
+          fi
+
+          curl -fsS -H "Content-Type: application/json" \
+            -d "{\"content\": \":rotating_light: mainブランチのCIが失敗しました (${COMMIT_SHA:0:7})\n${RUN_URL}\"}" \
+            "${DISCORD_WEBHOOK_URL}"


### PR DESCRIPTION
## 概要

mainブランチへのpushでCIが失敗した際に、Discordへ通知するようにしました。

## 背景

mainのCIが落ちてもGitHubを能動的に見に行かないと気づけないため、Discordで即座に検知できるようにします。PRのCI失敗はGitHub上で気づけるため対象外とし、mainへのpush時のみ通知します。

## 変更内容

- `.github/workflows/ci.yaml` に `notify-failure` ジョブを追加
  - `gate` ジョブを起点に、`failure() && push && refs/heads/main` の条件で発火
  - 既存の `cd.yaml` のスモークテスト失敗通知と同じ Discord Webhook パターンを踏襲
  - `DISCORD_WEBHOOK_URL` 未設定時は通知をスキップ
  - 失敗したコミットの短縮SHAと実行URLを通知に含める

## 確認事項

- [ ] `develop` 環境に `DISCORD_WEBHOOK_URL` シークレットが設定されていること（e2eジョブと同じ環境を利用）

https://claude.ai/code/session_0153hpcoKmqjjjLJwbuLt1RZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0153hpcoKmqjjjLJwbuLt1RZ)_