### PR TITLE
refactor(web): 未ログイン時フォールバックを共通コンポーネントに集約

### DIFF
--- a/application/packages/web/src/client/components/ui/feedback/login-required/index.tsx
+++ b/application/packages/web/src/client/components/ui/feedback/login-required/index.tsx
@@ -2,7 +2,7 @@ interface Props {
   pageTitle: string
 }
 
-export default function DiaryLoginRequired({ pageTitle }: Props) {
+export default function LoginRequired({ pageTitle }: Props) {
   return (
     <div className='p-6'>
       <h1 className='text-xl font-semibold text-gray-900'>{pageTitle}</h1>

--- a/application/packages/web/src/client/features/diary/index.ts
+++ b/application/packages/web/src/client/features/diary/index.ts
@@ -1,4 +1,3 @@
-export { default as DiaryLoginRequired } from './components/login-required'
 export { default as DiaryPageLayout } from './components/page-layout'
 export { default as DiaryReadListSection } from './components/read-list-section'
 export { default as DiaryReadPagination } from './components/read-pagination'

--- a/application/packages/web/src/client/routes/analytics/page.tsx
+++ b/application/packages/web/src/client/routes/analytics/page.tsx
@@ -8,8 +8,8 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from '@/client/components/shadcn/chart'
+import LoginRequired from '@/client/components/ui/feedback/login-required'
 import {
-  DiaryLoginRequired,
   DiaryPageLayout,
   DiaryReadListSection,
   DiaryReadPagination,
@@ -86,7 +86,7 @@ export default function AnalyticsPage({
   }
 
   if (!isLoggedIn) {
-    return <DiaryLoginRequired pageTitle={pageTitle} />
+    return <LoginRequired pageTitle={pageTitle} />
   }
 
   return (

--- a/application/packages/web/src/client/routes/diary/page.tsx
+++ b/application/packages/web/src/client/routes/diary/page.tsx
@@ -1,5 +1,5 @@
+import LoginRequired from '@/client/components/ui/feedback/login-required'
 import {
-  DiaryLoginRequired,
   DiaryPageLayout,
   DiaryReadListSection,
   DiaryReadPagination,
@@ -38,7 +38,7 @@ export default function DiaryPage({
   const pageTitle = 'ダイアリー'
 
   if (!isLoggedIn) {
-    return <DiaryLoginRequired pageTitle={pageTitle} />
+    return <LoginRequired pageTitle={pageTitle} />
   }
 
   return (

--- a/application/packages/web/src/client/routes/inbox/page.tsx
+++ b/application/packages/web/src/client/routes/inbox/page.tsx
@@ -2,6 +2,7 @@ import { isArticleMedia } from '@trend-diary/domain/article/media'
 import { CheckCircle2 } from 'lucide-react'
 import { Button } from '@/client/components/shadcn/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/client/components/shadcn/tooltip'
+import LoginRequired from '@/client/components/ui/feedback/login-required'
 import {
   MediaFilter,
   MediaIcon,
@@ -41,12 +42,7 @@ export default function InboxPage({
   onMediaChange,
 }: Props) {
   if (!isLoggedIn) {
-    return (
-      <div className='p-6'>
-        <h1 className='text-xl font-semibold text-gray-900'>未読消化</h1>
-        <p className='mt-4 text-sm text-gray-600'>この機能はログイン時のみ利用できます</p>
-      </div>
-    )
+    return <LoginRequired pageTitle='未読消化' />
   }
 
   return (


### PR DESCRIPTION
## 概要

未ログイン時のフォールバックUI（「この機能はログイン時のみ利用できます」）が複数箇所で重複していたため、共通コンポーネントに集約しました。

## 背景

未ログイン時のフォールバック表示は本来共通処理であるべきですが、以下のように分散・重複していました。

- `features/diary/components/login-required.tsx`（`DiaryLoginRequired`） … diary / analytics ページで利用
- `routes/inbox/page.tsx` … 同一UIをインラインで重複実装（句点だけが欠落していた）

## 変更内容

- `components/ui/feedback/login-required`（`LoginRequired`）として共通コンポーネントを新設
  - 既存の `loading-spinner` と同じ「ページ状態系」の置き場所に揃えています
- diary / analytics / inbox の各ページを共通コンポーネント利用に統一
- diary フィーチャー固有だった `DiaryLoginRequired` とその re-export を削除

## 確認

- `pnpm check:fix`（oxlint / oxfmt）: 既存warningのみ、本変更起因の指摘なし
- `pnpm --filter @trend-diary/web typecheck`: 通過
- 対象ページのテスト（diary / inbox / analytics）: 9件すべて通過

https://claude.ai/code/session_01QiVKzTZydNwv1j4vkyfJA6

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiVKzTZydNwv1j4vkyfJA6)_