### PR TITLE
fix(e2e): D1のSQLITE_BUSYをクライアント側リトライで吸収する

### DIFF
--- a/application/e2e/src/d1.ts
+++ b/application/e2e/src/d1.ts
@@ -34,7 +34,13 @@ async function withBusyRetry<T>(run: () => Promise<T>): Promise<T> {
   }
 }
 
-const STATEMENT_EXEC_METHODS = new Set<PropertyKey>(['first', 'run', 'all', 'raw'])
+// satisfies で実在する D1 メソッド名であることを強制し、タイポでリトライ対象から漏れるのを防ぐ
+const STATEMENT_EXEC_METHODS: ReadonlySet<PropertyKey> = new Set([
+  'first',
+  'run',
+  'all',
+  'raw',
+] satisfies (keyof D1PreparedStatement)[])
 
 function wrapStatementWithBusyRetry(statement: D1PreparedStatement): D1PreparedStatement {
   return new Proxy(statement, {
@@ -54,7 +60,10 @@ function wrapStatementWithBusyRetry(statement: D1PreparedStatement): D1PreparedS
   })
 }
 
-const DATABASE_EXEC_METHODS = new Set<PropertyKey>(['batch', 'exec'])
+const DATABASE_EXEC_METHODS: ReadonlySet<PropertyKey> = new Set([
+  'batch',
+  'exec',
+] satisfies (keyof D1Database)[])
 
 function wrapDbWithBusyRetry(db: D1Database): D1Database {
   return new Proxy(db, {

--- a/application/e2e/src/d1.ts
+++ b/application/e2e/src/d1.ts
@@ -1,11 +1,76 @@
 import { dirname, resolve } from 'node:path'
+import { setTimeout as sleep } from 'node:timers/promises'
 import { fileURLToPath } from 'node:url'
-import type { D1Database } from '@cloudflare/workers-types'
+import type { D1Database, D1PreparedStatement } from '@cloudflare/workers-types'
 import { getPlatformProxy } from 'wrangler'
 
 interface TestD1 {
   db: D1Database
   dispose: () => Promise<void>
+}
+
+// webServer(wrangler dev)とこのクライアント(getPlatformProxy)は別プロセスの workerd として
+// 同一 SQLite ファイル(.wrangler/state/v3)を共有するため、サーバーの書き込みと重なると
+// SQLITE_BUSY で一時的に失敗する。miniflare は busy_timeout を設定できないため、
+// クライアント側の再試行でロック解放を待って吸収する。
+const BUSY_RETRY_MAX_ATTEMPTS = 5
+const BUSY_RETRY_BASE_DELAY_MS = 100
+
+// SQLITE_BUSY は miniflare の D1 エミュレーションを経由すると「internal error」としか報告されない
+const RETRYABLE_ERROR_PATTERN = /internal error|SQLITE_BUSY|database is locked/i
+
+function isBusyError(error: unknown): boolean {
+  return error instanceof Error && RETRYABLE_ERROR_PATTERN.test(error.message)
+}
+
+async function withBusyRetry<T>(run: () => Promise<T>): Promise<T> {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await run()
+    } catch (error) {
+      if (attempt >= BUSY_RETRY_MAX_ATTEMPTS || !isBusyError(error)) throw error
+      await sleep(BUSY_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1))
+    }
+  }
+}
+
+const STATEMENT_EXEC_METHODS = new Set<PropertyKey>(['first', 'run', 'all', 'raw'])
+
+function wrapStatementWithBusyRetry(statement: D1PreparedStatement): D1PreparedStatement {
+  return new Proxy(statement, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver)
+      if (typeof value !== 'function') return value
+      const method = value.bind(target)
+      // bind は新しいステートメントを返すため、戻り値にも再試行を適用し続ける
+      if (prop === 'bind') {
+        return (...args: unknown[]) => wrapStatementWithBusyRetry(method(...args))
+      }
+      if (STATEMENT_EXEC_METHODS.has(prop)) {
+        return (...args: unknown[]) => withBusyRetry(() => method(...args))
+      }
+      return method
+    },
+  })
+}
+
+const DATABASE_EXEC_METHODS = new Set<PropertyKey>(['batch', 'exec'])
+
+function wrapDbWithBusyRetry(db: D1Database): D1Database {
+  return new Proxy(db, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver)
+      if (typeof value !== 'function') return value
+      const method = value.bind(target)
+      if (prop === 'prepare') {
+        return (...args: unknown[]) => wrapStatementWithBusyRetry(method(...args))
+      }
+      if (DATABASE_EXEC_METHODS.has(prop)) {
+        return (...args: unknown[]) => withBusyRetry(() => method(...args))
+      }
+      return method
+    },
+  })
 }
 
 // このパッケージ(e2e)から web パッケージ(apps/web)へ辿る。
