### PR TITLE
chore(deps-dev): @typescript/native-preview を dev.20260627.2 系へ更新し型チェックを通す

### DIFF
--- a/application/apps/e2e/package.json
+++ b/application/apps/e2e/package.json
@@ -22,6 +22,7 @@
     "@cloudflare/workers-types": "catalog:",
     "@faker-js/faker": "catalog:",
     "@playwright/test": "catalog:",
+    "@types/node": "catalog:",
     "playwright": "catalog:"
   }
 }

--- a/application/apps/web/package.json
+++ b/application/apps/web/package.json
@@ -59,6 +59,7 @@
     "@hono/vite-dev-server": "^0.26.0",
     "@playwright/test": "catalog:",
     "@react-router/dev": "^7.17.0",
+    "@react-router/node": "^7.17.0",
     "@storybook/addon-a11y": "^10.4.6",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-vitest": "^10.4.6",

--- a/application/package.json
+++ b/application/package.json
@@ -12,7 +12,7 @@
     "supabase:stop": "supabase stop"
   },
   "devDependencies": {
-    "@typescript/native-preview": "^7.0.0-dev.20251209.1",
+    "@typescript/native-preview": "^7.0.0-dev.20260627.2",
     "oxfmt": "^0.56.0",
     "oxlint": "^1.71.0",
     "typescript": "^5.9.3"

--- a/application/pnpm-lock.yaml
+++ b/application/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
   .:
     devDependencies:
       '@typescript/native-preview':
-        specifier: ^7.0.0-dev.20251209.1
-        version: 7.0.0-dev.20251209.1
+        specifier: ^7.0.0-dev.20260627.2
+        version: 7.0.0-dev.20260629.1
       oxfmt:
         specifier: ^0.56.0
         version: 0.56.0
@@ -151,6 +151,9 @@ importers:
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.61.1
+      '@types/node':
+        specifier: 'catalog:'
+        version: 26.0.1
       playwright:
         specifier: 'catalog:'
         version: 1.61.1
@@ -287,6 +290,9 @@ importers:
       '@react-router/dev':
         specifier: ^7.17.0
         version: 7.17.0(@types/node@26.0.1)(jiti@2.7.0)(lightningcss@1.32.0)(react-router@7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(tsx@4.22.4)(typescript@5.9.3)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))(wrangler@4.105.0(@cloudflare/workers-types@4.20260630.1))
+      '@react-router/node':
+        specifier: ^7.17.0
+        version: 7.18.1(react-router@7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
       '@storybook/addon-a11y':
         specifier: ^10.4.6
         version: 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react@19.2.7))
@@ -2266,6 +2272,16 @@ packages:
       typescript:
         optional: true
 
