### PR TITLE
refactor(web): FilterPanel を FilterParams で受け取るよう構造化

### DIFF
--- a/application/packages/web/src/client/features/article/components/filter-panel/index.tsx
+++ b/application/packages/web/src/client/features/article/components/filter-panel/index.tsx
@@ -1,31 +1,16 @@
 import { useIsMobile } from '@/client/components/shadcn/hooks/use-mobile'
-import { type DatePresetType, type FilterParams } from '../../hooks/use-articles'
-import { type MediaType } from '../media-filter'
-import { type ReadStatusType } from '../read-status-filter'
+import { type FilterParams } from '../../hooks/use-articles'
 import { DesktopFilterPanel } from './desktop-filter-panel'
 import { MobileFilterPanel } from './mobile-filter-panel'
 
 interface FilterPanelProps {
-  selectedMedia: MediaType
-  selectedReadStatus: ReadStatusType
-  selectedDatePreset: DatePresetType
+  applied: FilterParams
   onApplyFilters: (filters: FilterParams) => void
   isLoggedIn: boolean
 }
 
-export function FilterPanel({
-  selectedMedia,
-  selectedReadStatus,
-  selectedDatePreset,
-  onApplyFilters,
-  isLoggedIn,
-}: FilterPanelProps) {
+export function FilterPanel({ applied, onApplyFilters, isLoggedIn }: FilterPanelProps) {
   const isMobile = useIsMobile()
-  const applied: FilterParams = {
-    media: selectedMedia,
-    readStatus: selectedReadStatus,
-    datePreset: selectedDatePreset,
-  }
 
   return isMobile ? (
     <MobileFilterPanel applied={applied} isLoggedIn={isLoggedIn} onApplyFilters={onApplyFilters} />

--- a/application/packages/web/src/client/routes/trends._index/page.tsx
+++ b/application/packages/web/src/client/routes/trends._index/page.tsx
@@ -61,6 +61,12 @@ export default function TrendsPage({
   const isPrevDisabled = page <= 1
   const isNextDisabled = page >= totalPages
 
+  const appliedFilters: FilterParams = {
+    media: selectedMedia,
+    readStatus: selectedReadStatus,
+    datePreset: selectedDatePreset,
+  }
+
   const handleCardClick = (article: Article) => {
     openDrawer(article)
   }
@@ -82,14 +88,11 @@ export default function TrendsPage({
   return (
     <div className='relative min-h-screen bg-gradient-to-br from-gray-100 to-gray-200 p-6'>
       <h1 className='pb-4 text-xl italic'>- {toJaDateString(date)} -</h1>
-      {/* 適用済みフィルタが外部（URL 等）で変わったら draft を初期化したいので key で再マウントする */}
+      {/* 適用済みフィルタが外部（URL 等）で変わったら draft を初期化したいので key で再マウントする。
+          key はフィールド追加時の付け忘れを防ぐため applied の値から導出する */}
       <FilterPanel
-        key={`${selectedMedia ?? ''}__${selectedReadStatus}__${selectedDatePreset}`}
-        applied={{
-          media: selectedMedia,
-          readStatus: selectedReadStatus,
-          datePreset: selectedDatePreset,
-        }}
+        key={Object.values(appliedFilters).join('__')}
+        applied={appliedFilters}
         onApplyFilters={onApplyFilters}
         isLoggedIn={isLoggedIn}
       />

--- a/application/packages/web/src/client/routes/trends._index/page.tsx
+++ b/application/packages/web/src/client/routes/trends._index/page.tsx
@@ -85,9 +85,11 @@ export default function TrendsPage({
       {/* 適用済みフィルタが外部（URL 等）で変わったら draft を初期化したいので key で再マウントする */}
       <FilterPanel
         key={`${selectedMedia ?? ''}__${selectedReadStatus}__${selectedDatePreset}`}
-        selectedMedia={selectedMedia}
-        selectedReadStatus={selectedReadStatus}
-        selectedDatePreset={selectedDatePreset}
+        applied={{
+          media: selectedMedia,
+          readStatus: selectedReadStatus,
+          datePreset: selectedDatePreset,
+        }}
         onApplyFilters={onApplyFilters}
         isLoggedIn={isLoggedIn}
       />


### PR DESCRIPTION
## 概要

`FilterPanel` が個別に受け取っていた `selectedMedia` / `selectedReadStatus` / `selectedDatePreset` の3つを、既存のドメイン型 `FilterParams` にまとめて受け取るよう構造化しました。

## 背景・動機

「props が多いコンポーネントを構造化したい」という相談を起点に、現状コードを確認したところ `FilterPanel` が以下の状態でした。

- 3つのフィルタ条件をバラバラに受け取り、コンポーネント内部で再度 `FilterParams` に組み立て直していた
- 子の `DesktopFilterPanel` / `MobileFilterPanel` や `FilterControls` は既に `FilterParams`（`applied` / `filters`）で受け取っており、`FilterPanel` だけが分解されていて不整合だった

「常にセットで扱われ、既にドメイン型が存在する」典型的な構造化候補のため、ここを揃えました。route 境界の `page.tsx` など、無関係な props が並ぶだけの箇所はフラットなまま据え置いています。

## 変更内容

- `FilterPanel` の props を `applied: FilterParams` に変更し、内部での再組み立てを削除
- 呼び出し側 `trends._index/page.tsx` で `applied` オブジェクトを直接渡すよう更新

## 確認

- `oxlint` / `oxfmt --check`: 変更箇所に新規指摘なし
- `tsgo --noEmit`（typecheck）: パス
- client テスト（vitest `--project client`）: 153 件パス
- ※ server テストと storybook（ブラウザ）テストは実行環境の制約（DB / ブラウザ未起動）で未実施。本変更はクライアント限定のため影響なし

https://claude.ai/code/session_014apn1A7YiAnJsRQ5J5V2ZF

---
_Generated by [Claude Code](https://claude.ai/code/session_014apn1A7YiAnJsRQ5J5V2ZF)_