### PR TITLE
refactor(web): 単一子へ素通しする親で子の props 型を再利用する

### DIFF
--- a/application/packages/web/src/client/features/article/components/filter-panel/desktop-filter-panel.tsx
+++ b/application/packages/web/src/client/features/article/components/filter-panel/desktop-filter-panel.tsx
@@ -1,19 +1,10 @@
 import { Funnel } from 'lucide-react'
 import { scrollToTop } from '@/client/lib/scroll'
+import { type FilterPanelProps } from '.'
 import { type FilterParams } from '../../hooks/use-articles'
 import { FilterControls } from './filter-controls'
 
-interface DesktopFilterPanelProps {
-  applied: FilterParams
-  isLoggedIn: boolean
-  onApplyFilters: (filters: FilterParams) => void
-}
-
-export function DesktopFilterPanel({
-  applied,
-  isLoggedIn,
-  onApplyFilters,
-}: DesktopFilterPanelProps) {
+export function DesktopFilterPanel({ applied, isLoggedIn, onApplyFilters }: FilterPanelProps) {
   const commitField = (patch: Partial<FilterParams>) => {
     onApplyFilters({ ...applied, ...patch })
     scrollToTop()

--- a/application/packages/web/src/client/features/article/components/filter-panel/desktop-filter-panel.tsx
+++ b/application/packages/web/src/client/features/article/components/filter-panel/desktop-filter-panel.tsx
@@ -1,8 +1,8 @@
 import { Funnel } from 'lucide-react'
 import { scrollToTop } from '@/client/lib/scroll'
-import { type FilterPanelProps } from '.'
 import { type FilterParams } from '../../hooks/use-articles'
 import { FilterControls } from './filter-controls'
+import { type FilterPanelProps } from './types'
 
 export function DesktopFilterPanel({ applied, isLoggedIn, onApplyFilters }: FilterPanelProps) {
   const commitField = (patch: Partial<FilterParams>) => {

--- a/application/packages/web/src/client/features/article/components/filter-panel/index.tsx
+++ b/application/packages/web/src/client/features/article/components/filter-panel/index.tsx
@@ -3,7 +3,7 @@ import { type FilterParams } from '../../hooks/use-articles'
 import { DesktopFilterPanel } from './desktop-filter-panel'
 import { MobileFilterPanel } from './mobile-filter-panel'
 
-interface FilterPanelProps {
+export interface FilterPanelProps {
   applied: FilterParams
   onApplyFilters: (filters: FilterParams) => void
   isLoggedIn: boolean

--- a/application/packages/web/src/client/features/article/components/filter-panel/index.tsx
+++ b/application/packages/web/src/client/features/article/components/filter-panel/index.tsx
@@ -1,13 +1,7 @@
 import { useIsMobile } from '@/client/components/shadcn/hooks/use-mobile'
-import { type FilterParams } from '../../hooks/use-articles'
 import { DesktopFilterPanel } from './desktop-filter-panel'
 import { MobileFilterPanel } from './mobile-filter-panel'
-
-export interface FilterPanelProps {
-  applied: FilterParams
-  onApplyFilters: (filters: FilterParams) => void
-  isLoggedIn: boolean
-}
+import { type FilterPanelProps } from './types'
 
 export function FilterPanel({ applied, onApplyFilters, isLoggedIn }: FilterPanelProps) {
   const isMobile = useIsMobile()

--- a/application/packages/web/src/client/features/article/components/filter-panel/mobile-filter-panel.tsx
+++ b/application/packages/web/src/client/features/article/components/filter-panel/mobile-filter-panel.tsx
@@ -3,9 +3,9 @@ import { useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { Button } from '@/client/components/shadcn/button'
 import { scrollToTop } from '@/client/lib/scroll'
-import { type FilterPanelProps } from '.'
 import { type FilterParams } from '../../hooks/use-articles'
 import { FilterControls } from './filter-controls'
+import { type FilterPanelProps } from './types'
 
 const DEFAULT_FILTERS: FilterParams = { media: undefined, readStatus: 'all', datePreset: 'today' }
 

--- a/application/packages/web/src/client/features/article/components/filter-panel/mobile-filter-panel.tsx
+++ b/application/packages/web/src/client/features/article/components/filter-panel/mobile-filter-panel.tsx
@@ -3,18 +3,13 @@ import { useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { Button } from '@/client/components/shadcn/button'
 import { scrollToTop } from '@/client/lib/scroll'
+import { type FilterPanelProps } from '.'
 import { type FilterParams } from '../../hooks/use-articles'
 import { FilterControls } from './filter-controls'
 
 const DEFAULT_FILTERS: FilterParams = { media: undefined, readStatus: 'all', datePreset: 'today' }
 
-interface MobileFilterPanelProps {
-  applied: FilterParams
-  isLoggedIn: boolean
-  onApplyFilters: (filters: FilterParams) => void
-}
-
-export function MobileFilterPanel({ applied, isLoggedIn, onApplyFilters }: MobileFilterPanelProps) {
+export function MobileFilterPanel({ applied, isLoggedIn, onApplyFilters }: FilterPanelProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [draft, setDraft] = useState<FilterParams>(applied)
 

--- a/application/packages/web/src/client/features/article/components/filter-panel/types.ts
+++ b/application/packages/web/src/client/features/article/components/filter-panel/types.ts
@@ -1,6 +1,6 @@
 import { type FilterParams } from '../../hooks/use-articles'
 
-// 子が index を import すると循環参照になるため、共有 props 型はここに置く
+// 型を index に置くと子からの import が循環参照になるため
 export interface FilterPanelProps {
   applied: FilterParams
   onApplyFilters: (filters: FilterParams) => void

--- a/application/packages/web/src/client/features/article/components/filter-panel/types.ts
+++ b/application/packages/web/src/client/features/article/components/filter-panel/types.ts
@@ -1,0 +1,8 @@
+import { type FilterParams } from '../../hooks/use-articles'
+
+// index / desktop / mobile が同じ props を共有するため、循環参照を避けて単方向に依存できるよう型を切り出す
+export interface FilterPanelProps {
+  applied: FilterParams
+  onApplyFilters: (filters: FilterParams) => void
+  isLoggedIn: boolean
+}

--- a/application/packages/web/src/client/features/article/components/filter-panel/types.ts
+++ b/application/packages/web/src/client/features/article/components/filter-panel/types.ts
@@ -1,6 +1,6 @@
 import { type FilterParams } from '../../hooks/use-articles'
 
-// index / desktop / mobile が同じ props を共有するため、循環参照を避けて単方向に依存できるよう型を切り出す
+// 子が index を import すると循環参照になるため、共有 props 型はここに置く
 export interface FilterPanelProps {
   applied: FilterParams
   onApplyFilters: (filters: FilterParams) => void

--- a/application/packages/web/src/client/features/authenticate/components/authenticate-form.tsx
+++ b/application/packages/web/src/client/features/authenticate/components/authenticate-form.tsx
@@ -5,7 +5,7 @@ import { Label } from '@/client/components/shadcn/label'
 import { TurnstileWidget } from '@/client/features/authenticate/components/turnstile-widget'
 import type { AuthenticateErrors } from '@/client/features/authenticate/model/validation'
 
-interface Props {
+export interface AuthenticateFormProps {
   onSubmit: (formData: FormData) => void
   submitButtonText: string
   loadingSubmitButtonText: string
@@ -24,7 +24,7 @@ export const AuthenticateForm = ({
   errors,
   formError,
   turnstileSiteKey,
-}: Props) => {
+}: AuthenticateFormProps) => {
   // DOMイベントの関心はここで閉じ、呼び出し側（hooks）はFormDataだけを扱えるようにする
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()

--- a/application/packages/web/src/client/features/authenticate/components/authenticate-form.tsx
+++ b/application/packages/web/src/client/features/authenticate/components/authenticate-form.tsx
@@ -5,15 +5,18 @@ import { Label } from '@/client/components/shadcn/label'
 import { TurnstileWidget } from '@/client/features/authenticate/components/turnstile-widget'
 import type { AuthenticateErrors } from '@/client/features/authenticate/model/validation'
 
-export interface AuthenticateFormProps {
+export interface AuthenticateFormBaseProps {
   onSubmit: (formData: FormData) => void
-  submitButtonText: string
-  loadingSubmitButtonText: string
   isSubmitting: boolean
   errors?: AuthenticateErrors
   formError?: string
   // 未設定の環境ではCAPTCHAを無効とするため任意項目とする
   turnstileSiteKey?: string
+}
+
+export interface AuthenticateFormProps extends AuthenticateFormBaseProps {
+  submitButtonText: string
+  loadingSubmitButtonText: string
 }
 
 export const AuthenticateForm = ({

--- a/application/packages/web/src/client/features/authenticate/index.ts
+++ b/application/packages/web/src/client/features/authenticate/index.ts
@@ -1,4 +1,4 @@
-export { AuthenticateForm, type AuthenticateFormProps, LogoutButton } from './ui'
+export { AuthenticateForm, type AuthenticateFormBaseProps, LogoutButton } from './ui'
 export {
   AUTH_ERROR_MESSAGES,
   resolveLoginErrorMessage,

--- a/application/packages/web/src/client/features/authenticate/index.ts
+++ b/application/packages/web/src/client/features/authenticate/index.ts
@@ -1,4 +1,4 @@
-export { AuthenticateForm, LogoutButton } from './ui'
+export { AuthenticateForm, type AuthenticateFormProps, LogoutButton } from './ui'
 export {
   AUTH_ERROR_MESSAGES,
   resolveLoginErrorMessage,

--- a/application/packages/web/src/client/features/authenticate/ui.ts
+++ b/application/packages/web/src/client/features/authenticate/ui.ts
@@ -1,5 +1,5 @@
 // index.ts はSWR系フック（useSession 等）も束ねており、レイアウトのStorybookから読むと
 // use-sync-external-store の取り込みでブラウザバンドルが壊れる。UIだけを使う側はこの軽量な
 // 公開口から取り込むことでフック群の巻き込みを避ける。
-export { AuthenticateForm } from './components/authenticate-form'
+export { AuthenticateForm, type AuthenticateFormProps } from './components/authenticate-form'
 export { default as LogoutButton } from './components/logout-button'

--- a/application/packages/web/src/client/features/authenticate/ui.ts
+++ b/application/packages/web/src/client/features/authenticate/ui.ts
@@ -1,5 +1,5 @@
 // index.ts はSWR系フック（useSession 等）も束ねており、レイアウトのStorybookから読むと
 // use-sync-external-store の取り込みでブラウザバンドルが壊れる。UIだけを使う側はこの軽量な
 // 公開口から取り込むことでフック群の巻き込みを避ける。
-export { AuthenticateForm, type AuthenticateFormProps } from './components/authenticate-form'
+export { AuthenticateForm, type AuthenticateFormBaseProps } from './components/authenticate-form'
 export { default as LogoutButton } from './components/logout-button'

--- a/application/packages/web/src/client/routes/login/page.tsx
+++ b/application/packages/web/src/client/routes/login/page.tsx
@@ -1,11 +1,8 @@
-import { AuthenticateForm, type AuthenticateFormProps } from '@/client/features/authenticate'
+import { AuthenticateForm, type AuthenticateFormBaseProps } from '@/client/features/authenticate'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '../../components/shadcn/card'
 import Footer from '../../components/ui/layout/footer'
 import LandingHeader from '../../components/ui/layout/landing-header'
 import { AnchorLink } from '../../components/ui/navigation/link'
-
-// ボタン文言はページごとに固定するため除外する
-type Props = Omit<AuthenticateFormProps, 'submitButtonText' | 'loadingSubmitButtonText'>
 
 export default function LoginPage({
   onSubmit,
@@ -13,7 +10,7 @@ export default function LoginPage({
   errors,
   formError,
   turnstileSiteKey,
-}: Props) {
+}: AuthenticateFormBaseProps) {
   return (
     <div className='min-h-screen bg-gradient-to-br from-slate-50 to-white'>
       <LandingHeader />

--- a/application/packages/web/src/client/routes/login/page.tsx
+++ b/application/packages/web/src/client/routes/login/page.tsx
@@ -4,7 +4,7 @@ import Footer from '../../components/ui/layout/footer'
 import LandingHeader from '../../components/ui/layout/landing-header'
 import { AnchorLink } from '../../components/ui/navigation/link'
 
-// ボタン文言はページ側でハードコードするため、その2つを除いた AuthenticateForm の props を引き継ぐ
+// ボタン文言はページごとに固定するため除外する
 type Props = Omit<AuthenticateFormProps, 'submitButtonText' | 'loadingSubmitButtonText'>
 
 export default function LoginPage({

--- a/application/packages/web/src/client/routes/login/page.tsx
+++ b/application/packages/web/src/client/routes/login/page.tsx
@@ -1,16 +1,11 @@
-import { AuthenticateForm, type AuthenticateErrors } from '@/client/features/authenticate'
+import { AuthenticateForm, type AuthenticateFormProps } from '@/client/features/authenticate'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '../../components/shadcn/card'
 import Footer from '../../components/ui/layout/footer'
 import LandingHeader from '../../components/ui/layout/landing-header'
 import { AnchorLink } from '../../components/ui/navigation/link'
 
-interface Props {
-  onSubmit: (formData: FormData) => void
-  isSubmitting: boolean
-  errors?: AuthenticateErrors
-  formError?: string
-  turnstileSiteKey?: string
-}
+// ボタン文言はページ側でハードコードするため、その2つを除いた AuthenticateForm の props を引き継ぐ
+type Props = Omit<AuthenticateFormProps, 'submitButtonText' | 'loadingSubmitButtonText'>
 
 export default function LoginPage({
   onSubmit,

--- a/application/packages/web/src/client/routes/signup/page.tsx
+++ b/application/packages/web/src/client/routes/signup/page.tsx
@@ -11,7 +11,7 @@ import Footer from '../../components/ui/layout/footer'
 import LandingHeader from '../../components/ui/layout/landing-header'
 import { AnchorLink } from '../../components/ui/navigation/link'
 
-// ボタン文言はページ側でハードコードするため、その2つを除いた AuthenticateForm の props を引き継ぐ
+// ボタン文言はページごとに固定するため除外する
 type Props = Omit<AuthenticateFormProps, 'submitButtonText' | 'loadingSubmitButtonText'>
 
 export default function SignupPage({

--- a/application/packages/web/src/client/routes/signup/page.tsx
+++ b/application/packages/web/src/client/routes/signup/page.tsx
@@ -1,4 +1,4 @@
-import { AuthenticateForm, type AuthenticateFormProps } from '@/client/features/authenticate'
+import { AuthenticateForm, type AuthenticateFormBaseProps } from '@/client/features/authenticate'
 import {
   Card,
   CardContent,
@@ -11,16 +11,13 @@ import Footer from '../../components/ui/layout/footer'
 import LandingHeader from '../../components/ui/layout/landing-header'
 import { AnchorLink } from '../../components/ui/navigation/link'
 
-// ボタン文言はページごとに固定するため除外する
-type Props = Omit<AuthenticateFormProps, 'submitButtonText' | 'loadingSubmitButtonText'>
-
 export default function SignupPage({
   onSubmit,
   isSubmitting,
   errors,
   formError,
   turnstileSiteKey,
-}: Props) {
+}: AuthenticateFormBaseProps) {
   return (
     <div className='min-h-screen bg-gradient-to-br from-slate-50 to-white'>
       <LandingHeader />

--- a/application/packages/web/src/client/routes/signup/page.tsx
+++ b/application/packages/web/src/client/routes/signup/page.tsx
@@ -1,4 +1,4 @@
-import { AuthenticateForm, type AuthenticateErrors } from '@/client/features/authenticate'
+import { AuthenticateForm, type AuthenticateFormProps } from '@/client/features/authenticate'
 import {
   Card,
   CardContent,
@@ -11,13 +11,8 @@ import Footer from '../../components/ui/layout/footer'
 import LandingHeader from '../../components/ui/layout/landing-header'
 import { AnchorLink } from '../../components/ui/navigation/link'
 
-interface Props {
-  onSubmit: (formData: FormData) => void
-  isSubmitting: boolean
-  errors?: AuthenticateErrors
-  formError?: string
-  turnstileSiteKey?: string
-}
+// ボタン文言はページ側でハードコードするため、その2つを除いた AuthenticateForm の props を引き継ぐ
+type Props = Omit<AuthenticateFormProps, 'submitButtonText' | 'loadingSubmitButtonText'>
 
 export default function SignupPage({
   onSubmit,


### PR DESCRIPTION
## 概要

Issue #832 の対応です。「親が単一の子へ props を素通しするだけ」で props 型を重複定義していた箇所を、子の props 型を再利用して単一情報源化しました。

## 変更内容

### 1. `LoginPage` / `SignupPage` → `AuthenticateForm`（`Omit`）
- `AuthenticateForm` の props を `AuthenticateFormProps` として export（`ui.ts` / `index.ts` の公開口からも re-export）。
- 両ページの `Props` は、ページ側でハードコードする `submitButtonText` / `loadingSubmitButtonText` を除いた `Omit<AuthenticateFormProps, ...>` で定義。
- これに伴い不要になった `AuthenticateErrors` の import を削除。

### 2. `FilterPanel` / `DesktopFilterPanel` / `MobileFilterPanel`（共有 interface）
- 完全に同一だった 3 つの props interface を、`index.tsx` の `FilterPanelProps` 1 つに統一し、各コンポーネントが参照するように変更。

## 対象外
- `TrendsPage` / `DiaryPage` / `AnalyticsPage` は複数子へのファンアウト・prop の加工を伴うため、Issue の方針通り現状維持。

## 確認
- `oxlint`: 新規エラーなし
- `oxfmt --check`: OK
- `pnpm -r typecheck`: OK
- `vitest`: ブラウザ系テストは実行環境で Playwright ブラウザのダウンロードが遮断され実行不可、サーバ系テストは Supabase 未起動で `fetch failed`（いずれも環境要因で本変更とは無関係）。本変更は型の再利用のみのため挙動への影響はありません。

Closes #832

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDzCgugk5fF9KrahBcEiBS)_