+  '@react-router/node@7.18.1':
+    resolution: {integrity: sha512-2GhAwa90z/+GMFM8Q5HsgwzakYogbQcZpqpNonhN4YWDRjWkSz+t5jgwNAFvG8ENR8fKGEVEsOHIaNVDfW9Ouw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react-router: 7.18.1
+      typescript: ^5.1.0 || ^6.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@reduxjs/toolkit@2.12.0':
     resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
     peerDependencies:
@@ -2876,43 +2892,51 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20251209.1':
-    resolution: {integrity: sha512-F1cnYi+ZeinYQnaTQKKIsbuoq8vip5iepBkSZXlB8PjbG62LW1edUdktd/nVEc+Q+SEysSQ3jRdk9eU766s5iw==}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260629.1':
+    resolution: {integrity: sha512-wXRExZJweYoTzE4atRR7T5HwKJYkl6/KHxON0eF0iy2fvgLXDlyq4AQqhmV8mMx10PQKc/4sNbfhD4kjWWvm8A==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20251209.1':
-    resolution: {integrity: sha512-Ta6XKdAxEMBzd1xS4eQKXmlUkml+kMf23A9qFoegOxmyCdHJPak2gLH9ON5/C6js0ibZm1kdqwbcA0/INrcThg==}
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260629.1':
+    resolution: {integrity: sha512-xkL/tETzUuDxfRkk2rD0/CjjjGLyOLHeE103T52rpgj0VNSXMnn7tTiw+TSdxnS61b8ImOrWgQJujhPFTp0jng==}
+    engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20251209.1':
-    resolution: {integrity: sha512-kdiPMvs1hwi76hgvZjz4XQVNYTV+MAbJKnHXz6eL6aVXoTYzNtan5vWywKOHv9rV4jBMyVlZqtKbeG/XVV9WdQ==}
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260629.1':
+    resolution: {integrity: sha512-y4ey82krq4iLNHML4G1dUObBWY6gNAjVqaUHFDv7+LBu5bfAJy8VClBaLtAJce3siQQeB0/4SkN4XsAa0oZktQ==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20251209.1':
-    resolution: {integrity: sha512-4e7WSBLLdmfJUGzm9Id4WA2fDZ2sY3Q6iudyZPNSb5AFsCmqQksM/JGAlNROHpi/tIqo95e3ckbjmrZTmH60EA==}
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260629.1':
+    resolution: {integrity: sha512-QlTxO+O6yELc0NYZZYIbncZhkhw+K/vBoVg+mKipbEIK5b1E6cwW7ivWIrDp1FfssQ0Wu7zxincPappoci7KNw==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20251209.1':
-    resolution: {integrity: sha512-dH/Z50Xb52N4Csd0BXptmjuMN+87AhUAjM9Y5rNU8VwcUJJDFpKM6aKUhd4Q+XEVJWPFPlKDLx3pVhnO31CBhQ==}
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260629.1':
+    resolution: {integrity: sha512-ckb4HyugC5beDpOMPOVpEx1H3l2Z2RgsGPxFOLGMU6LLIHQwlCaSdRjSfH8Hq8yffPgKuotTQLdA89cP1IC8xQ==}
+    engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20251209.1':
-    resolution: {integrity: sha512-vW7IGRNIUhhQ0vzFY3sRNxvYavNGum2OWgW1Bwc05yhg9AexBlRjdhsUSTLQ2dUeaDm2nx4i38LhXIVgLzMNeA==}
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260629.1':
+    resolution: {integrity: sha512-Ktgepu9p0blqrbiryzYrw11ddnbESXPdeGKURDG/wXESoHQETsMNxKWhqAo587ItNnWjKOBFxoEM22eP9OzKnw==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20251209.1':
-    resolution: {integrity: sha512-jKT6npBrhRX/84LWSy9PbOWx2USTZhq9SOkvH2mcnU/+uqyNxZIMMVnW5exIyzcnWSPly3jK2qpfiHNjdrDaAA==}
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260629.1':
+    resolution: {integrity: sha512-b2wmeIpFJs/peej3NG26320ya+iYQz21JzFYDrnvtsEeR/g66rB9uvp4Owo4J1AG/BcmRWC/nuwrBy3Jdb+UDA==}
+    engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
 
-  '@typescript/native-preview@7.0.0-dev.20251209.1':
-    resolution: {integrity: sha512-xnx3A1S1TTx+mx8FfP1UwkNTwPBmhGCbOh4PDNRUV5gDZkVuDDN3y1F7NPGSMg6MXE1KKPSLNM+PQMN33ZAL2Q==}
+  '@typescript/native-preview@7.0.0-dev.20260629.1':
+    resolution: {integrity: sha512-KImWFkxGUa/V78bUEAgzeJQT+6wKQXDDYHHrOavof8wnbMCpj86KuPNyBIPQMtoHiz2If8aNTums2m50oE3oqw==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   '@vitest/browser-playwright@4.1.9':
@@ -6016,6 +6040,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@react-router/node@7.18.1(react-router@7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)':
+    dependencies:
+      '@mjackson/node-fetch-server': 0.2.0
+      react-router: 7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -6510,36 +6541,36 @@ snapshots:
       '@types/node': 26.0.1
     optional: true
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20251209.1':
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260629.1':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20251209.1':
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260629.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20251209.1':
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260629.1':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20251209.1':
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260629.1':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20251209.1':
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260629.1':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20251209.1':
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260629.1':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20251209.1':
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260629.1':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20251209.1':
+  '@typescript/native-preview@7.0.0-dev.20260629.1':
     optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20251209.1
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20251209.1
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20251209.1
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20251209.1
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20251209.1
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20251209.1
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20251209.1
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260629.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260629.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260629.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260629.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260629.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260629.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260629.1
 
   '@vitest/browser-playwright@4.1.9(playwright@1.61.1)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))(vitest@4.1.9)':
     dependencies:
@@ -7009,7 +7040,7 @@ snapshots:
       react-router: 7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     optionalDependencies:
       '@hono/node-server': 1.19.14(hono@4.12.27)
-      '@react-router/node': 7.17.0(react-router@7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
+      '@react-router/node': 7.18.1(react-router@7.16.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(typescript@5.9.3)
     transitivePeerDependencies:
       - miniflare
       - react


### PR DESCRIPTION
# 概要

Dependabot の #861（`@typescript/native-preview` 更新）は、そのままだと CI の `web-build` / `code-quality` が型チェックで落ちてマージできませんでした。原因を切り分けたうえで、直接依存の明示で解消したものです。#861 を置き換えます。

## 課題

新しい `tsgo`（native-preview `dev.20260627` 系）は、`tsconfig.json` の `compilerOptions.types` に列挙した型ライブラリを**直接依存からのみ**解決するようになりました。旧版が黙認していた推移的／catalog 依存の型ライブラリは解決できず、以下の `TS2688` で型チェックが失敗します。

- `apps/e2e`: `error TS2688: Cannot find type definition file for 'node'.`（tsconfig の `types: ["node"]`、`@types/node` は catalog 経由の推移的依存）
- `apps/web`: `error TS2688: Cannot find type definition file for '@react-router/node'.`（`@react-router/node` は `@react-router/dev` 経由の推移的依存）

## 修正内容

- fix: <!-- #861 -->
- `types` で参照している型ライブラリを、参照元パッケージの直接 `devDependency` として明示する（tsconfig の `types` に書くなら直接依存であるべき、という整合の担保）
  - `apps/e2e`: `@types/node`（catalog 参照）を追加
  - `apps/web`: `@react-router/node`（`^7.17.0`、react-router 7 系に整合）を追加
- あわせて `@typescript/native-preview` を `^7.0.0-dev.20260627.2` へ更新（#861 相当）。lockfile は `minimumReleaseAge` に従い `dev.20260629.1` に解決

### その方針を選んだ理由

- 型チェックの失敗はプレビューコンパイラの `types` 解決仕様の変更に起因するものであり、`tsconfig` から参照している型ライブラリを直接依存にするのは本来あるべき状態でもあるため、ワークアラウンドではなく整合を取る形で解消した
- グループ対象外の依存を巻き込まないよう、lockfile は既存解決を維持し native-preview と追加した型ライブラリのみを更新している

## その他・参考情報

ローカルで以下を確認済みです。

- `pnpm -r typecheck`: 全パッケージ成功（`apps/e2e` / `apps/web` の TS2688 解消）
- `pnpm install --frozen-lockfile`: 整合 OK
- `oxlint`（warning のみ・既存）/ `oxfmt --check`: パス

なお `react-router` 8 系（#860 / #862）は本 PR の対象外です。`hono-react-router-adapter` が最新の `0.6.5` でも `react-router: ^7` 依存で v8 未対応のため、アダプタが middleware（`RouterContextProvider`）へ対応するまで実装での解消が難しく、見送っています。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q68b1CgJXrdkUTB3pL9wEJ)_