### PR TITLE
docs: GitHub操作でMCP利用を制限する記述を削除

### DIFF
--- a/docs/development_rule.md
+++ b/docs/development_rule.md
@@ -49,12 +49,6 @@ trend_diary/
 └── docs/                       # ドキュメント（adr / how_to_guides / system_config）
 ```
 
-### GitHub操作
-
-- GitHub操作は原則`gh` CLIで行う
-- GitHub MCP（`mcp__github__*`）は原則禁止。ただし**PRの作成・更新**と**レビューコメントへの返信**はMCP利用可
-- 上記以外（Issue・CIなど）は`gh` CLIで行うこと
-
 ### レビュー時のprefix
 
 レビューコメントには以下のprefixをつける:


### PR DESCRIPTION
## Summary
- `docs/development_rule.md`（`CLAUDE.md`のシンボリックリンク先）から、GitHub MCP（`mcp__github__*`）の利用を原則禁止としていた「GitHub操作」セクションを削除

## Test plan
- [x] ドキュメントのみの変更のためビルド・テストへの影響なし


---
_Generated by [Claude Code](https://claude.ai/code/session_019ieqJ29X1wVNetcH8uGg1M)_