### PR TITLE
refactor(web): ログアウトボタンをvariant出し分けから見た目ごとの分割に変更

### DIFF
--- a/application/packages/web/src/client/components/ui/layout/app-header/index.tsx
+++ b/application/packages/web/src/client/components/ui/layout/app-header/index.tsx
@@ -40,7 +40,7 @@ export default function AppHeader({ isLoggedIn }: Props) {
               <SheetTitle>メニュー</SheetTitle>
               <SheetDescription>ナビゲーションとユーザー設定</SheetDescription>
             </SheetHeader>
-            <div className='flex flex-col gap-4'>
+            <div className='flex flex-col gap-4 flex-1'>
               <NavMenu variant='sheet' menuItems={visibleMenuItems} />
 
               {isLoggedIn && (

--- a/application/packages/web/src/client/components/ui/layout/app-header/index.tsx
+++ b/application/packages/web/src/client/components/ui/layout/app-header/index.tsx
@@ -43,7 +43,13 @@ export default function AppHeader({ isLoggedIn }: Props) {
             <div className='flex flex-col gap-4'>
               <NavMenu variant='sheet' menuItems={visibleMenuItems} />
 
-              {isLoggedIn && <LogoutButton variant='sheet' />}
+              {isLoggedIn && (
+                <div className='border-t pt-4 mt-auto'>
+                  <div className='flex flex-col gap-2 px-3'>
+                    <LogoutButton />
+                  </div>
+                </div>
+              )}
             </div>
           </SheetContent>
         </Sheet>

--- a/application/packages/web/src/client/components/ui/layout/sidebar/index.tsx
+++ b/application/packages/web/src/client/components/ui/layout/sidebar/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/client/components/shadcn/sidebar'
 import { AnchorLink } from '@/client/components/ui/navigation/link'
 import NavMenu from '@/client/components/ui/navigation/nav-menu'
-import { LogoutButton } from '@/client/features/authenticate/ui'
+import { SidebarLogoutButton } from '@/client/features/authenticate/ui'
 import type { InternalPath } from '@/client/routes'
 
 export interface MenuItem {
@@ -78,7 +78,7 @@ export default function AppSidebar({ isLoggedIn }: Props) {
           {isLoggedIn && (
             <SidebarGroup className='absolute bottom-0 left-0 w-full'>
               <SidebarGroupContent>
-                <LogoutButton variant='sidebar' />
+                <SidebarLogoutButton />
               </SidebarGroupContent>
             </SidebarGroup>
           )}

--- a/application/packages/web/src/client/features/authenticate/components/logout-button.tsx
+++ b/application/packages/web/src/client/features/authenticate/components/logout-button.tsx
@@ -1,33 +1,12 @@
 import { Button } from '@/client/components/shadcn/button'
-import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/client/components/shadcn/sidebar'
 import useLogout from '@/client/features/authenticate/hooks/use-logout'
 
-interface Props {
-  variant: 'sidebar' | 'sheet'
-}
-
-export default function LogoutButton({ variant }: Props) {
+export default function LogoutButton() {
   const { handleLogout, isLoading } = useLogout()
 
-  if (variant === 'sidebar') {
-    return (
-      <SidebarMenu>
-        <SidebarMenuItem>
-          <SidebarMenuButton onClick={handleLogout} disabled={isLoading}>
-            {isLoading ? 'ログアウト中...' : 'ログアウト'}
-          </SidebarMenuButton>
-        </SidebarMenuItem>
-      </SidebarMenu>
-    )
-  }
-
   return (
-    <div className='border-t pt-4 mt-auto'>
-      <div className='flex flex-col gap-2 px-3'>
-        <Button onClick={handleLogout} disabled={isLoading} variant='outline'>
-          {isLoading ? 'ログアウト中...' : 'ログアウト'}
-        </Button>
-      </div>
-    </div>
+    <Button onClick={handleLogout} disabled={isLoading} variant='outline'>
+      {isLoading ? 'ログアウト中...' : 'ログアウト'}
+    </Button>
   )
 }

--- a/application/packages/web/src/client/features/authenticate/components/sidebar-logout-button.stories.tsx
+++ b/application/packages/web/src/client/features/authenticate/components/sidebar-logout-button.stories.tsx
@@ -1,8 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect, fn, userEvent } from 'storybook/test'
 import { vi } from 'vitest'
+import { SidebarProvider } from '@/client/components/shadcn/sidebar'
 import useLogout from '@/client/features/authenticate/hooks/use-logout'
-import LogoutButton from './logout-button'
+import SidebarLogoutButton from './sidebar-logout-button'
 
 vi.mock('@/client/features/authenticate/hooks/use-logout', () => ({
   default: vi.fn(),
@@ -10,20 +11,27 @@ vi.mock('@/client/features/authenticate/hooks/use-logout', () => ({
 
 const handleLogout = fn()
 
-const meta: Meta<typeof LogoutButton> = {
-  component: LogoutButton,
+const meta: Meta<typeof SidebarLogoutButton> = {
+  component: SidebarLogoutButton,
   beforeEach: () => {
     handleLogout.mockClear()
     vi.mocked(useLogout).mockReturnValue({ handleLogout, isLoading: false })
   },
+  decorators: [
+    (Story) => (
+      <SidebarProvider>
+        <Story />
+      </SidebarProvider>
+    ),
+  ],
 }
 export default meta
 
-type Story = StoryObj<typeof LogoutButton>
+type Story = StoryObj<typeof SidebarLogoutButton>
 
 export const Default: Story = {
   play: async ({ canvas }) => {
-    const button = canvas.getByRole('button', { name: 'ログアウト' })
+    const button = canvas.getByText('ログアウト')
     await userEvent.click(button)
     await expect(handleLogout).toHaveBeenCalled()
   },
@@ -34,7 +42,7 @@ export const Loading: Story = {
     vi.mocked(useLogout).mockReturnValue({ handleLogout, isLoading: true })
   },
   play: async ({ canvas }) => {
-    const button = canvas.getByRole('button', { name: 'ログアウト中...' })
+    const button = canvas.getByText('ログアウト中...')
     await expect(button).toBeDisabled()
   },
 }

--- a/application/packages/web/src/client/features/authenticate/components/sidebar-logout-button.tsx
+++ b/application/packages/web/src/client/features/authenticate/components/sidebar-logout-button.tsx
@@ -1,0 +1,16 @@
+import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/client/components/shadcn/sidebar'
+import useLogout from '@/client/features/authenticate/hooks/use-logout'
+
+export default function SidebarLogoutButton() {
+  const { handleLogout, isLoading } = useLogout()
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <SidebarMenuButton onClick={handleLogout} disabled={isLoading}>
+          {isLoading ? 'ログアウト中...' : 'ログアウト'}
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}

--- a/application/packages/web/src/client/features/authenticate/index.ts
+++ b/application/packages/web/src/client/features/authenticate/index.ts
@@ -1,4 +1,9 @@
-export { AuthenticateForm, type AuthenticateFormBaseProps, LogoutButton } from './ui'
+export {
+  AuthenticateForm,
+  type AuthenticateFormBaseProps,
+  LogoutButton,
+  SidebarLogoutButton,
+} from './ui'
 export {
   AUTH_ERROR_MESSAGES,
   resolveLoginErrorMessage,

--- a/application/packages/web/src/client/features/authenticate/ui.ts
+++ b/application/packages/web/src/client/features/authenticate/ui.ts
@@ -3,3 +3,4 @@
 // 公開口から取り込むことでフック群の巻き込みを避ける。
 export { AuthenticateForm, type AuthenticateFormBaseProps } from './components/authenticate-form'
 export { default as LogoutButton } from './components/logout-button'
+export { default as SidebarLogoutButton } from './components/sidebar-logout-button'


### PR DESCRIPTION
## 背景・課題

`LogoutButton` が `variant: 'sidebar' | 'sheet'` を受け取り、その値で**まったく別のDOMツリー**を出し分けていました。

- `variant` の語義が破綻していた。shadcn の `variant`（`outline` 等）は「同一ボタンの見た目バリエーション」を指すが、ここでは「**どのレイアウトに置かれているか**（配置先）」を表しており意味が合っていなかった。
- 責務が混在していた。共通なのは「ログアウトする振る舞い」（`useLogout`）だけで、`SidebarMenuButton` を使う見た目と `Button variant='outline'` を使う見た目は別物なのに、1つの関数に `if` で同居していた。結果、sidebar 側が「ログアウトボタンなのに sidebar メニュー構造まで背負う」状態になっていた。
- レイアウト余白（`border-t pt-4 mt-auto`）がボタンに混入しており、ボタン自身の関心事でない配置都合を抱えていた。

## 変更内容

振る舞い（`useLogout`）は共有したまま、**見た目ごとにコンポーネントを分割**し `variant` を廃止しました。

| コンポーネント | 見た目 | 使う場所 |
|---|---|---|
| `SidebarLogoutButton`（新設） | `SidebarMenu/Item/Button`（sidebar プリミティブ） | `sidebar` |
| `LogoutButton` | `Button variant='outline'` のみ（配置余白なし） | sheet（`app-header`）。汎用的に再利用可 |

- 余白 `border-t pt-4 mt-auto` は `app-header` 側の配置 `div` へ移し、`LogoutButton` を配置非依存にした。
- `ui.ts` / `index.ts` のエクスポートを更新（フック束を巻き込まない既存の公開口の方針は維持）。
- Storybook を 2 コンポーネントに分割（`logout-button.stories.tsx` / `sidebar-logout-button.stories.tsx`）。

## 確認

- `oxlint` / `oxfmt` / `tsgo --noEmit`（typecheck）すべてパス。
- テストは Storybook の in-browser 実行（要 chromium）・server ハンドラ（要 Workers バインディング）が当環境では実行できず、base ブランチと同一の事前失敗のみ。本変更による新規失敗はなし。

https://claude.ai/code/session_01FNxmUFNdq4bu65tu3fjQEM

---
_Generated by [Claude Code](https://claude.ai/code/session_01FNxmUFNdq4bu65tu3fjQEM)_