### PR TITLE
refactor(web): inbox の複雑なロジックを features に切り出す

### DIFF
--- a/application/packages/web/src/client/features/inbox/components/inbox-article-card.tsx
+++ b/application/packages/web/src/client/features/inbox/components/inbox-article-card.tsx
@@ -1,0 +1,68 @@
+import { isArticleMedia } from '@trend-diary/domain/article/media'
+import { Button } from '@/client/components/shadcn/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/client/components/shadcn/tooltip'
+import { MediaIcon, type MediaIconType } from '@/client/features/article'
+import type { Article } from '../hooks/use-unread-digestion'
+
+interface Props {
+  article: Article
+  onSkip: () => Promise<void>
+  onRead: () => Promise<void>
+  onLater: () => void
+}
+
+const toMediaType = (media: string): MediaIconType => {
+  if (isArticleMedia(media)) return media
+  return 'zenn'
+}
+
+export default function InboxArticleCard({ article, onSkip, onRead, onLater }: Props) {
+  return (
+    <div className='mt-2 flex flex-col rounded-xl border border-gray-200 bg-white p-5'>
+      <h2 className='flex h-[2lh] items-start gap-2 text-lg font-semibold text-gray-900 leading-relaxed'>
+        <span className='mt-0.5 shrink-0'>
+          <MediaIcon media={toMediaType(article.media)} size='md' />
+        </span>
+        <span className='line-clamp-2'>{article.title}</span>
+      </h2>
+      <div className='mt-2 flex h-[1lh] items-center gap-3 overflow-hidden text-sm text-gray-600'>
+        <span className='min-w-0 truncate'>著者: {article.author}</span>
+      </div>
+      <p className='mt-3 h-24 overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words pr-1 text-sm leading-relaxed text-gray-700 md:h-56'>
+        {article.description}
+      </p>
+      <div className='sticky bottom-0 -mx-5 mt-3 flex flex-wrap gap-2 border-t border-gray-200 bg-white/95 px-5 pt-3 pb-1 md:static md:mx-0 md:mt-4 md:border-0 md:bg-transparent md:p-0'>
+        <Tooltip>
+          <TooltipTrigger asChild={true}>
+            <Button type='button' variant='outline' onClick={onSkip}>
+              スキップ
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side='top' align='start' className='bg-primary/85'>
+            対象外にする
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild={true}>
+            <Button type='button' onClick={onRead}>
+              読む
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side='top' align='start' className='bg-primary/85'>
+            読んで消化する
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild={true}>
+            <Button type='button' variant='secondary' onClick={onLater}>
+              後で
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side='top' align='start' className='bg-primary/85'>
+            このセッション内であとで見る
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
+  )
+}

--- a/application/packages/web/src/client/features/inbox/components/inbox-article-card.tsx
+++ b/application/packages/web/src/client/features/inbox/components/inbox-article-card.tsx
@@ -11,7 +11,7 @@ interface Props {
   onLater: () => void
 }
 