@@ -25,5 +90,5 @@ export async function openTestD1(): Promise<TestD1> {
       'D1 バインディング "DB" が見つかりません。wrangler.toml の設定を確認してください。',
     )
   }
-  return { db: proxy.env.DB, dispose: () => proxy.dispose() }
+  return { db: wrapDbWithBusyRetry(proxy.env.DB), dispose: () => proxy.dispose() }
 }


### PR DESCRIPTION
# 概要
## 問題のあった領域

- [ ] フロントエンド
  - [ ] UIの描画(レンダリング)
  - [ ] ビジネスロジック（状態管理、非同期処理、エラーハンドリングなど）
  - [ ] バックエンドとの整合ミス
- [ ] バックエンド
  - [ ] API（プレゼン層）
  - [ ] ビジネスロジック
  - [ ] データアクセス（DB・SQL）
  - [ ] 脆弱性
- [x] その他
    - [x] CI/CD（GitHub Actionsやクラウド上のCI/CD関連）
    - [ ] インフラ（パブリッククラウドの設定・技術詳細）

### 要因の詳細

mainのCI（[run 29034715190](https://github.com/geek-beyond/trend_diary/actions/runs/29034715190)）でE2Eジョブが失敗していました。`passkey-basic.test.ts` の `afterAll` クリーンアップ（`helper/user.ts` の `cleanUpByEmailPattern`）のD1クエリが1回目の試行で失敗し、リトライでは成功したため `--fail-on-flaky-tests` によりflaky扱いとなりCIが落ちています。

直接のエラーは `D1_ERROR: Failed to parse body as JSON, got: Error: internal error` ですが、同時刻のworkerdログに実際の原因が出ています。

```
workerd/util/sqlite.c++:1671: failed: ... SQLite failed; ... database is locked: SQLITE_BUSY
```

構造的な原因は、Playwrightの `webServer`（`wrangler dev`）とテスト用RDBクライアント（`getPlatformProxy`）が**別プロセスのworkerd**として同一のSQLiteファイル（`apps/web/.wrangler/state/v3` のlocal D1）を共有していることです。サーバーがリクエスト処理で書き込み中に、テスト側のクエリが重なるとロック競合で `SQLITE_BUSY` になります。タイミング依存のため恒常的なflaky要因になっていました（7/9の [run 28993986608](https://github.com/geek-beyond/trend_diary/actions/runs/28993986608) も同様にE2Eで失敗）。

### 再現手順

タイミング依存のため決定的な再現は困難ですが、E2E実行中にwebServerへのリクエスト処理（書き込み）とテスト側のD1クエリ（`afterAll` クリーンアップ等）が重なると発生します。CI上では上記2つのrunで発生しています。

## 修正方針

E2E側のD1クライアント（`e2e/src/d1.ts`）に、ステートメント実行レベル（`first` / `run` / `all` / `raw` / `batch` / `exec`）の指数バックオフ付きリトライ（最大5回、100ms〜）を追加しました。`SQLITE_BUSY` / `database is locked` / miniflare経由で丸められる `internal error` のみをリトライ対象とし、それ以外のエラーは即時throwします。

fixturesの `rdb` もglobal-setupのマイグレーションもすべて `openTestD1` を経由するため、ここでラップすることで全経路に一元的に適用されます。

### その方針を選んだ理由

検討した代替案:

- **`busy_timeout` の設定**: miniflare / `getPlatformProxy` はSQLiteの `busy_timeout` を公開しておらず設定できません
- **DB共有をやめる（サーバーAPI経由でクリーンアップ）**: テストデータ操作用のAPIが存在せず、テスト都合のAPIを本体に生やすことになるため見送りました
- **`--fail-on-flaky-tests` の撤去**: flaky検知の仕組み自体は「落ちるべきときに落ちる」担保として維持すべきなので採用しません

`SQLITE_BUSY` はロック取得前に返るエラーでコミットは発生していないため、リトライは安全（冪等）です。ロック保持は一瞬なので短いバックオフで確実に回復します（実際、Playwrightのテストリトライでは成功していました）。

## その他、参考情報

- ローカル環境にDocker/Supabaseがないため実機E2Eは未実行です。lint / typecheck は通過済み、リトライラッパーのロジックはCI実ログのエラーメッセージを再現したスクリプトで検証済みです（BUSYでリトライして成功・`bind` 経由でも適用・BUSY以外は即時throw・上限到達でthrow）
- 本PRのCIおよびマージ後のmain CIのE2E結果で最終確認します

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Y24P2j8CAKH2jET1EJjkp

---
_Generated by [Claude Code](https://claude.ai/code/session_019Y24P2j8CAKH2jET1EJjkp)_