### PR TITLE
refactor(inbox): 完了演出の保留状態をモジュールオブジェクトに集約

### DIFF
--- a/application/packages/web/src/client/features/inbox/hooks/use-completion-celebration.ts
+++ b/application/packages/web/src/client/features/inbox/hooks/use-completion-celebration.ts
@@ -1,8 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import {
-  hasCompletionPending,
-  setCompletionPending,
-} from '@/client/features/inbox/model/completion-pending-storage'
+import { completionPendingStorage } from '@/client/features/inbox/model/completion-pending-storage'
 import useDocumentVisibility from './use-document-visibility'
 
 const CompletionDisplayDurationMs = 2500
@@ -34,14 +31,15 @@ export default function useCompletionCelebration({ remaining, queueLength, batch
 
   useEffect(() => {
     const reachedZeroByAction = remaining === 0 && actionConsumedRef.current
-    const shouldPlayCompletion = reachedZeroByAction || (remaining === 0 && hasCompletionPending())
+    const shouldPlayCompletion =
+      reachedZeroByAction || (remaining === 0 && completionPendingStorage.has())
 
     if (shouldPlayCompletion && visibilityState === 'visible') {
       setIsJustCompleted(true)
-      setCompletionPending(false)
+      completionPendingStorage.set(false)
     } else if (reachedZeroByAction) {
       // 操作直後にタブが非表示（別タブで読了等）なら、復帰時に演出を再生するため保留にする
-      setCompletionPending(true)
+      completionPendingStorage.set(true)
     }
 
     actionConsumedRef.current = false
@@ -51,10 +49,10 @@ export default function useCompletionCelebration({ remaining, queueLength, batch
     // タブ復帰時、保留中の完了演出を再生する
     if (visibilityState !== 'visible') return
     if (queueLength !== 0) return
-    if (!hasCompletionPending()) return
+    if (!completionPendingStorage.has()) return
 
     setIsJustCompleted(true)
-    setCompletionPending(false)
+    completionPendingStorage.set(false)
   }, [visibilityState, queueLength])
 
   useEffect(() => {

--- a/application/packages/web/src/client/features/inbox/model/completion-pending-storage.ts
+++ b/application/packages/web/src/client/features/inbox/model/completion-pending-storage.ts
@@ -15,7 +15,6 @@ const writeFlag = Result.fromThrowable((pending: boolean) => {
 const readFlag = Result.fromThrowable(() => window.sessionStorage.getItem(StorageKey) === '1')
 
 export const completionPendingStorage = {
-  // 保存できない環境では諦めるだけなので結果は問わない
   set(pending: boolean) {
     writeFlag(pending)
   },

--- a/application/packages/web/src/client/features/inbox/model/completion-pending-storage.ts
+++ b/application/packages/web/src/client/features/inbox/model/completion-pending-storage.ts
@@ -14,7 +14,6 @@ const writeFlag = Result.fromThrowable((pending: boolean) => {
 
 const readFlag = Result.fromThrowable(() => window.sessionStorage.getItem(StorageKey) === '1')
 
-// 完了演出を後で再生するための保留状態をまとめて扱う
 export const completionPendingStorage = {
   // 保存できない環境では諦めるだけなので結果は問わない
   set(pending: boolean) {

--- a/application/packages/web/src/client/features/inbox/model/completion-pending-storage.ts
+++ b/application/packages/web/src/client/features/inbox/model/completion-pending-storage.ts
@@ -14,11 +14,13 @@ const writeFlag = Result.fromThrowable((pending: boolean) => {
 
 const readFlag = Result.fromThrowable(() => window.sessionStorage.getItem(StorageKey) === '1')
 
-// 完了演出を後で再生するための保留状態。保存できない環境では諦めるだけなので結果は問わない
-export function setCompletionPending(pending: boolean) {
-  writeFlag(pending)
-}
-
-export function hasCompletionPending() {
-  return readFlag().unwrapOr(false)
+// 完了演出を後で再生するための保留状態をまとめて扱う
+export const completionPendingStorage = {
+  // 保存できない環境では諦めるだけなので結果は問わない
+  set(pending: boolean) {
+    writeFlag(pending)
+  },
+  has() {
+    return readFlag().unwrapOr(false)
+  },
 }


### PR DESCRIPTION
## 概要

`completion-pending-storage.ts` がトップレベルの `setCompletionPending` / `hasCompletionPending` という 2 つの関数とプライベートヘルパーに散らばっており、まとまりが分かりにくかったため、単一の `completionPendingStorage` オブジェクトに集約しました。

呼び出し側は `completionPendingStorage.set(...)` / `completionPendingStorage.has()` という形に統一され、何のストレージを操作しているかが読み取りやすくなります。

## 設計判断（class / namespace / module）

- **namespace**: レガシー TS 機能で ESM 構成では非推奨のため不採用
- **class**: インスタンス状態を持たない static-only クラスは TS のアンチパターン（実際 oxlint の `no-extraneous-class` が警告する）のため不採用
- **module パターン（オブジェクトリテラル）**: 既存の `AUTH_ERROR_MESSAGES` と同様のスタイルで、余計なインスタンスも作らずまとまりだけ得られるため採用

挙動は変更していません（sessionStorage を `Result` で包む点もそのまま）。

## 確認

- `pnpm lint`（oxlint + oxfmt + typecheck）: パス（既存の他ファイル警告のみ）
- `vitest`: 関連テスト 9 件パス

https://claude.ai/code/session_01TLu96BBz32rLymHfgNwXCV

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLu96BBz32rLymHfgNwXCV)_