-const toMediaType = (media: string): MediaIconType => {
+function toMediaType(media: string): MediaIconType {
   if (isArticleMedia(media)) return media
   return 'zenn'
 }

--- a/application/packages/web/src/client/features/inbox/components/inbox-body.tsx
+++ b/application/packages/web/src/client/features/inbox/components/inbox-body.tsx
@@ -2,7 +2,7 @@ import type { Article } from '../hooks/use-unread-digestion'
 import InboxArticleCard from './inbox-article-card'
 import InboxCompletionCard from './inbox-completion-card'
 
-interface Props {
+export interface InboxBodyProps {
   article: Article | null
   isJustCompleted: boolean
   onSkip: () => Promise<void>
@@ -10,7 +10,13 @@ interface Props {
   onLater: () => void
 }
 
-export default function InboxBody({ article, isJustCompleted, onSkip, onRead, onLater }: Props) {
+export default function InboxBody({
+  article,
+  isJustCompleted,
+  onSkip,
+  onRead,
+  onLater,
+}: InboxBodyProps) {
   if (article) {
     return <InboxArticleCard article={article} onSkip={onSkip} onRead={onRead} onLater={onLater} />
   }

--- a/application/packages/web/src/client/features/inbox/components/inbox-body.tsx
+++ b/application/packages/web/src/client/features/inbox/components/inbox-body.tsx
@@ -1,0 +1,32 @@
+import type { Article } from '../hooks/use-unread-digestion'
+import InboxArticleCard from './inbox-article-card'
+import InboxCompletionCard from './inbox-completion-card'
+
+interface Props {
+  article: Article | null
+  isLoading: boolean
+  isJustCompleted: boolean
+  onSkip: () => Promise<void>
+  onRead: () => Promise<void>
+  onLater: () => void
+}
+
+export default function InboxBody({
+  article,
+  isLoading,
+  isJustCompleted,
+  onSkip,
+  onRead,
+  onLater,
+}: Props) {
+  if (isLoading) {
+    return <p className='mt-4 text-sm text-gray-600'>読み込み中...</p>
+  }
+  if (article) {
+    return <InboxArticleCard article={article} onSkip={onSkip} onRead={onRead} onLater={onLater} />
+  }
+  if (isJustCompleted) {
+    return <InboxCompletionCard />
+  }
+  return <p className='mt-4 text-sm text-gray-600'>未読記事はありません</p>
+}

--- a/application/packages/web/src/client/features/inbox/components/inbox-body.tsx
+++ b/application/packages/web/src/client/features/inbox/components/inbox-body.tsx
@@ -4,24 +4,13 @@ import InboxCompletionCard from './inbox-completion-card'
 
 interface Props {
   article: Article | null
-  isLoading: boolean
   isJustCompleted: boolean
   onSkip: () => Promise<void>
   onRead: () => Promise<void>
   onLater: () => void
 }
 
-export default function InboxBody({
-  article,
-  isLoading,
-  isJustCompleted,
-  onSkip,
-  onRead,
-  onLater,
-}: Props) {
-  if (isLoading) {
-    return <p className='mt-4 text-sm text-gray-600'>読み込み中...</p>
-  }
+export default function InboxBody({ article, isJustCompleted, onSkip, onRead, onLater }: Props) {
   if (article) {
     return <InboxArticleCard article={article} onSkip={onSkip} onRead={onRead} onLater={onLater} />
   }

--- a/application/packages/web/src/client/features/inbox/components/inbox-completion-card.tsx
+++ b/application/packages/web/src/client/features/inbox/components/inbox-completion-card.tsx
@@ -1,0 +1,20 @@
+import { CheckCircle2 } from 'lucide-react'
+
+export default function InboxCompletionCard() {
+  return (
+    <section
+      data-slot='inbox-completion-card'
+      className='animate-in fade-in zoom-in-95 mt-4 rounded-xl border border-emerald-200 bg-emerald-50/80 p-5 text-emerald-900 duration-700'
+    >
+      <span className='inline-flex items-center rounded-full border border-emerald-300 bg-emerald-100 px-2.5 py-0.5 text-xs font-semibold'>
+        消化完了
+      </span>
+      <div className='mt-3 flex items-center gap-2'>
+        <CheckCircle2 className='h-5 w-5 shrink-0' />
+        <p className='text-sm leading-relaxed text-emerald-800'>
+          いいペース。次の更新までこのペースをキープしよう。
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/application/packages/web/src/client/features/inbox/hooks/use-completion-celebration.ts
+++ b/application/packages/web/src/client/features/inbox/hooks/use-completion-celebration.ts
@@ -1,0 +1,95 @@
+import { useEffect, useRef, useState } from 'react'
+
+const CompletionPendingStorageKey = 'inbox-completion-pending'
+const CompletionDisplayDurationMs = 2500
+
+const setCompletionPending = (pending: boolean) => {
+  try {
+    if (pending) {
+      window.sessionStorage.setItem(CompletionPendingStorageKey, '1')
+      return
+    }
+
+    window.sessionStorage.removeItem(CompletionPendingStorageKey)
+  } catch {
+    // INFO: ストレージ利用不可環境では完了演出の遅延再生を無効化する
+  }
+}
+
+const hasCompletionPending = () => {
+  try {
+    return window.sessionStorage.getItem(CompletionPendingStorageKey) === '1'
+  } catch {
+    return false
+  }
+}
+
+interface Params {
+  remaining: number
+  queueLength: number
+  // 新しいバッチを取得したことを判別するための参照。変化したらデータ起因の0件とみなす
+  batchToken: unknown
+}
+
+// 未読を消化しきった瞬間だけ完了演出を出すためのフック。
+// 「操作で消化した」事実は actionConsumedRef が持ち、それが立つのは表示中の記事を
+// 消化した時＝直前まで remaining>0 だった時に限る。データ起因の0件では立てない。
+export default function useCompletionCelebration({ remaining, queueLength, batchToken }: Params) {
+  const [isJustCompleted, setIsJustCompleted] = useState(false)
+  const actionConsumedRef = useRef(false)
+
+  // 表示中の記事を操作で消化したことを伝える。完了演出の発火条件になる
+  const notifyConsumed = () => {
+    actionConsumedRef.current = true
+  }
+
+  useEffect(() => {
+    // 新しいバッチ取得でリセットし、データ起因の0件で演出が出ないようにする
+    actionConsumedRef.current = false
+  }, [batchToken])
+
+  useEffect(() => {
+    const reachedZeroByAction = remaining === 0 && actionConsumedRef.current
+    const shouldPlayCompletion = reachedZeroByAction || (remaining === 0 && hasCompletionPending())
+
+    if (shouldPlayCompletion && document.visibilityState === 'visible') {
+      setIsJustCompleted(true)
+      setCompletionPending(false)
+    } else if (reachedZeroByAction) {
+      // 操作直後にタブが非表示（別タブで読了等）なら、復帰時に演出を再生するため保留にする
+      setCompletionPending(true)
+    }
+
+    actionConsumedRef.current = false
+  }, [remaining])
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== 'visible') return
+      if (queueLength !== 0) return
+      if (!hasCompletionPending()) return
+
+      setIsJustCompleted(true)
+      setCompletionPending(false)
+    }
+
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [queueLength])
+
+  useEffect(() => {
+    if (!isJustCompleted) return
+
+    const timerId = window.setTimeout(() => {
+      setIsJustCompleted(false)
+    }, CompletionDisplayDurationMs)
+
+    return () => {
+      window.clearTimeout(timerId)
+    }
+  }, [isJustCompleted])
+
+  return { isJustCompleted, notifyConsumed }
+}

--- a/application/packages/web/src/client/features/inbox/hooks/use-completion-celebration.ts
+++ b/application/packages/web/src/client/features/inbox/hooks/use-completion-celebration.ts
@@ -1,50 +1,11 @@
-import { Result } from 'neverthrow'
-import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import {
+  hasCompletionPending,
+  setCompletionPending,
+} from '@/client/features/inbox/model/completion-pending-storage'
+import useDocumentVisibility from './use-document-visibility'
 
-const CompletionPendingStorageKey = 'inbox-completion-pending'
 const CompletionDisplayDurationMs = 2500
-
-// sessionStorage はストレージ無効環境（プライベートモード等）で例外を投げうるため Result で包む
-const readPendingFlag = Result.fromThrowable(() =>
-  window.sessionStorage.getItem(CompletionPendingStorageKey),
-)
-const writePendingFlag = Result.fromThrowable(() =>
-  window.sessionStorage.setItem(CompletionPendingStorageKey, '1'),
-)
-const clearPendingFlag = Result.fromThrowable(() =>
-  window.sessionStorage.removeItem(CompletionPendingStorageKey),
-)
-
-function setCompletionPending(pending: boolean) {
-  // 保存できない環境では遅延再生を諦めるだけなので結果は問わない
-  if (pending) {
-    writePendingFlag()
-    return
-  }
-
-  clearPendingFlag()
-}
-
-function hasCompletionPending() {
-  return readPendingFlag()
-    .map((value) => value === '1')
-    .unwrapOr(false)
-}
-
-function subscribeVisibility(onStoreChange: () => void) {
-  document.addEventListener('visibilitychange', onStoreChange)
-  return () => {
-    document.removeEventListener('visibilitychange', onStoreChange)
-  }
-}
-
-function getVisibilitySnapshot() {
-  return document.visibilityState
-}
-// SSR では可視扱いにし、ハイドレーション後のちらつきを避ける
-function getVisibilityServerSnapshot() {
-  return 'visible' as const
-}
 
 interface Params {
   remaining: number
@@ -59,11 +20,7 @@ interface Params {
 export default function useCompletionCelebration({ remaining, queueLength, batchToken }: Params) {
   const [isJustCompleted, setIsJustCompleted] = useState(false)
   const actionConsumedRef = useRef(false)
-  const visibilityState = useSyncExternalStore(
-    subscribeVisibility,
-    getVisibilitySnapshot,
-    getVisibilityServerSnapshot,
-  )
+  const visibilityState = useDocumentVisibility()
 
   // 表示中の記事を操作で消化したことを伝える。完了演出の発火条件になる
   const notifyConsumed = () => {

--- a/application/packages/web/src/client/features/inbox/hooks/use-completion-celebration.ts
+++ b/application/packages/web/src/client/features/inbox/hooks/use-completion-celebration.ts
@@ -1,39 +1,50 @@
+import { Result } from 'neverthrow'
 import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 
 const CompletionPendingStorageKey = 'inbox-completion-pending'
 const CompletionDisplayDurationMs = 2500
 
-const setCompletionPending = (pending: boolean) => {
-  try {
-    if (pending) {
-      window.sessionStorage.setItem(CompletionPendingStorageKey, '1')
-      return
-    }
+// sessionStorage はストレージ無効環境（プライベートモード等）で例外を投げうるため Result で包む
+const readPendingFlag = Result.fromThrowable(() =>
+  window.sessionStorage.getItem(CompletionPendingStorageKey),
+)
+const writePendingFlag = Result.fromThrowable(() =>
+  window.sessionStorage.setItem(CompletionPendingStorageKey, '1'),
+)
+const clearPendingFlag = Result.fromThrowable(() =>
+  window.sessionStorage.removeItem(CompletionPendingStorageKey),
+)
 
-    window.sessionStorage.removeItem(CompletionPendingStorageKey)
-  } catch {
-    // INFO: ストレージ利用不可環境では完了演出の遅延再生を無効化する
+function setCompletionPending(pending: boolean) {
+  // 保存できない環境では遅延再生を諦めるだけなので結果は問わない
+  if (pending) {
+    writePendingFlag()
+    return
   }
+
+  clearPendingFlag()
 }
 
-const hasCompletionPending = () => {
-  try {
-    return window.sessionStorage.getItem(CompletionPendingStorageKey) === '1'
-  } catch {
-    return false
-  }
+function hasCompletionPending() {
+  return readPendingFlag()
+    .map((value) => value === '1')
+    .unwrapOr(false)
 }
 
-const subscribeVisibility = (onStoreChange: () => void) => {
+function subscribeVisibility(onStoreChange: () => void) {
   document.addEventListener('visibilitychange', onStoreChange)
   return () => {
     document.removeEventListener('visibilitychange', onStoreChange)
   }
 }
 
-const getVisibilitySnapshot = () => document.visibilityState
+function getVisibilitySnapshot() {
+  return document.visibilityState
+}
 // SSR では可視扱いにし、ハイドレーション後のちらつきを避ける
-const getVisibilityServerSnapshot = () => 'visible' as const
+function getVisibilityServerSnapshot() {
+  return 'visible' as const
+}
 
 interface Params {
   remaining: number

--- a/application/packages/web/src/client/features/inbox/hooks/use-completion-celebration.ts
+++ b/application/packages/web/src/client/features/inbox/hooks/use-completion-celebration.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 
 const CompletionPendingStorageKey = 'inbox-completion-pending'
 const CompletionDisplayDurationMs = 2500
@@ -24,6 +24,17 @@ const hasCompletionPending = () => {
   }
 }
 
+const subscribeVisibility = (onStoreChange: () => void) => {
+  document.addEventListener('visibilitychange', onStoreChange)
+  return () => {
+    document.removeEventListener('visibilitychange', onStoreChange)
+  }
+}
+
+const getVisibilitySnapshot = () => document.visibilityState
+// SSR では可視扱いにし、ハイドレーション後のちらつきを避ける
+const getVisibilityServerSnapshot = () => 'visible' as const
+
 interface Params {
   remaining: number
   queueLength: number
@@ -37,6 +48,11 @@ interface Params {
 export default function useCompletionCelebration({ remaining, queueLength, batchToken }: Params) {
   const [isJustCompleted, setIsJustCompleted] = useState(false)
   const actionConsumedRef = useRef(false)
+  const visibilityState = useSyncExternalStore(
+    subscribeVisibility,
+    getVisibilitySnapshot,
+    getVisibilityServerSnapshot,
+  )
 
   // 表示中の記事を操作で消化したことを伝える。完了演出の発火条件になる
   const notifyConsumed = () => {
@@ -52,7 +68,7 @@ export default function useCompletionCelebration({ remaining, queueLength, batch
     const reachedZeroByAction = remaining === 0 && actionConsumedRef.current
     const shouldPlayCompletion = reachedZeroByAction || (remaining === 0 && hasCompletionPending())
 
-    if (shouldPlayCompletion && document.visibilityState === 'visible') {
+    if (shouldPlayCompletion && visibilityState === 'visible') {
       setIsJustCompleted(true)
       setCompletionPending(false)
     } else if (reachedZeroByAction) {
@@ -61,23 +77,17 @@ export default function useCompletionCelebration({ remaining, queueLength, batch
     }
 
     actionConsumedRef.current = false
-  }, [remaining])
+  }, [remaining, visibilityState])
 
   useEffect(() => {
-    const handleVisibilityChange = () => {
-      if (document.visibilityState !== 'visible') return
-      if (queueLength !== 0) return
-      if (!hasCompletionPending()) return
+    // タブ復帰時、保留中の完了演出を再生する
+    if (visibilityState !== 'visible') return
+    if (queueLength !== 0) return
+    if (!hasCompletionPending()) return
 
-      setIsJustCompleted(true)
-      setCompletionPending(false)
-    }
-
-    document.addEventListener('visibilitychange', handleVisibilityChange)
-    return () => {
-      document.removeEventListener('visibilitychange', handleVisibilityChange)
-    }
-  }, [queueLength])
+    setIsJustCompleted(true)
+    setCompletionPending(false)
+  }, [visibilityState, queueLength])
 
   useEffect(() => {
     if (!isJustCompleted) return

--- a/application/packages/web/src/client/features/inbox/hooks/use-document-visibility.ts
+++ b/application/packages/web/src/client/features/inbox/hooks/use-document-visibility.ts
@@ -1,0 +1,21 @@
+import { useSyncExternalStore } from 'react'
+
+function subscribe(onStoreChange: () => void) {
+  document.addEventListener('visibilitychange', onStoreChange)
+  return () => {
+    document.removeEventListener('visibilitychange', onStoreChange)
+  }
+}
+
+function getSnapshot() {
+  return document.visibilityState
+}
+
+// SSR では可視扱いにし、ハイドレーション後のちらつきを避ける
+function getServerSnapshot() {
+  return 'visible' as const
+}
+
+export default function useDocumentVisibility() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}

--- a/application/packages/web/src/client/features/inbox/hooks/use-unread-digestion.ts
+++ b/application/packages/web/src/client/features/inbox/hooks/use-unread-digestion.ts
@@ -25,27 +25,29 @@ export default function useUnreadDigestion(enabled: boolean, selectedMedia: Medi
   const [remaining, setRemaining] = useState(0)
   const [isActionLoading, setIsActionLoading] = useState(false)
   const swrKey = enabled ? ['api/articles/unread-digestion', selectedMedia] : null
-  const { data, isLoading, isValidating, mutate } = useSWR<UnreadDigestionResponse>(
-    swrKey,
-    async () => {
-      const query = selectedMedia ? { media: selectedMedia } : {}
-      const result = await apiCall<UnreadDigestionResponse>(() =>
-        client.articles['unread-digestion'].$get({ query }, { init: { credentials: 'include' } }),
-      )
+  const {
+    data,
+    isLoading: isInitialLoading,
+    isValidating,
+    mutate,
+  } = useSWR<UnreadDigestionResponse>(swrKey, async () => {
+    const query = selectedMedia ? { media: selectedMedia } : {}
+    const result = await apiCall<UnreadDigestionResponse>(() =>
+      client.articles['unread-digestion'].$get({ query }, { init: { credentials: 'include' } }),
+    )
 
-      if (!result) {
-        throw new Error('未読消化データの取得に失敗しました')
-      }
+    if (!result) {
+      throw new Error('未読消化データの取得に失敗しました')
+    }
 
-      return {
-        data: result.data.map((article) => ({
-          ...article,
-          createdAt: new Date(article.createdAt),
-        })),
-        total: result.total,
-      }
-    },
-  )
+    return {
+      data: result.data.map((article) => ({
+        ...article,
+        createdAt: new Date(article.createdAt),
+      })),
+      total: result.total,
+    }
+  })
 
   const { isJustCompleted, notifyConsumed } = useCompletionCelebration({
     remaining,
@@ -127,9 +129,12 @@ export default function useUnreadDigestion(enabled: boolean, selectedMedia: Medi
     })
   }
 
+  // 次バッチ取得中はキューが空になる。記事表示中のフォーカス再検証ではキューが残るのでローディングを出さない
+  const isFetchingNextBatch = isValidating && queue.length === 0
+  const isLoading = isInitialLoading || isActionLoading || isFetchingNextBatch
+
   return {
-    // 次バッチ取得中はキューが空。記事表示中のフォーカス再検証ではローディングを出さない
-    isLoading: isLoading || isActionLoading || (isValidating && queue.length === 0),
+    isLoading,
     isJustCompleted,
     currentArticle,
     remainingCount: remaining,

--- a/application/packages/web/src/client/features/inbox/hooks/use-unread-digestion.ts
+++ b/application/packages/web/src/client/features/inbox/hooks/use-unread-digestion.ts
@@ -1,5 +1,5 @@
 import type { ArticleOutput } from '@trend-diary/domain/article/schema/article-schema'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { toast } from 'sonner'
 import useSWR from 'swr'
 import { type MediaType, useReadArticle } from '@/client/features/article'
@@ -24,6 +24,8 @@ export default function useUnreadDigestion(enabled: boolean, selectedMedia: Medi
   // バッチ件数ではなく未読総数。残件表示と完了判定の基準にする
   const [remaining, setRemaining] = useState(0)
   const [isActionLoading, setIsActionLoading] = useState(false)
+  // 直近で同期済みのバッチ。SWR が新しい応答を返したか（参照が変わったか）の判定に使う
+  const [syncedBatch, setSyncedBatch] = useState<UnreadDigestionResponse>()
   const swrKey = enabled ? ['api/articles/unread-digestion', selectedMedia] : null
   const {
     data,
@@ -49,19 +51,19 @@ export default function useUnreadDigestion(enabled: boolean, selectedMedia: Medi
     }
   })
 
+  // SWR が新しいバッチを返したらキュー/残数を同期する。消化中の楽観更新は次の取得まで保持する。
+  // SWR は同一内容の再取得では data の参照を保つため、深く等しい応答ではここをスキップできる
+  if (data && data !== syncedBatch) {
+    setSyncedBatch(data)
+    setRemaining(data.total)
+    setQueue(data.data)
+  }
+
   const { isJustCompleted, notifyConsumed } = useCompletionCelebration({
     remaining,
     queueLength: queue.length,
     batchToken: data,
   })
-
-  useEffect(() => {
-    if (!data) return
-
-    // 取得のたびにサーバ総数へ同期し、消化中の楽観的減算のズレを補正する
-    setRemaining(data.total)
-    setQueue(data.data)
-  }, [data])
 
   const currentArticle = queue[0] ?? null
 

--- a/application/packages/web/src/client/features/inbox/hooks/use-unread-digestion.ts
+++ b/application/packages/web/src/client/features/inbox/hooks/use-unread-digestion.ts
@@ -1,9 +1,10 @@
 import type { ArticleOutput } from '@trend-diary/domain/article/schema/article-schema'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import useSWR from 'swr'
 import { type MediaType, useReadArticle } from '@/client/features/article'
 import createSWRFetcher from '@/client/infrastructure/create-swr-fetcher'
+import useCompletionCelebration from './use-completion-celebration'
 
 export type Article = Omit<ArticleOutput, 'articleId'> & {
   articleId: string
@@ -15,29 +16,6 @@ interface UnreadDigestionResponse {
 }
 
 const SkipErrorMessage = 'スキップに失敗しました'
-const CompletionPendingStorageKey = 'inbox-completion-pending'
-const CompletionDisplayDurationMs = 2500
-
-const setCompletionPending = (pending: boolean) => {
-  try {
-    if (pending) {
-      window.sessionStorage.setItem(CompletionPendingStorageKey, '1')
-      return
-    }
-
-    window.sessionStorage.removeItem(CompletionPendingStorageKey)
-  } catch {
-    // INFO: ストレージ利用不可環境では完了演出の遅延再生を無効化する
-  }
-}
-
-const hasCompletionPending = () => {
-  try {
-    return window.sessionStorage.getItem(CompletionPendingStorageKey) === '1'
-  } catch {
-    return false
-  }
-}
 
 export default function useUnreadDigestion(enabled: boolean, selectedMedia: MediaType) {
   const { client, apiCall } = createSWRFetcher()
@@ -46,9 +24,6 @@ export default function useUnreadDigestion(enabled: boolean, selectedMedia: Medi
   // バッチ件数ではなく未読総数。残件表示と完了判定の基準にする
   const [remaining, setRemaining] = useState(0)
   const [isActionLoading, setIsActionLoading] = useState(false)
-  const [isJustCompleted, setIsJustCompleted] = useState(false)
-  const completionTriggeredByActionRef = useRef(false)
-
   const swrKey = enabled ? ['api/articles/unread-digestion', selectedMedia] : null
   const { data, isLoading, isValidating, mutate } = useSWR<UnreadDigestionResponse>(
     swrKey,
@@ -72,65 +47,24 @@ export default function useUnreadDigestion(enabled: boolean, selectedMedia: Medi
     },
   )
 
+  const { isJustCompleted, notifyConsumed } = useCompletionCelebration({
+    remaining,
+    queueLength: queue.length,
+    batchToken: data,
+  })
+
   useEffect(() => {
     if (!data) return
 
-    completionTriggeredByActionRef.current = false
     // 取得のたびにサーバ総数へ同期し、消化中の楽観的減算のズレを補正する
     setRemaining(data.total)
     setQueue(data.data)
   }, [data])
 
-  useEffect(() => {
-    // 完了演出はサーバ未読総数が操作によって0に達した時だけ出す。
-    // 「操作で消化した」事実は completionTriggeredByActionRef が持ち、
-    // それが立つのは表示中の記事を消化した時＝直前まで remaining>0 だった時に限る
-    const reachedZeroByAction = remaining === 0 && completionTriggeredByActionRef.current
-    const shouldPlayCompletion = reachedZeroByAction || (remaining === 0 && hasCompletionPending())
-
-    if (shouldPlayCompletion && document.visibilityState === 'visible') {
-      setIsJustCompleted(true)
-      setCompletionPending(false)
-    } else if (reachedZeroByAction) {
-      // 操作直後にタブが非表示（別タブで読了等）なら、復帰時に演出を再生するため保留にする
-      setCompletionPending(true)
-    }
-
-    completionTriggeredByActionRef.current = false
-  }, [remaining])
-
-  useEffect(() => {
-    const handleVisibilityChange = () => {
-      if (document.visibilityState !== 'visible') return
-      if (queue.length !== 0) return
-      if (!hasCompletionPending()) return
-
-      setIsJustCompleted(true)
-      setCompletionPending(false)
-    }
-
-    document.addEventListener('visibilitychange', handleVisibilityChange)
-    return () => {
-      document.removeEventListener('visibilitychange', handleVisibilityChange)
-    }
-  }, [queue.length])
-
-  useEffect(() => {
-    if (!isJustCompleted) return
-
-    const timerId = window.setTimeout(() => {
-      setIsJustCompleted(false)
-    }, CompletionDisplayDurationMs)
-
-    return () => {
-      window.clearTimeout(timerId)
-    }
-  }, [isJustCompleted])
-
   const currentArticle = queue[0] ?? null
 
   const consumeCurrent = () => {
-    completionTriggeredByActionRef.current = true
+    notifyConsumed()
     setRemaining((prev) => Math.max(0, prev - 1))
     setQueue((prev) => prev.slice(1))
   }

--- a/application/packages/web/src/client/features/inbox/index.ts
+++ b/application/packages/web/src/client/features/inbox/index.ts
@@ -1,3 +1,4 @@
 export { default as InboxArticleCard } from './components/inbox-article-card'
+export { default as InboxBody } from './components/inbox-body'
 export { default as InboxCompletionCard } from './components/inbox-completion-card'
 export { default as useUnreadDigestion, type Article } from './hooks/use-unread-digestion'

--- a/application/packages/web/src/client/features/inbox/index.ts
+++ b/application/packages/web/src/client/features/inbox/index.ts
@@ -1,4 +1,4 @@
 export { default as InboxArticleCard } from './components/inbox-article-card'
-export { default as InboxBody } from './components/inbox-body'
+export { default as InboxBody, type InboxBodyProps } from './components/inbox-body'
 export { default as InboxCompletionCard } from './components/inbox-completion-card'
 export { default as useUnreadDigestion, type Article } from './hooks/use-unread-digestion'

--- a/application/packages/web/src/client/features/inbox/index.ts
+++ b/application/packages/web/src/client/features/inbox/index.ts
@@ -1,1 +1,3 @@
+export { default as InboxArticleCard } from './components/inbox-article-card'
+export { default as InboxCompletionCard } from './components/inbox-completion-card'
 export { default as useUnreadDigestion, type Article } from './hooks/use-unread-digestion'

--- a/application/packages/web/src/client/features/inbox/model/completion-pending-storage.ts
+++ b/application/packages/web/src/client/features/inbox/model/completion-pending-storage.ts
@@ -1,0 +1,24 @@
+import { Result } from 'neverthrow'
+
+const StorageKey = 'inbox-completion-pending'
+
+// sessionStorage はストレージ無効環境（プライベートモード等）で例外を投げうるため Result で包む
+const writeFlag = Result.fromThrowable((pending: boolean) => {
+  if (pending) {
+    window.sessionStorage.setItem(StorageKey, '1')
+    return
+  }
+
+  window.sessionStorage.removeItem(StorageKey)
+})
+
+const readFlag = Result.fromThrowable(() => window.sessionStorage.getItem(StorageKey) === '1')
+
+// 完了演出を後で再生するための保留状態。保存できない環境では諦めるだけなので結果は問わない
+export function setCompletionPending(pending: boolean) {
+  writeFlag(pending)
+}
+
+export function hasCompletionPending() {
+  return readFlag().unwrapOr(false)
+}

--- a/application/packages/web/src/client/routes/inbox/page.tsx
+++ b/application/packages/web/src/client/routes/inbox/page.tsx
@@ -1,14 +1,5 @@
-import { isArticleMedia } from '@trend-diary/domain/article/media'
-import { CheckCircle2 } from 'lucide-react'
-import { Button } from '@/client/components/shadcn/button'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/client/components/shadcn/tooltip'
-import {
-  MediaFilter,
-  MediaIcon,
-  type MediaIconType as IconMediaType,
-  type MediaType as FilterMediaType,
-} from '@/client/features/article'
-import type { Article } from '@/client/features/inbox'
+import { MediaFilter, type MediaType as FilterMediaType } from '@/client/features/article'
+import { type Article, InboxArticleCard, InboxCompletionCard } from '@/client/features/inbox'
 
 interface Props {
   article: Article | null
@@ -21,11 +12,6 @@ interface Props {
   remainingCount: number
   selectedMedia: FilterMediaType
   onMediaChange: (media: FilterMediaType) => void
-}
-
-const toMediaType = (media: string): IconMediaType => {
-  if (isArticleMedia(media)) return media
-  return 'zenn'
 }
 
 export default function InboxPage({
@@ -66,70 +52,10 @@ export default function InboxPage({
           <p className='mt-4 text-sm text-gray-600'>未読記事はありません</p>
         )}
 
-        {!isLoading && !article && isJustCompleted && (
-          <section
-            data-slot='inbox-completion-card'
-            className='animate-in fade-in zoom-in-95 mt-4 rounded-xl border border-emerald-200 bg-emerald-50/80 p-5 text-emerald-900 duration-700'
-          >
-            <span className='inline-flex items-center rounded-full border border-emerald-300 bg-emerald-100 px-2.5 py-0.5 text-xs font-semibold'>
-              消化完了
-            </span>
-            <div className='mt-3 flex items-center gap-2'>
-              <CheckCircle2 className='h-5 w-5 shrink-0' />
-              <p className='text-sm leading-relaxed text-emerald-800'>
-                いいペース。次の更新までこのペースをキープしよう。
-              </p>
-            </div>
-          </section>
-        )}
+        {!isLoading && !article && isJustCompleted && <InboxCompletionCard />}
 
         {!isLoading && article && (
-          <div className='mt-2 flex flex-col rounded-xl border border-gray-200 bg-white p-5'>
-            <h2 className='flex h-[2lh] items-start gap-2 text-lg font-semibold text-gray-900 leading-relaxed'>
-              <span className='mt-0.5 shrink-0'>
-                <MediaIcon media={toMediaType(article.media)} size='md' />
-              </span>
-              <span className='line-clamp-2'>{article.title}</span>
-            </h2>
-            <div className='mt-2 flex h-[1lh] items-center gap-3 overflow-hidden text-sm text-gray-600'>
-              <span className='min-w-0 truncate'>著者: {article.author}</span>
-            </div>
-            <p className='mt-3 h-24 overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words pr-1 text-sm leading-relaxed text-gray-700 md:h-56'>
-              {article.description}
-            </p>
-            <div className='sticky bottom-0 -mx-5 mt-3 flex flex-wrap gap-2 border-t border-gray-200 bg-white/95 px-5 pt-3 pb-1 md:static md:mx-0 md:mt-4 md:border-0 md:bg-transparent md:p-0'>
-              <Tooltip>
-                <TooltipTrigger asChild={true}>
-                  <Button type='button' variant='outline' onClick={onSkip}>
-                    スキップ
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side='top' align='start' className='bg-primary/85'>
-                  対象外にする
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild={true}>
-                  <Button type='button' onClick={onRead}>
-                    読む
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side='top' align='start' className='bg-primary/85'>
-                  読んで消化する
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild={true}>
-                  <Button type='button' variant='secondary' onClick={onLater}>
-                    後で
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side='top' align='start' className='bg-primary/85'>
-                  このセッション内であとで見る
-                </TooltipContent>
-              </Tooltip>
-            </div>
-          </div>
+          <InboxArticleCard article={article} onSkip={onSkip} onRead={onRead} onLater={onLater} />
         )}
       </div>
     </div>

--- a/application/packages/web/src/client/routes/inbox/page.tsx
+++ b/application/packages/web/src/client/routes/inbox/page.tsx
@@ -1,6 +1,6 @@
 import LoginRequired from '@/client/components/ui/feedback/login-required'
 import { MediaFilter, type MediaType as FilterMediaType } from '@/client/features/article'
-import { type Article, InboxArticleCard, InboxCompletionCard } from '@/client/features/inbox'
+import { type Article, InboxBody } from '@/client/features/inbox'
 
 interface Props {
   article: Article | null
@@ -13,28 +13,6 @@ interface Props {
   remainingCount: number
   selectedMedia: FilterMediaType
   onMediaChange: (media: FilterMediaType) => void
-}
-
-interface BodyProps {
-  article: Article | null
-  isLoading: boolean
-  isJustCompleted: boolean
-  onSkip: () => Promise<void>
-  onRead: () => Promise<void>
-  onLater: () => void
-}
-
-function InboxBody({ article, isLoading, isJustCompleted, onSkip, onRead, onLater }: BodyProps) {
-  if (isLoading) {
-    return <p className='mt-4 text-sm text-gray-600'>読み込み中...</p>
-  }
-  if (article) {
-    return <InboxArticleCard article={article} onSkip={onSkip} onRead={onRead} onLater={onLater} />
-  }
-  if (isJustCompleted) {
-    return <InboxCompletionCard />
-  }
-  return <p className='mt-4 text-sm text-gray-600'>未読記事はありません</p>
 }
 
 export default function InboxPage({

--- a/application/packages/web/src/client/routes/inbox/page.tsx
+++ b/application/packages/web/src/client/routes/inbox/page.tsx
@@ -42,14 +42,17 @@ export default function InboxPage({
         </div>
         <p className='mt-1 text-sm text-gray-600'>残り {remainingCount} 件</p>
 
-        <InboxBody
-          article={article}
-          isLoading={isLoading}
-          isJustCompleted={isJustCompleted}
-          onSkip={onSkip}
-          onRead={onRead}
-          onLater={onLater}
-        />
+        {isLoading ? (
+          <p className='mt-4 text-sm text-gray-600'>読み込み中...</p>
+        ) : (
+          <InboxBody
+            article={article}
+            isJustCompleted={isJustCompleted}
+            onSkip={onSkip}
+            onRead={onRead}
+            onLater={onLater}
+          />
+        )}
       </div>
     </div>
   )

--- a/application/packages/web/src/client/routes/inbox/page.tsx
+++ b/application/packages/web/src/client/routes/inbox/page.tsx
@@ -1,15 +1,10 @@
 import LoginRequired from '@/client/components/ui/feedback/login-required'
 import { MediaFilter, type MediaType as FilterMediaType } from '@/client/features/article'
-import { type Article, InboxBody } from '@/client/features/inbox'
+import { InboxBody, type InboxBodyProps } from '@/client/features/inbox'
 
-interface Props {
-  article: Article | null
+interface Props extends InboxBodyProps {
   isLoading: boolean
-  isJustCompleted: boolean
   isLoggedIn: boolean
-  onSkip: () => Promise<void>
-  onRead: () => Promise<void>
-  onLater: () => void
   remainingCount: number
   selectedMedia: FilterMediaType
   onMediaChange: (media: FilterMediaType) => void

--- a/application/packages/web/src/client/routes/inbox/page.tsx
+++ b/application/packages/web/src/client/routes/inbox/page.tsx
@@ -15,6 +15,28 @@ interface Props {
   onMediaChange: (media: FilterMediaType) => void
 }
 
+interface BodyProps {
+  article: Article | null
+  isLoading: boolean
+  isJustCompleted: boolean
+  onSkip: () => Promise<void>
+  onRead: () => Promise<void>
+  onLater: () => void
+}
+
+function InboxBody({ article, isLoading, isJustCompleted, onSkip, onRead, onLater }: BodyProps) {
+  if (isLoading) {
+    return <p className='mt-4 text-sm text-gray-600'>読み込み中...</p>
+  }
+  if (article) {
+    return <InboxArticleCard article={article} onSkip={onSkip} onRead={onRead} onLater={onLater} />
+  }
+  if (isJustCompleted) {
+    return <InboxCompletionCard />
+  }
+  return <p className='mt-4 text-sm text-gray-600'>未読記事はありません</p>
+}
+
 export default function InboxPage({
   article,
   isLoading,
@@ -42,15 +64,14 @@ export default function InboxPage({
         </div>
         <p className='mt-1 text-sm text-gray-600'>残り {remainingCount} 件</p>
 
-        {isLoading ? (
-          <p className='mt-4 text-sm text-gray-600'>読み込み中...</p>
-        ) : article ? (
-          <InboxArticleCard article={article} onSkip={onSkip} onRead={onRead} onLater={onLater} />
-        ) : isJustCompleted ? (
-          <InboxCompletionCard />
-        ) : (
-          <p className='mt-4 text-sm text-gray-600'>未読記事はありません</p>
-        )}
+        <InboxBody
+          article={article}
+          isLoading={isLoading}
+          isJustCompleted={isJustCompleted}
+          onSkip={onSkip}
+          onRead={onRead}
+          onLater={onLater}
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
## 概要

未読消化（inbox）ページに集中していた複雑なロジックを、責務ごとに `features/inbox` 配下へ適切な粒度で切り出しました。挙動の変更はありません。

## 背景

`use-unread-digestion` フックが「データ取得・キュー管理」と「完了演出（達成カードの出し分け）」という性質の異なる関心事を1つに抱えており、後者は sessionStorage 連携・`visibilitychange` 購読・自動非表示タイマー・操作起因判定の ref と、追いづらいロジックになっていました。`page.tsx` も状態の出し分けに加えて記事カード・完了カードのマークアップを直接持っており肥大化していました。

## 変更内容

### フックの分割
- 完了演出ロジックを `hooks/use-completion-celebration.ts` へ抽出
  - sessionStorage への保留状態の保存／復元、`visibilitychange` での復帰時再生、2.5秒後の自動非表示、操作起因の0件判定をこのフックに集約
  - 新バッチ取得時のリセットは、外部から関数を渡して `useEffect` 依存に載せるとキューの楽観的更新を巻き戻すリスクがあるため、`batchToken`（取得データの参照）を渡してフック内部の `useEffect` で扱う形にしています
- `use-unread-digestion.ts` はキュー管理・取得・スキップ／既読／後で操作に専念

### コンポーネントの分割
- `components/inbox-article-card.tsx`: 記事カード（メディアアイコン・著者・本文・操作ボタン）
- `components/inbox-completion-card.tsx`: 消化完了カード
- `routes/inbox/page.tsx` は状態に応じた出し分けのみを担う薄い構成に

## テスト

- 既存の `use-unread-digestion.test.ts` / `page.test.ts`（計9件）はそのまま通過
- `pnpm run check`（oxlint + oxfmt）・`typecheck` ともにグリーン（指摘は既存の無関係ファイルの warning のみ）

https://claude.ai/code/session_01BRxXvdxnUdtMzqA9aRMxFw

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRxXvdxnUdtMzqA9aRMxFw)_