### PR TITLE
test(web): Storybook のカバレッジを補強し閾値を80%へ引き上げる

### DIFF
--- a/application/packages/web/src/client/components/ui/feedback/login-required/login-required.stories.tsx
+++ b/application/packages/web/src/client/components/ui/feedback/login-required/login-required.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect } from 'storybook/test'
+import LoginRequired from './index'
+
+const meta: Meta<typeof LoginRequired> = {
+  component: LoginRequired,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    pageTitle: 'インボックス',
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof LoginRequired>
+
+export const Default: Story = {
+  play: async ({ canvas, step }) => {
+    await step('ページタイトルが見出しとして表示されることを確認', async () => {
+      await expect(canvas.getByRole('heading', { name: 'インボックス' })).toBeInTheDocument()
+    })
+
+    await step('ログイン要求メッセージが表示されることを確認', async () => {
+      await expect(canvas.getByText('この機能はログイン時のみ利用できます。')).toBeInTheDocument()
+    })
+  },
+}

--- a/application/packages/web/src/client/components/ui/navigation/link/link.stories.tsx
+++ b/application/packages/web/src/client/components/ui/navigation/link/link.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect } from 'storybook/test'
+import { AnchorLink, LinkAsButton } from './index'
+
+const meta: Meta<typeof AnchorLink> = {
+  component: AnchorLink,
+  parameters: {
+    layout: 'centered',
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof AnchorLink>
+
+// 外部リンクは別タブで開く生の <a> として描画される
+export const ExternalAnchor: Story = {
+  args: {
+    to: 'https://example.com',
+    children: '外部リンク',
+  },
+  play: async ({ canvas, step }) => {
+    await step('外部リンクが別タブ用の属性を持つことを確認', async () => {
+      const link = canvas.getByRole('link', { name: '外部リンク' })
+      await expect(link).toHaveAttribute('href', 'https://example.com')
+      await expect(link).toHaveAttribute('target', '_blank')
+      await expect(link).toHaveAttribute('rel', 'noopener noreferrer nofollow')
+    })
+  },
+}
+
+// 内部リンクは React Router の Link として描画される
+export const InternalAnchor: Story = {
+  args: {
+    to: '/',
+    children: 'トップへ',
+  },
+  play: async ({ canvas, step }) => {
+    await step('内部リンクが描画されることを確認', async () => {
+      const link = canvas.getByRole('link', { name: 'トップへ' })
+      await expect(link).toHaveAttribute('href', '/')
+      await expect(link).not.toHaveAttribute('target', '_blank')
+    })
+  },
+}
+
+type ButtonStory = StoryObj<typeof LinkAsButton>
+
+// LinkAsButton はボタン見た目で内部/外部リンクとして振る舞う
+export const AsButtonExternal: ButtonStory = {
+  render: (args) => <LinkAsButton {...args} />,
+  args: {
+    to: 'https://example.com',
+    children: 'ボタン風外部リンク',
+  },
+  play: async ({ canvas, step }) => {
+    await step('ボタン見た目の外部リンクが描画されることを確認', async () => {
+      const link = canvas.getByRole('link', { name: 'ボタン風外部リンク' })
+      await expect(link).toHaveAttribute('href', 'https://example.com')
+      await expect(link).toHaveAttribute('target', '_blank')
+    })
+  },
+}
+
+export const AsButtonInternal: ButtonStory = {
+  render: (args) => <LinkAsButton {...args} />,
+  args: {
+    to: '/',
+    children: 'ボタン風内部リンク',
+  },
+  play: async ({ canvas, step }) => {
+    await step('ボタン見た目の内部リンクが描画されることを確認', async () => {
+      const link = canvas.getByRole('link', { name: 'ボタン風内部リンク' })
+      await expect(link).toHaveAttribute('href', '/')
+    })
+  },
+}

--- a/application/packages/web/src/client/components/ui/navigation/link/link.stories.tsx
+++ b/application/packages/web/src/client/components/ui/navigation/link/link.stories.tsx
@@ -53,10 +53,12 @@ export const AsButtonExternal: ButtonStory = {
     children: 'ボタン風外部リンク',
   },
   play: async ({ canvas, step }) => {
-    await step('ボタン見た目の外部リンクが描画されることを確認', async () => {
+    await step('ボタン見た目の外部リンクが別タブ用の属性を持つことを確認', async () => {
       const link = canvas.getByRole('link', { name: 'ボタン風外部リンク' })
       await expect(link).toHaveAttribute('href', 'https://example.com')
       await expect(link).toHaveAttribute('target', '_blank')
+      // 別タブ遷移時の reverse tabnabbing を防ぐ rel が引き継がれることを担保する
+      await expect(link).toHaveAttribute('rel', 'noopener noreferrer nofollow')
     })
   },
 }

--- a/application/packages/web/src/client/features/authenticate/components/authenticate-form.stories.tsx
+++ b/application/packages/web/src/client/features/authenticate/components/authenticate-form.stories.tsx
@@ -9,9 +9,6 @@ const meta: Meta<typeof AuthenticateForm> = {
   args: {
     onSubmit,
   },
-  beforeEach: () => {
-    onSubmit.mockClear()
-  },
 }
 export default meta
 

--- a/application/packages/web/src/client/features/authenticate/components/authenticate-form.stories.tsx
+++ b/application/packages/web/src/client/features/authenticate/components/authenticate-form.stories.tsx
@@ -1,9 +1,17 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { expect } from 'storybook/test'
+import { expect, fn, userEvent } from 'storybook/test'
 import { AuthenticateForm } from './authenticate-form'
+
+const onSubmit = fn()
 
 const meta: Meta<typeof AuthenticateForm> = {
   component: AuthenticateForm,
+  args: {
+    onSubmit,
+  },
+  beforeEach: () => {
+    onSubmit.mockClear()
+  },
 }
 export default meta
 
@@ -98,5 +106,22 @@ export const FormValidationError: Story = {
 
     // ローディング状態ではないため、通常のボタンテキストが表示されることを確認
     await expect(canvas.getByRole('button')).toHaveTextContent('ログイン')
+  },
+}
+
+// 送信時に入力値が FormData として onSubmit へ渡されることを検証する。
+export const SubmitInteraction: Story = {
+  args: defaultArgs,
+  play: async ({ canvas, args, step }) => {
+    await step('入力して送信すると onSubmit が FormData 付きで呼ばれることを確認', async () => {
+      await userEvent.type(canvas.getByLabelText('メールアドレス'), 'taro@example.com')
+      await userEvent.type(canvas.getByLabelText('パスワード'), 'password123')
+      await userEvent.click(canvas.getByRole('button', { name: 'ログイン' }))
+
+      await expect(args.onSubmit).toHaveBeenCalledTimes(1)
+      const formData = onSubmit.mock.calls[0]?.[0] as FormData
+      await expect(formData.get('email')).toBe('taro@example.com')
+      await expect(formData.get('password')).toBe('password123')
+    })
   },
 }

--- a/application/packages/web/src/client/features/authenticate/components/authenticate-form.stories.tsx
+++ b/application/packages/web/src/client/features/authenticate/components/authenticate-form.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 import { expect, fn, userEvent } from 'storybook/test'
 import { AuthenticateForm } from './authenticate-form'
 
-const onSubmit = fn()
+const onSubmit = fn((_formData: FormData) => {})
 
 const meta: Meta<typeof AuthenticateForm> = {
   component: AuthenticateForm,
@@ -112,16 +112,17 @@ export const FormValidationError: Story = {
 // 送信時に入力値が FormData として onSubmit へ渡されることを検証する。
 export const SubmitInteraction: Story = {
   args: defaultArgs,
-  play: async ({ canvas, args, step }) => {
+  play: async ({ canvas, step }) => {
     await step('入力して送信すると onSubmit が FormData 付きで呼ばれることを確認', async () => {
       await userEvent.type(canvas.getByLabelText('メールアドレス'), 'taro@example.com')
       await userEvent.type(canvas.getByLabelText('パスワード'), 'password123')
       await userEvent.click(canvas.getByRole('button', { name: 'ログイン' }))
 
-      await expect(args.onSubmit).toHaveBeenCalledTimes(1)
-      const formData = onSubmit.mock.calls[0]?.[0] as FormData
-      await expect(formData.get('email')).toBe('taro@example.com')
-      await expect(formData.get('password')).toBe('password123')
+      // 呼び出し回数と引数のどちらも、型付きのモック実体（args.onSubmit と同一参照）で検証して一貫させる
+      await expect(onSubmit).toHaveBeenCalledTimes(1)
+      const formData = onSubmit.mock.calls[0]?.[0]
+      await expect(formData?.get('email')).toBe('taro@example.com')
+      await expect(formData?.get('password')).toBe('password123')
     })
   },
 }

--- a/application/packages/web/src/client/features/authenticate/components/turnstile-widget.stories.tsx
+++ b/application/packages/web/src/client/features/authenticate/components/turnstile-widget.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn, waitFor } from 'storybook/test'
+import { TurnstileWidget } from './turnstile-widget'
+
+const renderMock = fn((_container: HTMLElement, _options: { sitekey: string }) => 'widget-id')
+const removeMock = fn((_widgetId: string) => {})
+
+const meta: Meta<typeof TurnstileWidget> = {
+  component: TurnstileWidget,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    siteKey: '1x00000000000000000000AA',
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof TurnstileWidget>
+
+// API 読み込み済みの場合、マウント時に即 render される分岐を検証する。
+export const ApiAlreadyLoaded: Story = {
+  beforeEach: () => {
+    renderMock.mockClear()
+    removeMock.mockClear()
+    window.turnstile = { render: renderMock, remove: removeMock }
+    return () => {
+      window.turnstile = undefined
+    }
+  },
+  play: async ({ args, step }) => {
+    await step('siteKey 付きで turnstile.render が呼ばれることを確認', async () => {
+      await waitFor(() => {
+        expect(renderMock).toHaveBeenCalledTimes(1)
+      })
+      await expect(renderMock.mock.calls[0]?.[1]).toEqual({ sitekey: args.siteKey })
+    })
+  },
+}
+
+// API 未読み込みの場合、onload コールバック用のスクリプトが追加される分岐を検証する。
+export const ApiNotLoaded: Story = {
+  beforeEach: () => {
+    window.turnstile = undefined
+    return () => {
+      document.getElementById('cf-turnstile-script')?.remove()
+    }
+  },
+  play: async ({ step }) => {
+    await step('Turnstile スクリプトが head に追加されることを確認', async () => {
+      await waitFor(() => {
+        expect(document.getElementById('cf-turnstile-script')).toBeInTheDocument()
+      })
+    })
+  },
+}

--- a/application/packages/web/src/client/features/inbox/components/inbox-article-card.stories.tsx
+++ b/application/packages/web/src/client/features/inbox/components/inbox-article-card.stories.tsx
@@ -1,0 +1,103 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn, userEvent } from 'storybook/test'
+import type { Article } from '../hooks/use-unread-digestion'
+import InboxArticleCard from './inbox-article-card'
+
+const defaultArticle: Article = {
+  articleId: '1',
+  media: 'qiita',
+  title: 'デフォルトタイトル',
+  author: 'デフォルト著者',
+  description: 'デフォルトの説明文です',
+  url: 'https://example.com',
+  createdAt: new Date('2024-01-01T00:00:00Z'),
+}
+
+const generateArticle = (params?: Partial<Article>): Article => ({
+  ...defaultArticle,
+  ...params,
+})
+
+const meta: Meta<typeof InboxArticleCard> = {
+  component: InboxArticleCard,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    article: defaultArticle,
+    onSkip: fn(),
+    onRead: fn(),
+    onLater: fn(),
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof InboxArticleCard>
+
+export const Default: Story = {
+  play: async ({ canvas, step }) => {
+    await step('タイトル・著者・説明が表示されることを確認', async () => {
+      await expect(canvas.getByText(defaultArticle.title)).toBeInTheDocument()
+      await expect(canvas.getByText(`著者: ${defaultArticle.author}`)).toBeInTheDocument()
+      await expect(canvas.getByText(defaultArticle.description)).toBeInTheDocument()
+    })
+
+    await step('操作ボタンが3つ表示されることを確認', async () => {
+      await expect(canvas.getByRole('button', { name: 'スキップ' })).toBeInTheDocument()
+      await expect(canvas.getByRole('button', { name: '読む' })).toBeInTheDocument()
+      await expect(canvas.getByRole('button', { name: '後で' })).toBeInTheDocument()
+    })
+  },
+}
+
+export const ZennArticle: Story = {
+  args: {
+    article: generateArticle({ media: 'zenn' }),
+  },
+  play: async ({ canvas, step }) => {
+    await step('Zennメディアアイコンが表示されることを確認', async () => {
+      const mediaIcon = canvas.getByRole('img')
+      await expect(mediaIcon).toHaveAttribute('src', '/images/zenn-icon.svg')
+    })
+  },
+}
+
+// isArticleMedia に該当しないメディアは zenn にフォールバックする分岐を検証する
+export const UnknownMediaFallsBackToZenn: Story = {
+  args: {
+    article: generateArticle({ media: 'unknown-media' }),
+  },
+  play: async ({ canvas, step }) => {
+    await step('未知のメディアは zenn アイコンにフォールバックすることを確認', async () => {
+      const mediaIcon = canvas.getByRole('img')
+      await expect(mediaIcon).toHaveAttribute('src', '/images/zenn-icon.svg')
+    })
+  },
+}
+
+export const SkipInteraction: Story = {
+  play: async ({ canvas, args, step }) => {
+    await step('スキップボタンクリックで onSkip が呼ばれることを確認', async () => {
+      await userEvent.click(canvas.getByRole('button', { name: 'スキップ' }))
+      await expect(args.onSkip).toHaveBeenCalledTimes(1)
+    })
+  },
+}
+
+export const ReadInteraction: Story = {
+  play: async ({ canvas, args, step }) => {
+    await step('読むボタンクリックで onRead が呼ばれることを確認', async () => {
+      await userEvent.click(canvas.getByRole('button', { name: '読む' }))
+      await expect(args.onRead).toHaveBeenCalledTimes(1)
+    })
+  },
+}
+
+export const LaterInteraction: Story = {
+  play: async ({ canvas, args, step }) => {
+    await step('後でボタンクリックで onLater が呼ばれることを確認', async () => {
+      await userEvent.click(canvas.getByRole('button', { name: '後で' }))
+      await expect(args.onLater).toHaveBeenCalledTimes(1)
+    })
+  },
+}

--- a/application/packages/web/src/client/features/inbox/components/inbox-article-card.tsx
+++ b/application/packages/web/src/client/features/inbox/components/inbox-article-card.tsx
@@ -1,7 +1,10 @@
 import { isArticleMedia } from '@trend-diary/domain/article/media'
 import { Button } from '@/client/components/shadcn/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/client/components/shadcn/tooltip'
-import { MediaIcon, type MediaIconType } from '@/client/features/article'
+// barrel 経由だと article のデータ取得フック群まで読み込まれるため、表示専用の MediaIcon は実体を直接参照する
+import MediaIcon, {
+  type MediaType as MediaIconType,
+} from '@/client/features/article/components/media-icon'
 import type { Article } from '../hooks/use-unread-digestion'
 
 interface Props {

--- a/application/packages/web/src/client/features/inbox/components/inbox-body.stories.tsx
+++ b/application/packages/web/src/client/features/inbox/components/inbox-body.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, fn } from 'storybook/test'
+import type { Article } from '../hooks/use-unread-digestion'
+import InboxBody from './inbox-body'
+
+const article: Article = {
+  articleId: '1',
+  media: 'qiita',
+  title: '未読記事タイトル',
+  author: 'テスト著者',
+  description: 'テストの説明文です',
+  url: 'https://example.com',
+  createdAt: new Date('2024-01-01T00:00:00Z'),
+}
+
+const meta: Meta<typeof InboxBody> = {
+  component: InboxBody,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    onSkip: fn(),
+    onRead: fn(),
+    onLater: fn(),
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof InboxBody>
+
+// 記事がある場合は記事カードを表示する分岐
+export const WithArticle: Story = {
+  args: {
+    article,
+    isJustCompleted: false,
+  },
+  play: async ({ canvas, step }) => {
+    await step('未読記事カードが表示されることを確認', async () => {
+      await expect(canvas.getByText(article.title)).toBeInTheDocument()
+      await expect(canvas.getByRole('button', { name: '読む' })).toBeInTheDocument()
+    })
+  },
+}
+
+// 記事が無く、消化完了直後は完了カードを表示する分岐
+export const JustCompleted: Story = {
+  args: {
+    article: null,
+    isJustCompleted: true,
+  },
+  play: async ({ canvas, step }) => {
+    await step('完了カードが表示されることを確認', async () => {
+      await expect(canvas.getByText('消化完了')).toBeInTheDocument()
+    })
+  },
+}
+
+// 記事が無く、完了直後でもない場合は空メッセージを表示する分岐
+export const Empty: Story = {
+  args: {
+    article: null,
+    isJustCompleted: false,
+  },
+  play: async ({ canvas, step }) => {
+    await step('未読なしメッセージが表示されることを確認', async () => {
+      await expect(canvas.getByText('未読記事はありません')).toBeInTheDocument()
+    })
+  },
+}

--- a/application/packages/web/src/client/features/inbox/components/inbox-completion-card.stories.tsx
+++ b/application/packages/web/src/client/features/inbox/components/inbox-completion-card.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect } from 'storybook/test'
+import InboxCompletionCard from './inbox-completion-card'
+
+const meta: Meta<typeof InboxCompletionCard> = {
+  component: InboxCompletionCard,
+  parameters: {
+    layout: 'centered',
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof InboxCompletionCard>
+
+export const Default: Story = {
+  play: async ({ canvas, step }) => {
+    await step('完了バッジが表示されることを確認', async () => {
+      await expect(canvas.getByText('消化完了')).toBeInTheDocument()
+    })
+
+    await step('完了メッセージが表示されることを確認', async () => {
+      await expect(
+        canvas.getByText('いいペース。次の更新までこのペースをキープしよう。'),
+      ).toBeInTheDocument()
+    })
+  },
+}

--- a/application/packages/web/vitest.config.ts
+++ b/application/packages/web/vitest.config.ts
@@ -109,10 +109,10 @@ export default defineConfig(() => {
         ],
         // ベタガキしないと、Github Actionsに閾値が反映されない
         thresholds: {
-          statements: 75,
-          branches: 75,
-          functions: 75,
-          lines: 75,
+          statements: 80,
+          branches: 80,
+          functions: 80,
+          lines: 80,
         },
       },
     },


### PR DESCRIPTION
## 概要

Storybook（`storybook` プロジェクト）のカバレッジを補強し、`vitest.config.ts` のカバレッジ閾値を **75% → 80%** へ引き上げました。

CI はプロジェクト単位（client / server / storybook）で `--coverage` を実行し、閾値は各プロジェクトに個別適用されます。本変更で 3 プロジェクトすべてが 80% を満たすことを確認済みです。

## 変更点

### ストーリー追加（インタラクションテスト付き）

ストーリー未整備で `storybook` プロジェクトのカバレッジを押し下げていた表示系コンポーネントに、`play` 関数付きのストーリーを追加しました。

- `inbox-article-card` … タイトル/著者/説明・メディアアイコン（zenn フォールバック含む）・スキップ/読む/後で の各操作
- `inbox-body` … 記事あり / 完了直後 / 空 の 3 分岐
- `inbox-completion-card` … 完了表示
- `login-required` … 見出し・ログイン要求メッセージ
- `link` … `AnchorLink`（内部/外部）・`LinkAsButton`（内部/外部）
- `turnstile-widget` … API 読み込み済み（即 render）/ 未読み込み（スクリプト追加）の分岐
- `authenticate-form` … 送信時に入力値が `FormData` として `onSubmit` へ渡る振る舞いを追加検証

### 計測母数の適正化

- `inbox-article-card` は表示専用の `MediaIcon` のみを必要としますが、barrel（`@/client/features/article`）経由だと article のデータ取得フック群まで読み込まれ、`storybook` プロジェクトの計測母数を不当に押し下げていました。`article-card.tsx` と同様にコンポーネント実体を直接参照するよう変更しています。

### 閾値の引き上げ

- `statements` / `branches` / `functions` / `lines` をいずれも 75 → 80 に変更。

## カバレッジ（ローカル / CI 実績）

| プロジェクト | Statements | Branches | Functions | Lines |
|---|---|---|---|---|
| storybook（本PR後・ローカル） | 89.38% | 93.42% | 85.36% | 90.74% |
| client（#838 CI 実績） | 93.78% | 90.13% | 92.08% | 94.63% |
| server（#838 CI 実績） | 94.91% | 84.48% | 100% | 94.82% |

いずれも閾値 80% を満たしています。

## 確認

- `pnpm vitest run --project storybook`: 82 件すべて成功
- `pnpm vitest run --project storybook --coverage` / `--project client --coverage`: 閾値 80% を満たしグリーン
- `oxlint` / `oxfmt --check` / `tsgo --noEmit`（typecheck）: いずれもパス
- server プロジェクトは当環境では Supabase（Auth）を起動できず未実行のため、CI（#838 実績）の数値で 80% 充足を確認

> 注: ローカルでは Playwright のブラウザ（chromium v1223）配信ホストが egress 制限で取得できず、近接バージョンのバイナリで代替実行しています。最終的なカバレッジは CI の結果を正とします。

---
_Generated by [Claude Code](https://claude.ai/code/session_015TqRLm2BVhdX6WPyQ1P4FX)_