### PR TITLE
fix(ci): Dependabot の cooldown を pnpm minimumReleaseAge より長くする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,13 @@ updates:
     directory: "/application"
     schedule:
       interval: "weekly"
-    # pnpm の minimumReleaseAge(3日) と揃え、公開直後のパッケージを提案しない。
+    # pnpm の minimumReleaseAge(3日=4320分) より長くする。
+    # 同日数だと Dependabot(日単位判定) が選んだ版を pnpm(分単位判定) が
+    # 境界差で弾き、lockfile 更新が "No matching version found" で失敗して
+    # PR が作られなくなる（dependabot-core#13165）。閾値に余裕を持たせて回避する。
     # CVE等のセキュリティ更新はクールダウン対象外で即時PRが作成される。
     cooldown:
-      default-days: 3
+      default-days: 5
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## 背景

「Dependabot のPRが出なくなった」という相談から調査しました。

- Dependabot の最後のPRは **6/11（#820〜#824）** で、以降は出ていない。
- `.github/dependabot.yml` の `cooldown: default-days: 3` と `application/pnpm-workspace.yaml` の `minimumReleaseAge: 4320`（= 3日）は、**同じPR #767（6/10マージ）で同時に追加**され、意図的に3日で揃えられていた。

## 原因

cooldown と pnpm の `minimumReleaseAge` を **同じ日数で揃える** と、dependabot-core の既知バグ [dependabot/dependabot-core#13165](https://github.com/dependabot/dependabot-core/issues/13165)（open）に該当します。

1. Dependabot が cooldown(3日, 日単位判定)を通過した版を更新候補に選ぶ
2. lockfile 更新のため `pnpm install` を実行
3. pnpm の `minimumReleaseAge`(分単位判定)が境界差で同じ版を弾く
4. → `No matching version found ...` で解決失敗し、**PRが作られない**

## 変更内容

- npm の `cooldown.default-days` を `3` → `5` に引き上げ、pnpm の3日制限を必ず上回らせて境界衝突を回避。
- 意図をコメントに明記。
- github-actions 側は pnpm 非依存で衝突しないため据え置き。

## 確認のお願い

マージ後、`Insights → Dependency graph → Dependabot` で次回実行が成功し、PRが再び生成されることをご確認ください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TG1J2aQbmgMzegdpHGqKLJ)_