### PR TITLE
chore(ci): Dependabot の minor/patch 更新を group 化して lockfile 競合を防ぐ

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,23 @@ updates:
     # CVE等のセキュリティ更新はクールダウン対象外で即時PRが作成される。
     cooldown:
       default-days: 5
+    # 単一の pnpm-lock.yaml を複数 PR が同時に書き換えると相互に競合し、
+    # branch protection 下では Dependabot がリベースを完了できず詰まる。
+    # minor/patch を 1 PR に集約して lockfile 変更を 1 回に束ね、競合を防ぐ。
+    # major は個別 PR のまま残し、破壊的変更を単独でレビューできるようにする。
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     cooldown:
       default-days: 3
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## 背景

Dependabot 復活後の週次バッチで複数の npm 更新 PR が同時に出たところ、全 PR が単一の `application/pnpm-lock.yaml` を書き換えるため、1 件マージすると残りが競合（dirty）になりました。さらに本リポジトリの branch protection 下では **Dependabot がブランチをリベースできず**、競合した PR が詰まる状態になりました。

## 変更内容

npm / github-actions の **minor/patch 更新を group 化**し、1 回の実行でまとめて 1 PR に集約します。

- lockfile の変更が 1 PR に束ねられ、PR 間の相互競合が起きない
- major は引き続き個別 PR として出し、破壊的変更を単独でレビュー可能
- cooldown(5日) 等の既存設定は維持

## 現在詰まっている PR の扱い

このグループ設定が main にマージされた後、現在個別に開いている minor/patch の PR（#843 / #845 / #848）はクローズし、次回実行でグループ PR として再生成させる運用とします（#846 typescript は major なので個別のまま）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TG1J2aQbmgMzegdpHGqKLJ)_