### PR TITLE
feat: ダークモードに対応する

### DIFF
--- a/application/apps/web/src/client/components/ui/input/toggle-group/index.tsx
+++ b/application/apps/web/src/client/components/ui/input/toggle-group/index.tsx
@@ -37,8 +37,9 @@ export function ToggleGroup<T>({
             variant='outline'
             aria-pressed={isSelected}
             className={cn(
-              'border-gray-300 text-gray-700 hover:bg-gray-100',
-              isSelected && 'border-blue-600 bg-blue-50 text-blue-700 hover:bg-blue-100',
+              'border-border text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+              isSelected &&
+                'border-blue-600 bg-blue-50 text-blue-700 hover:bg-blue-100 dark:border-blue-400 dark:bg-blue-950 dark:text-blue-200 dark:hover:bg-blue-900',
             )}
             onClick={() => onSelect(option.value)}
             data-slot={option.dataSlot}

--- a/application/apps/web/src/client/components/ui/layout/app-header/index.tsx
+++ b/application/apps/web/src/client/components/ui/layout/app-header/index.tsx
@@ -21,7 +21,7 @@ export default function AppHeader({ isLoggedIn }: Props) {
   const visibleMenuItems = getVisibleMenuItems(isLoggedIn)
 
   return (
-    <header className='border-b border-slate-200 bg-white/80 backdrop-blur-sm sticky top-0 z-50 md:hidden'>
+    <header className='border-b border-border bg-background/80 backdrop-blur-sm sticky top-0 z-50 md:hidden'>
       <div className='flex justify-between items-center h-16 px-4'>
         <AnchorLink to='/' className='flex items-center gap-2 hover:opacity-80 transition-opacity'>
           <TrendingUp className='h-6 w-6 text-blue-600' />

--- a/application/apps/web/src/client/components/ui/layout/landing-header/index.tsx
+++ b/application/apps/web/src/client/components/ui/layout/landing-header/index.tsx
@@ -3,7 +3,7 @@ import { AnchorLink } from '@/client/components/ui/navigation/link'
 
 export default function LandingHeader() {
   return (
-    <header className='border-b border-slate-200 bg-white/80 backdrop-blur-sm sticky top-0 z-50'>
+    <header className='border-b border-border bg-background/80 backdrop-blur-sm sticky top-0 z-50'>
       <div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'>
         <div className='flex justify-between items-center h-16'>
           <AnchorLink
@@ -11,12 +11,12 @@ export default function LandingHeader() {
             className='flex items-center gap-1.5 sm:gap-2 hover:opacity-80 transition-opacity'
           >
             <TrendingUp className='h-6 w-6 sm:h-8 sm:w-8 text-blue-600' />
-            <h1 className='text-lg sm:text-2xl font-bold text-slate-900'>TrendDiary</h1>
+            <h1 className='text-lg sm:text-2xl font-bold text-foreground'>TrendDiary</h1>
           </AnchorLink>
           <div className='flex items-center gap-2 sm:gap-4'>
             <AnchorLink
               to='/login'
-              className='inline-flex items-center px-2.5 py-1.5 sm:px-4 sm:py-2 border border-slate-300 rounded-md text-xs sm:text-sm font-medium text-slate-700 bg-white hover:bg-slate-50 transition-colors duration-200'
+              className='inline-flex items-center px-2.5 py-1.5 sm:px-4 sm:py-2 border border-border rounded-md text-xs sm:text-sm font-medium text-foreground bg-background hover:bg-accent transition-colors duration-200'
             >
               ログイン
             </AnchorLink>

--- a/application/apps/web/src/client/components/ui/layout/landing-header/landing-header.stories.tsx
+++ b/application/apps/web/src/client/components/ui/layout/landing-header/landing-header.stories.tsx
@@ -52,7 +52,7 @@ export const HoverInteraction: Story = {
     // ログインボタンにホバーした時の動作を確認
     const loginLink = canvas.getByRole('link', { name: 'ログイン' })
     await userEvent.hover(loginLink)
-    await expect(loginLink).toHaveClass('hover:bg-slate-50')
+    await expect(loginLink).toHaveClass('hover:bg-accent')
 
     // アカウント作成ボタンにホバーした時の動作を確認
     const signupLink = canvas.getByRole('link', { name: 'アカウント作成' })

--- a/application/apps/web/src/client/components/ui/layout/sidebar/index.tsx
+++ b/application/apps/web/src/client/components/ui/layout/sidebar/index.tsx
@@ -67,7 +67,7 @@ export default function AppSidebar({ isLoggedIn }: Props) {
         <SidebarHeader>
           <AnchorLink
             to='/'
-            className='flex items-center gap-2 px-4 py-2 hover:bg-gray-100 rounded-md transition-colors'
+            className='flex items-center gap-2 px-4 py-2 hover:bg-accent rounded-md transition-colors'
           >
             <TrendingUp className='h-8 w-8 text-blue-600' />
             <span className='text-xl font-semibold'>TrendDiary</span>

--- a/application/apps/web/src/client/components/ui/navigation/nav-menu/index.tsx
+++ b/application/apps/web/src/client/components/ui/navigation/nav-menu/index.tsx
@@ -28,12 +28,12 @@ export default function NavMenu({ variant, menuItems }: NavMenuProps) {
 
   return (
     <nav className='flex flex-col gap-2'>
-      <div className='text-xs font-semibold text-gray-500 px-3'>Application</div>
+      <div className='text-xs font-semibold text-muted-foreground px-3'>Application</div>
       {menuItems.map((item) => (
         <SheetClose key={item.title} asChild={true}>
           <AnchorLink
             to={item.url}
-            className='flex items-center gap-3 px-3 py-2 rounded-md hover:bg-gray-100 transition-colors'
+            className='flex items-center gap-3 px-3 py-2 rounded-md hover:bg-accent transition-colors'
           >
             <item.icon className='h-5 w-5' />
             <span>{item.title}</span>

--- a/application/apps/web/src/client/components/ui/typography/legal/index.tsx
+++ b/application/apps/web/src/client/components/ui/typography/legal/index.tsx
@@ -11,15 +11,15 @@ interface ParagraphProps {
 }
 
 export function Heading1({ children }: HeadingProps) {
-  return <h1 className='mb-8 text-3xl font-bold text-slate-900'>{children}</h1>
+  return <h1 className='mb-8 text-3xl font-bold text-foreground'>{children}</h1>
 }
 
 export function Heading2({ children }: HeadingProps) {
-  return <h2 className='mb-4 mt-8 text-xl font-bold text-slate-900'>{children}</h2>
+  return <h2 className='mb-4 mt-8 text-xl font-bold text-foreground'>{children}</h2>
 }
 
 export function Heading3({ children }: HeadingProps) {
-  return <h3 className='mb-3 mt-6 text-lg font-semibold text-slate-900'>{children}</h3>
+  return <h3 className='mb-3 mt-6 text-lg font-semibold text-foreground'>{children}</h3>
 }
 
 export function Paragraph({ children, className }: ParagraphProps) {

--- a/application/apps/web/src/client/features/article/components/article-card-skeleton.tsx
+++ b/application/apps/web/src/client/features/article/components/article-card-skeleton.tsx
@@ -9,7 +9,7 @@ export default function ArticleCardSkeleton() {
       aria-hidden='true'
       data-slot='card'
       data-testid='article-card-skeleton'
-      className='h-32 w-full sm:w-64 rounded-3xl border border-white/40 bg-white/30 p-6 shadow-2xl backdrop-blur-xl'
+      className='h-32 w-full sm:w-64 rounded-3xl border border-border bg-card/30 p-6 shadow-2xl backdrop-blur-xl'
     >
       <CardContent className='flex h-full flex-col p-0'>
         <div className='flex-1 space-y-2'>

--- a/application/apps/web/src/client/features/article/components/article-card.tsx
+++ b/application/apps/web/src/client/features/article/components/article-card.tsx
@@ -28,7 +28,7 @@ export default function ArticleCard({
       data-slot='card'
       data-testid='article-card'
       className={cn(
-        'relative h-32 w-full sm:w-64 rounded-3xl border border-white/40 bg-white/30 p-6 shadow-2xl backdrop-blur-xl transition-all duration-300 hover:shadow-xl',
+        'relative h-32 w-full sm:w-64 rounded-3xl border border-border bg-card/30 p-6 shadow-2xl backdrop-blur-xl transition-all duration-300 hover:shadow-xl',
         isRead && 'opacity-60',
       )}
     >
@@ -42,7 +42,7 @@ export default function ArticleCard({
       />
 
       <CardContent className='flex h-full flex-col p-0'>
-        <CardTitle className='line-clamp-2 flex-1 text-sm leading-relaxed font-bold text-gray-700'>
+        <CardTitle className='line-clamp-2 flex-1 text-sm leading-relaxed font-bold text-foreground'>
           <MediaIcon media={toMediaType(article.media)} size='sm' />
           <span className='ml-1'>{article.title}</span>
           {isRead && (
@@ -56,12 +56,12 @@ export default function ArticleCard({
         </CardTitle>
 
         <CardDescription className='mt-3 flex items-end justify-between'>
-          <span className='text-sm text-gray-600'>{article.author}</span>
+          <span className='text-sm text-muted-foreground'>{article.author}</span>
           {isLoggedIn && (
             <button
               type='button'
               onClick={handleToggleRead}
-              className='relative z-10 text-xs text-gray-500 hover:text-gray-700 underline'
+              className='relative z-10 text-xs text-muted-foreground hover:text-foreground underline'
             >
               {isRead ? '未読にする' : '既読にする'}
             </button>

--- a/application/apps/web/src/client/features/article/components/article-drawer.tsx
+++ b/application/apps/web/src/client/features/article/components/article-drawer.tsx
@@ -64,7 +64,7 @@ export default function ArticleDrawer({
         <DrawerHeader className='flex flex-row items-center justify-between pb-4'>
           <div className='flex flex-1 items-center gap-2' data-slot='drawer-header-icon'>
             <MediaIcon media={media} />
-            <DrawerTitle className='text-xl leading-relaxed font-bold text-gray-900'>
+            <DrawerTitle className='text-xl leading-relaxed font-bold text-foreground'>
               {article.title}
             </DrawerTitle>
             {/* スクリーンリーダー向けの説明。Radix Dialog の aria-describedby 警告も解消する */}
@@ -93,12 +93,12 @@ export default function ArticleDrawer({
         {/* data-vaul-no-dragをfalseに指定し、ドラッグしてDrawerが閉じないように */}
         <div className='flex-1 overflow-y-auto px-4 select-text' data-vaul-no-drag={false}>
           <div
-            className='mb-6 flex flex-wrap items-center gap-6 text-sm text-gray-600'
+            className='mb-6 flex flex-wrap items-center gap-6 text-sm text-muted-foreground'
             data-slot='drawer-content-meta'
           >
             <div className='flex items-center gap-1' data-slot='drawer-content-author'>
               <User className='size-4' />
-              <span className='text-sm font-medium text-gray-700'>{article.author}</span>
+              <span className='text-sm font-medium text-foreground'>{article.author}</span>
             </div>
             <div className='flex items-center gap-1'>
               <Calendar className='size-4' />
@@ -107,10 +107,10 @@ export default function ArticleDrawer({
           </div>
 
           <div className='mb-8' data-slot='drawer-content-description'>
-            <h3 className='mb-3 text-lg font-semibold text-gray-900'>概要</h3>
+            <h3 className='mb-3 text-lg font-semibold text-foreground'>概要</h3>
             <p
               className={cn(
-                'leading-relaxed text-gray-700',
+                'leading-relaxed text-foreground',
                 shouldShowDescriptionToggle && !isDescriptionExpanded && 'line-clamp-4',
               )}
               data-slot='drawer-content-description-content'

--- a/application/apps/web/src/client/features/article/components/filter-panel/desktop-filter-panel.tsx
+++ b/application/apps/web/src/client/features/article/components/filter-panel/desktop-filter-panel.tsx
@@ -11,9 +11,9 @@ export function DesktopFilterPanel({ applied, isLoggedIn, onApplyFilters }: Filt
   }
 
   return (
-    <div className='mb-4 rounded-lg border border-gray-300 bg-white/50 p-4'>
-      <h2 className='mb-3 inline-flex items-center gap-2 text-sm font-semibold text-gray-700'>
-        <Funnel className='h-4 w-4 text-gray-600' />
+    <div className='mb-4 rounded-lg border border-border bg-card/50 p-4'>
+      <h2 className='mb-3 inline-flex items-center gap-2 text-sm font-semibold text-foreground'>
+        <Funnel className='h-4 w-4 text-muted-foreground' />
         <span>絞り込み</span>
       </h2>
       <div className='flex items-start gap-4'>

--- a/application/apps/web/src/client/features/article/components/filter-panel/filter-field.tsx
+++ b/application/apps/web/src/client/features/article/components/filter-panel/filter-field.tsx
@@ -15,7 +15,9 @@ export function FilterField({
   const isMobile = variant === 'mobile'
   return (
     <div className={isMobile ? 'flex w-full flex-col items-start gap-2' : 'flex flex-col gap-1'}>
-      <span className={twMerge('font-medium text-gray-600', isMobile ? 'text-sm' : 'text-xs')}>
+      <span
+        className={twMerge('font-medium text-muted-foreground', isMobile ? 'text-sm' : 'text-xs')}
+      >
         {label}
       </span>
       {children}

--- a/application/apps/web/src/client/features/article/components/filter-panel/mobile-filter-panel.tsx
+++ b/application/apps/web/src/client/features/article/components/filter-panel/mobile-filter-panel.tsx
@@ -44,7 +44,7 @@ export function MobileFilterPanel({ applied, isLoggedIn, onApplyFilters }: Filte
   }
 
   return (
-    <div className='mb-4 rounded-lg border border-gray-300 bg-white/50 p-4'>
+    <div className='mb-4 rounded-lg border border-border bg-card/50 p-4'>
       <button
         type='button'
         className='flex w-full items-center justify-between'
@@ -52,8 +52,8 @@ export function MobileFilterPanel({ applied, isLoggedIn, onApplyFilters }: Filte
         data-slot='mobile-filter-trigger'
       >
         <span className='inline-flex items-center gap-2'>
-          <Funnel className='h-4 w-4 text-gray-600' />
-          <span className='text-sm font-semibold text-gray-700'>絞り込み</span>
+          <Funnel className='h-4 w-4 text-muted-foreground' />
+          <span className='text-sm font-semibold text-foreground'>絞り込み</span>
           {appliedFilterCount > 0 && (
             <span
               className='rounded-full bg-blue-100 px-2 py-0.5 text-xs font-semibold text-blue-700'
@@ -65,7 +65,7 @@ export function MobileFilterPanel({ applied, isLoggedIn, onApplyFilters }: Filte
         </span>
         <ChevronDown
           className={twMerge(
-            'h-4 w-4 text-gray-600 transition-transform',
+            'h-4 w-4 text-muted-foreground transition-transform',
             isOpen ? 'rotate-180' : '',
           )}
         />

--- a/application/apps/web/src/client/features/diary/components/page-layout.tsx
+++ b/application/apps/web/src/client/features/diary/components/page-layout.tsx
@@ -7,9 +7,9 @@ type Props = PropsWithChildren<{
 
 export default function DiaryPageLayout({ pageTitle, dateResolveError, children }: Props) {
   return (
-    <div className='min-h-screen bg-gradient-to-br from-gray-100 to-gray-200 p-6'>
-      <div className='mx-auto w-full max-w-3xl rounded-2xl border border-white/40 bg-white/60 p-6 shadow-xl backdrop-blur-sm'>
-        <h1 className='text-xl font-semibold text-gray-900'>{pageTitle}</h1>
+    <div className='min-h-screen bg-gradient-to-br from-muted to-background p-6'>
+      <div className='mx-auto w-full max-w-3xl rounded-2xl border border-border bg-card/60 p-6 shadow-xl backdrop-blur-sm'>
+        <h1 className='text-xl font-semibold text-foreground'>{pageTitle}</h1>
         {dateResolveError && (
           <p className='mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700'>
             JST日付の解決に失敗した。時間をおいて再読み込みして。

--- a/application/apps/web/src/client/features/diary/components/read-list-section.tsx
+++ b/application/apps/web/src/client/features/diary/components/read-list-section.tsx
@@ -15,7 +15,7 @@ interface Props {
 export default function DiaryReadListSection({ isLoading, shouldShowDailyDetails, reads }: Props) {
   return (
     <div className='mt-6'>
-      <h2 className='text-sm font-semibold text-gray-700'>読了した記事一覧</h2>
+      <h2 className='text-sm font-semibold text-foreground'>読了した記事一覧</h2>
       <ReadListContent
         isLoading={isLoading}
         shouldShowDailyDetails={shouldShowDailyDetails}
@@ -33,14 +33,14 @@ function ReadListContent({ isLoading, shouldShowDailyDetails, reads }: Props) {
   // 日付未選択（analytics）はグラフからの導線を案内する
   if (!shouldShowDailyDetails) {
     return (
-      <p className='mt-2 text-sm text-gray-500'>
+      <p className='mt-2 text-sm text-muted-foreground'>
         グラフの日付をクリックすると、読了記事一覧を表示します。
       </p>
     )
   }
   if (reads.length === 0) {
     return (
-      <p className='mt-2 text-sm text-gray-500'>
+      <p className='mt-2 text-sm text-muted-foreground'>
         <span>読了した記事はまだありません。</span>
         <AnchorLink to='/trends' className='ml-1 text-blue-700 underline hover:text-blue-800'>
           トレンド一覧へ
@@ -56,7 +56,7 @@ function ReadListContent({ isLoading, shouldShowDailyDetails, reads }: Props) {
         return (
           <li
             key={read.readHistoryId}
-            className='flex items-center justify-between gap-3 text-gray-800'
+            className='flex items-center justify-between gap-3 text-foreground'
           >
             <div className='flex min-w-0 flex-1 items-center gap-2'>
               <MediaIcon media={read.media} size='sm' />
@@ -68,10 +68,10 @@ function ReadListContent({ isLoading, shouldShowDailyDetails, reads }: Props) {
                   {read.title}
                 </AnchorLink>
               ) : (
-                <span className='block truncate text-gray-700'>{read.title}</span>
+                <span className='block truncate text-foreground'>{read.title}</span>
               )}
             </div>
-            <p className='shrink-0 text-xs text-gray-500'>{toJaTimeString(read.readAt)}</p>
+            <p className='shrink-0 text-xs text-muted-foreground'>{toJaTimeString(read.readAt)}</p>
           </li>
         )
       })}

--- a/application/apps/web/src/client/features/diary/components/read-pagination.tsx
+++ b/application/apps/web/src/client/features/diary/components/read-pagination.tsx
@@ -22,17 +22,17 @@ export default function DiaryReadPagination({
     <div className='mt-4 flex items-center justify-start gap-3'>
       <button
         type='button'
-        className='rounded border border-gray-300 px-3 py-1 text-sm text-gray-700 disabled:cursor-not-allowed disabled:opacity-50'
+        className='rounded border border-border px-3 py-1 text-sm text-foreground disabled:cursor-not-allowed disabled:opacity-50'
         onClick={onPrevPage}
         disabled={!shouldShowDailyDetails || !readPagination.hasPrev}
         data-slot='diary-read-prev'
       >
         前へ
       </button>
-      <span className='text-sm text-gray-600'>{paginationLabel}</span>
+      <span className='text-sm text-muted-foreground'>{paginationLabel}</span>
       <button
         type='button'
-        className='rounded border border-gray-300 px-3 py-1 text-sm text-gray-700 disabled:cursor-not-allowed disabled:opacity-50'
+        className='rounded border border-border px-3 py-1 text-sm text-foreground disabled:cursor-not-allowed disabled:opacity-50'
         onClick={onNextPage}
         disabled={!shouldShowDailyDetails || !readPagination.hasNext}
         data-slot='diary-read-next'

--- a/application/apps/web/src/client/features/diary/components/summary-section.tsx
+++ b/application/apps/web/src/client/features/diary/components/summary-section.tsx
@@ -20,13 +20,13 @@ interface Props {
 export default function DiarySummarySection({ sources, displaySummary, targetDate }: Props) {
   return (
     <div className='mt-4'>
-      <h2 className='text-sm font-semibold text-gray-700'>集計</h2>
+      <h2 className='text-sm font-semibold text-foreground'>集計</h2>
       {targetDate && (
-        <p className='mt-1 text-sm text-gray-600' data-slot='diary-target-date'>
+        <p className='mt-1 text-sm text-muted-foreground' data-slot='diary-target-date'>
           対象日: {toJaDateString(toJstDate(targetDate))}
         </p>
       )}
-      <div className='mt-2 rounded-lg border border-gray-200 bg-white p-3'>
+      <div className='mt-2 rounded-lg border border-border bg-card p-3'>
         <Table>
           <TableHeader>
             <TableRow>

--- a/application/apps/web/src/client/features/inbox/components/inbox-article-card.tsx
+++ b/application/apps/web/src/client/features/inbox/components/inbox-article-card.tsx
@@ -13,20 +13,20 @@ interface Props {
 
 export default function InboxArticleCard({ article, onSkip, onRead, onLater }: Props) {
   return (
-    <div className='mt-2 flex flex-col rounded-xl border border-gray-200 bg-white p-5'>
-      <h2 className='flex h-[2lh] items-start gap-2 text-lg font-semibold text-gray-900 leading-relaxed'>
+    <div className='mt-2 flex flex-col rounded-xl border border-border bg-card p-5'>
+      <h2 className='flex h-[2lh] items-start gap-2 text-lg font-semibold text-foreground leading-relaxed'>
         <span className='mt-0.5 shrink-0'>
           <MediaIcon media={toMediaType(article.media)} size='md' />
         </span>
         <span className='line-clamp-2'>{article.title}</span>
       </h2>
-      <div className='mt-2 flex h-[1lh] items-center gap-3 overflow-hidden text-sm text-gray-600'>
+      <div className='mt-2 flex h-[1lh] items-center gap-3 overflow-hidden text-sm text-muted-foreground'>
         <span className='min-w-0 truncate'>著者: {article.author}</span>
       </div>
-      <p className='mt-3 h-24 overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words pr-1 text-sm leading-relaxed text-gray-700 md:h-56'>
+      <p className='mt-3 h-24 overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words pr-1 text-sm leading-relaxed text-foreground md:h-56'>
         {article.description}
       </p>
-      <div className='sticky bottom-0 -mx-5 mt-3 flex flex-wrap gap-2 border-t border-gray-200 bg-white/95 px-5 pt-3 pb-1 md:static md:mx-0 md:mt-4 md:border-0 md:bg-transparent md:p-0'>
+      <div className='sticky bottom-0 -mx-5 mt-3 flex flex-wrap gap-2 border-t border-border bg-card/95 px-5 pt-3 pb-1 md:static md:mx-0 md:mt-4 md:border-0 md:bg-transparent md:p-0'>
         <Tooltip>
           <TooltipTrigger asChild={true}>
             <Button type='button' variant='outline' onClick={onSkip}>

--- a/application/apps/web/src/client/features/inbox/components/inbox-body-skeleton.tsx
+++ b/application/apps/web/src/client/features/inbox/components/inbox-body-skeleton.tsx
@@ -4,10 +4,7 @@ export default function InboxBodySkeleton() {
   return (
     <div role='status' aria-label='読み込み中' className='mt-2'>
       {/* 視覚的なプレースホルダーは支援技術から隠す。InboxArticleCard と同じ高さ（タイトル 2lh / 著者 1lh / 本文 h-24 md:h-56）で組み、レイアウトシフトを避ける */}
-      <div
-        aria-hidden='true'
-        className='flex flex-col rounded-xl border border-gray-200 bg-white p-5'
-      >
+      <div aria-hidden='true' className='flex flex-col rounded-xl border border-border bg-card p-5'>
         <div className='flex h-[2lh] flex-col gap-2'>
           <Skeleton className='h-5 w-3/4' />
           <Skeleton className='h-5 w-1/2' />

--- a/application/apps/web/src/client/features/inbox/components/inbox-body.tsx
+++ b/application/apps/web/src/client/features/inbox/components/inbox-body.tsx
@@ -25,7 +25,7 @@ export default function InboxBody({
     return <InboxCompletionCard />
   }
   return (
-    <p className='mt-4 text-sm text-gray-600'>
+    <p className='mt-4 text-sm text-muted-foreground'>
       <span>未読記事はありません</span>
       <AnchorLink to='/trends' className='ml-1 text-blue-700 underline hover:text-blue-800'>
         トレンド一覧へ

--- a/application/apps/web/src/client/features/passkey/passkey-toggle.tsx
+++ b/application/apps/web/src/client/features/passkey/passkey-toggle.tsx
@@ -19,7 +19,7 @@ export default function PasskeyToggle() {
 
   return (
     <div className='flex items-center gap-3'>
-      <Fingerprint className='size-4 text-gray-600' />
+      <Fingerprint className='size-4 text-muted-foreground' />
       <Switch
         checked={hasPasskey}
         onCheckedChange={handleToggle}

--- a/application/apps/web/src/client/features/theme/index.ts
+++ b/application/apps/web/src/client/features/theme/index.ts
@@ -1,0 +1,3 @@
+// テーマ機能の公開口
+export { default as ThemeProvider } from './theme-provider'
+export { default as ThemeToggle } from './theme-toggle'

--- a/application/apps/web/src/client/features/theme/theme-provider.tsx
+++ b/application/apps/web/src/client/features/theme/theme-provider.tsx
@@ -1,0 +1,19 @@
+import { ThemeProvider as NextThemesProvider } from 'next-themes'
+
+interface Props {
+  children: React.ReactNode
+}
+
+// class属性でテーマを切り替える（styles.css の .dark 変数定義と対応させるため）
+export default function ThemeProvider({ children }: Props) {
+  return (
+    <NextThemesProvider
+      attribute='class'
+      defaultTheme='system'
+      enableSystem={true}
+      disableTransitionOnChange={true}
+    >
+      {children}
+    </NextThemesProvider>
+  )
+}

--- a/application/apps/web/src/client/features/theme/theme-toggle.test.ts
+++ b/application/apps/web/src/client/features/theme/theme-toggle.test.ts
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { createElement } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ThemeToggle from './theme-toggle'
+
+const setThemeMock = vi.fn()
+const themeState: { theme: string | undefined } = { theme: 'system' }
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ theme: themeState.theme, setTheme: setThemeMock }),
+}))
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    themeState.theme = 'system'
+  })
+
+  describe('正常系', () => {
+    it('現在のテーマのボタンにのみ選択スタイルが当たる', () => {
+      themeState.theme = 'dark'
+
+      render(createElement(ThemeToggle))
+
+      expect(screen.getByRole('button', { name: 'ダーク' })).toHaveAttribute('aria-pressed', 'true')
+      expect(screen.getByRole('button', { name: 'システム' })).toHaveAttribute(
+        'aria-pressed',
+        'false',
+      )
+      expect(screen.getByRole('button', { name: 'ライト' })).toHaveAttribute(
+        'aria-pressed',
+        'false',
+      )
+    })
+
+    it('ボタンを押すと選択したテーマでsetThemeが呼ばれる', () => {
+      render(createElement(ThemeToggle))
+
+      fireEvent.click(screen.getByRole('button', { name: 'ライト' }))
+
+      expect(setThemeMock).toHaveBeenCalledWith('light')
+    })
+  })
+})

--- a/application/apps/web/src/client/features/theme/theme-toggle.tsx
+++ b/application/apps/web/src/client/features/theme/theme-toggle.tsx
@@ -1,0 +1,28 @@
+import { useTheme } from 'next-themes'
+import { useEffect, useState } from 'react'
+import { ToggleGroup, type ToggleOption } from '@/client/components/ui/input/toggle-group'
+
+const themeOptions: readonly ToggleOption<string>[] = [
+  { value: 'system', label: 'システム', dataSlot: 'theme-system' },
+  { value: 'light', label: 'ライト', dataSlot: 'theme-light' },
+  { value: 'dark', label: 'ダーク', dataSlot: 'theme-dark' },
+]
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  // サーバー描画時はテーマが未確定のため、ハイドレーション不一致を避けてマウント後に選択状態を反映する
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  return (
+    <ToggleGroup
+      options={themeOptions}
+      selectedValue={mounted ? (theme ?? 'system') : ''}
+      onSelect={setTheme}
+      dataSlot='theme-toggle'
+    />
+  )
+}

--- a/application/apps/web/src/client/root.tsx
+++ b/application/apps/web/src/client/root.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-router'
 import './styles.css'
 import { AnchorLink } from '@/client/components/ui/navigation/link'
+import { ThemeProvider } from '@/client/features/theme'
 import { SITE_URL } from '@/client/lib/meta'
 import { Toaster } from './components/shadcn/sonner'
 
@@ -45,7 +46,8 @@ export const meta: MetaFunction = () => [
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang='ja'>
+    // next-themesがハイドレーション前にhtmlへdarkクラスを付与するため、SSRとの差分警告を抑止する
+    <html lang='ja' suppressHydrationWarning={true}>
       <head>
         <Meta />
         <Links />
@@ -53,16 +55,12 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <meta name='viewport' content='width=device-width, initial-scale=1.0' />
       </head>
       <body>
-        {children}
-        <ScrollRestoration />
-        <Scripts />
-        <Toaster
-          position='top-left'
-          visibleToasts={3}
-          theme='system'
-          richColors={true}
-          expand={true}
-        />
+        <ThemeProvider>
+          {children}
+          <ScrollRestoration />
+          <Scripts />
+          <Toaster position='top-left' visibleToasts={3} richColors={true} expand={true} />
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/application/apps/web/src/client/routes/_index.tsx
+++ b/application/apps/web/src/client/routes/_index.tsx
@@ -54,7 +54,7 @@ const TrendDiaryTopPage = () => {
               </AnchorLink>
               <AnchorLink
                 to='/login'
-                className='inline-flex w-44 sm:w-auto items-center justify-center px-4 py-2.5 sm:px-8 sm:py-4 border-2 border-border text-foreground rounded-lg text-base sm:text-lg font-semibold hover:border-border hover:bg-muted transition-all duration-200'
+                className='inline-flex w-44 sm:w-auto items-center justify-center px-4 py-2.5 sm:px-8 sm:py-4 border-2 border-border text-foreground rounded-lg text-base sm:text-lg font-semibold hover:bg-muted transition-all duration-200'
               >
                 ログイン
               </AnchorLink>
@@ -170,7 +170,7 @@ const TrendDiaryTopPage = () => {
           </p>
           <AnchorLink
             to='/signup'
-            className='inline-flex items-center justify-center px-6 py-3 sm:px-8 sm:py-4 bg-card text-blue-600 rounded-lg text-base sm:text-lg font-semibold hover:bg-blue-50 transition-all duration-200 shadow-lg hover:shadow-xl'
+            className='inline-flex items-center justify-center px-6 py-3 sm:px-8 sm:py-4 bg-white text-blue-600 rounded-lg text-base sm:text-lg font-semibold hover:bg-blue-50 transition-all duration-200 shadow-lg hover:shadow-xl'
           >
             <ClipText text='無料でアカウントを作成' />
           </AnchorLink>

--- a/application/apps/web/src/client/routes/_index.tsx
+++ b/application/apps/web/src/client/routes/_index.tsx
@@ -19,7 +19,7 @@ export const meta: MetaFunction = ({ matches, location }) =>
 
 const TrendDiaryTopPage = () => {
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 to-white'>
+    <div className='min-h-screen bg-gradient-to-br from-muted to-background'>
       <LandingHeader />
 
       {/* Hero Section */}
@@ -35,12 +35,12 @@ const TrendDiaryTopPage = () => {
               </div>
             </div>
 
-            <h1 className='text-5xl sm:text-6xl font-bold text-slate-900 tracking-tight mb-6'>
+            <h1 className='text-5xl sm:text-6xl font-bold text-foreground tracking-tight mb-6'>
               技術トレンドを
               <ClipText text='効率的に追跡' className='mt-2' />
             </h1>
 
-            <p className='text-xl text-slate-600 max-w-3xl mx-auto mb-10 leading-relaxed'>
+            <p className='text-xl text-muted-foreground max-w-3xl mx-auto mb-10 leading-relaxed'>
               QiitaやZennの記事を読んだかどうかを管理し、技術トレンドを見逃さない。
               日々のキャッチアップを日記のように記録できるブラウザアプリです。
             </p>
@@ -54,7 +54,7 @@ const TrendDiaryTopPage = () => {
               </AnchorLink>
               <AnchorLink
                 to='/login'
-                className='inline-flex w-44 sm:w-auto items-center justify-center px-4 py-2.5 sm:px-8 sm:py-4 border-2 border-slate-300 text-slate-700 rounded-lg text-base sm:text-lg font-semibold hover:border-slate-400 hover:bg-slate-50 transition-all duration-200'
+                className='inline-flex w-44 sm:w-auto items-center justify-center px-4 py-2.5 sm:px-8 sm:py-4 border-2 border-border text-foreground rounded-lg text-base sm:text-lg font-semibold hover:border-border hover:bg-muted transition-all duration-200'
               >
                 ログイン
               </AnchorLink>
@@ -73,64 +73,68 @@ const TrendDiaryTopPage = () => {
       </section>
 
       {/* Features Section */}
-      <section className='py-20 bg-white'>
+      <section className='py-20 bg-card'>
         <div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'>
           <div className='text-center mb-16'>
-            <h2 className='text-3xl font-bold text-slate-900 mb-4'>なぜTrendDiaryを選ぶのか？</h2>
-            <p className='text-lg text-slate-600 max-w-2xl mx-auto'>
+            <h2 className='text-3xl font-bold text-foreground mb-4'>なぜTrendDiaryを選ぶのか？</h2>
+            <p className='text-lg text-muted-foreground max-w-2xl mx-auto'>
               Slack
               RSSフィードとは違って特定のアプリに依存せず、Webブラウザからトレンド記事を確認できます。
             </p>
           </div>
 
           <div className='grid grid-cols-1 md:grid-cols-3 gap-8'>
-            <div className='text-center p-6 rounded-xl border border-slate-200 hover:border-blue-300 hover:shadow-lg transition-all duration-200'>
+            <div className='text-center p-6 rounded-xl border border-border hover:border-blue-300 hover:shadow-lg transition-all duration-200'>
               <div className='w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mx-auto mb-4'>
                 <BookOpen className='h-6 w-6 text-blue-600' />
               </div>
-              <h3 className='text-xl font-semibold text-slate-900 mb-2'>読書状況の管理</h3>
-              <p className='text-slate-600'>
+              <h3 className='text-xl font-semibold text-foreground mb-2'>読書状況の管理</h3>
+              <p className='text-muted-foreground'>
                 記事を読んだかどうかを簡単に記録し、読み逃しを防げます。
               </p>
             </div>
 
-            <div className='text-center p-6 rounded-xl border border-slate-200 hover:border-blue-300 hover:shadow-lg transition-all duration-200'>
+            <div className='text-center p-6 rounded-xl border border-border hover:border-blue-300 hover:shadow-lg transition-all duration-200'>
               <div className='w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center mx-auto mb-4'>
                 <TrendingUp className='h-6 w-6 text-green-600' />
               </div>
-              <h3 className='text-xl font-semibold text-slate-900 mb-2'>トレンド追跡</h3>
-              <p className='text-slate-600'>
+              <h3 className='text-xl font-semibold text-foreground mb-2'>トレンド追跡</h3>
+              <p className='text-muted-foreground'>
                 QiitaやZennの最新技術トレンドを効率的にキャッチアップできます
               </p>
             </div>
 
-            <div className='text-center p-6 rounded-xl border border-slate-200 hover:border-blue-300 hover:shadow-lg transition-all duration-200'>
+            <div className='text-center p-6 rounded-xl border border-border hover:border-blue-300 hover:shadow-lg transition-all duration-200'>
               <div className='w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center mx-auto mb-4'>
                 <Users className='h-6 w-6 text-purple-600' />
               </div>
-              <h3 className='text-xl font-semibold text-slate-900 mb-2'>技術者向け</h3>
-              <p className='text-slate-600'>技術者のニーズに特化した、使いやすいインターフェース</p>
+              <h3 className='text-xl font-semibold text-foreground mb-2'>技術者向け</h3>
+              <p className='text-muted-foreground'>
+                技術者のニーズに特化した、使いやすいインターフェース
+              </p>
             </div>
           </div>
         </div>
       </section>
 
       {/* System Requirements */}
-      <section className='py-20 bg-slate-50'>
+      <section className='py-20 bg-muted'>
         <div className='max-w-4xl mx-auto px-4 sm:px-6 lg:px-8'>
           <div className='text-center mb-12'>
-            <h2 className='text-3xl font-bold text-slate-900 mb-4'>推奨環境</h2>
-            <p className='text-lg text-slate-600'>TrendDiaryを快適にご利用いただくための推奨環境</p>
+            <h2 className='text-3xl font-bold text-foreground mb-4'>推奨環境</h2>
+            <p className='text-lg text-muted-foreground'>
+              TrendDiaryを快適にご利用いただくための推奨環境
+            </p>
           </div>
 
-          <div className='bg-white rounded-2xl shadow-sm border border-slate-200 p-8'>
+          <div className='bg-card rounded-2xl shadow-sm border border-border p-8'>
             <div className='flex justify-center'>
               <div className='text-center max-w-md'>
                 <div className='w-20 h-20 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-6'>
                   <Monitor className='h-10 w-10 text-blue-600' />
                 </div>
-                <h3 className='text-2xl font-semibold text-slate-900 mb-4'>推奨環境</h3>
-                <div className='space-y-3 text-slate-600'>
+                <h3 className='text-2xl font-semibold text-foreground mb-4'>推奨環境</h3>
+                <div className='space-y-3 text-muted-foreground'>
                   <div className='flex items-center space-x-3'>
                     <span className='w-2 h-2 bg-blue-500 rounded-full flex-shrink-0'></span>
                     <span className='text-lg'>Mac</span>
@@ -166,7 +170,7 @@ const TrendDiaryTopPage = () => {
           </p>
           <AnchorLink
             to='/signup'
-            className='inline-flex items-center justify-center px-6 py-3 sm:px-8 sm:py-4 bg-white text-blue-600 rounded-lg text-base sm:text-lg font-semibold hover:bg-blue-50 transition-all duration-200 shadow-lg hover:shadow-xl'
+            className='inline-flex items-center justify-center px-6 py-3 sm:px-8 sm:py-4 bg-card text-blue-600 rounded-lg text-base sm:text-lg font-semibold hover:bg-blue-50 transition-all duration-200 shadow-lg hover:shadow-xl'
           >
             <ClipText text='無料でアカウントを作成' />
           </AnchorLink>

--- a/application/apps/web/src/client/routes/analytics/page.tsx
+++ b/application/apps/web/src/client/routes/analytics/page.tsx
@@ -94,20 +94,20 @@ export default function AnalyticsPage({
       ) : (
         <>
           <div className='mt-5'>
-            <h2 className='text-sm font-semibold text-gray-700'>グラフ</h2>
+            <h2 className='text-sm font-semibold text-foreground'>グラフ</h2>
             <div
-              className='mt-2 rounded-lg border border-gray-200 bg-white p-4'
+              className='mt-2 rounded-lg border border-border bg-card p-4'
               data-slot='diary-analytics'
             >
               <div className='flex min-h-8 items-center gap-2'>
-                <p className='text-sm font-semibold text-gray-700'>
+                <p className='text-sm font-semibold text-foreground'>
                   選択日: {selectedDate ? toJaDateString(toJstDate(selectedDate)) : '未選択'}
                 </p>
                 {selectedDate && (
                   <button
                     type='button'
                     onClick={onClearSelectedDate}
-                    className='w-24 rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-100'
+                    className='w-24 rounded border border-border bg-card px-2 py-1 text-xs text-foreground hover:bg-muted'
                     data-slot='diary-clear-selected-date'
                   >
                     選択をクリア

--- a/application/apps/web/src/client/routes/inbox/page.tsx
+++ b/application/apps/web/src/client/routes/inbox/page.tsx
@@ -25,15 +25,15 @@ export default function InboxPage({
   onMediaChange,
 }: Props) {
   return (
-    <div className='min-h-screen bg-gradient-to-br from-gray-100 to-gray-200 p-6'>
-      <div className='mx-auto w-full max-w-3xl rounded-2xl border border-white/40 bg-white/50 p-6 shadow-xl backdrop-blur-sm'>
-        <h1 className='text-xl font-semibold text-gray-900'>未読消化</h1>
-        <p className='mt-0.5 text-sm text-gray-600'>未読記事を1件ずつ確認できます。</p>
+    <div className='min-h-screen bg-gradient-to-br from-muted to-background p-6'>
+      <div className='mx-auto w-full max-w-3xl rounded-2xl border border-border bg-card/50 p-6 shadow-xl backdrop-blur-sm'>
+        <h1 className='text-xl font-semibold text-foreground'>未読消化</h1>
+        <p className='mt-0.5 text-sm text-muted-foreground'>未読記事を1件ずつ確認できます。</p>
         <div className='mt-2'>
-          <p className='mb-2 text-sm text-gray-600'>メディア</p>
+          <p className='mb-2 text-sm text-muted-foreground'>メディア</p>
           <MediaFilter selectedMedia={selectedMedia} onMediaChange={onMediaChange} />
         </div>
-        <p className='mt-1 text-sm text-gray-600'>残り {remainingCount} 件</p>
+        <p className='mt-1 text-sm text-muted-foreground'>残り {remainingCount} 件</p>
 
         {isLoading ? (
           <InboxBodySkeleton />

--- a/application/apps/web/src/client/routes/login/page.tsx
+++ b/application/apps/web/src/client/routes/login/page.tsx
@@ -18,7 +18,7 @@ export default function LoginPage({
   redirectTo,
 }: Props) {
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 to-white'>
+    <div className='min-h-screen bg-gradient-to-br from-muted to-background'>
       <LandingHeader />
       <div className='flex min-h-[calc(100vh-180px)] items-center justify-center p-4'>
         <Card className='flex w-full max-w-md flex-col'>

--- a/application/apps/web/src/client/routes/privacy-policy/page.tsx
+++ b/application/apps/web/src/client/routes/privacy-policy/page.tsx
@@ -4,10 +4,10 @@ import { Heading1, Heading2, Heading3, Paragraph } from '../../components/ui/typ
 
 export default function PrivacyPolicyPage() {
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 to-white'>
+    <div className='min-h-screen bg-gradient-to-br from-muted to-background'>
       <LandingHeader />
       <main className='mx-auto max-w-3xl px-4 py-12'>
-        <article className='text-slate-700'>
+        <article className='text-foreground'>
           <Heading1>プライバシーポリシー</Heading1>
           <Paragraph>
             TrendDiary（以下「当サービス」）は、ユーザーの個人情報の保護を重要視し、個人情報保護法をはじめとする関連法令を遵守し、適切に取り扱います。
@@ -128,9 +128,9 @@ export default function PrivacyPolicyPage() {
             当プライバシーポリシーは、法令の変更やサービス内容の変更に伴い、予告なく変更することがあります。重要な変更については、サービス内でお知らせいたします。
           </Paragraph>
 
-          <hr className='my-8 border-slate-200' />
+          <hr className='my-8 border-border' />
 
-          <p className='text-sm text-slate-600'>
+          <p className='text-sm text-muted-foreground'>
             <strong>制定日：</strong> 2025年1月16日
             <br />
             <strong>最終更新日：</strong> 2025年1月16日

--- a/application/apps/web/src/client/routes/settings/page.test.ts
+++ b/application/apps/web/src/client/routes/settings/page.test.ts
@@ -3,12 +3,22 @@ import { createElement } from 'react'
 import { describe, expect, it, vi } from 'vitest'
 import SettingsPage from './page'
 
-// トグル本体はpasskey-toggle.test.tsで検証するため、ここではセクションの出し分けだけを見る
+// トグル本体は各featureのテストで検証するため、ここではセクションの出し分けだけを見る
 vi.mock('@/client/features/passkey/passkey-toggle', () => ({
   default: () => createElement('div', { role: 'switch', 'aria-label': 'パスキーを有効にする' }),
 }))
+vi.mock('@/client/features/theme/theme-toggle', () => ({
+  default: () => createElement('div', { 'data-testid': 'theme-toggle' }),
+}))
 
 describe('SettingsPage', () => {
+  it('テーマ設定セクションを表示する', () => {
+    render(createElement(SettingsPage))
+
+    expect(screen.getByRole('heading', { name: 'テーマ' })).toBeInTheDocument()
+    expect(screen.getByTestId('theme-toggle')).toBeInTheDocument()
+  })
+
   it('パスキートグルを表示する', () => {
     render(createElement(SettingsPage))
 

--- a/application/apps/web/src/client/routes/settings/page.tsx
+++ b/application/apps/web/src/client/routes/settings/page.tsx
@@ -1,21 +1,32 @@
 import { Badge } from '@/client/components/shadcn/badge'
 import { PasskeyToggle } from '@/client/features/passkey'
+import { ThemeToggle } from '@/client/features/theme'
 
 export default function SettingsPage() {
   const pageTitle = '設定'
 
   return (
-    <div className='min-h-screen bg-gradient-to-br from-gray-100 to-gray-200 p-6'>
-      <div className='mx-auto w-full max-w-3xl rounded-2xl border border-white/40 bg-white/50 p-6 shadow-xl backdrop-blur-sm'>
-        <h1 className='text-xl font-semibold text-gray-900'>{pageTitle}</h1>
+    <div className='min-h-screen bg-gradient-to-br from-muted to-background p-6'>
+      <div className='mx-auto w-full max-w-3xl rounded-2xl border border-border bg-card/50 p-6 shadow-xl backdrop-blur-sm'>
+        <h1 className='text-xl font-semibold text-foreground'>{pageTitle}</h1>
 
         <section className='mt-6 flex items-start justify-between gap-4'>
           <div>
+            <h2 className='text-sm font-semibold text-foreground'>テーマ</h2>
+            <p className='mt-1 text-sm text-muted-foreground'>
+              画面の配色を選べます。「システム」はお使いの端末の設定に追従します。
+            </p>
+          </div>
+          <ThemeToggle />
+        </section>
+
+        <section className='mt-6 flex items-start justify-between gap-4 border-t border-border pt-6'>
+          <div>
             <div className='flex items-center gap-2'>
-              <h2 className='text-sm font-semibold text-gray-700'>パスキー</h2>
+              <h2 className='text-sm font-semibold text-foreground'>パスキー</h2>
               <Badge variant='secondary'>β版</Badge>
             </div>
-            <p className='mt-1 text-sm text-gray-600'>
+            <p className='mt-1 text-sm text-muted-foreground'>
               パスキーを有効にすると、次回から生体認証やデバイスのロックだけでログインできます。
             </p>
           </div>

--- a/application/apps/web/src/client/routes/signup/page.tsx
+++ b/application/apps/web/src/client/routes/signup/page.tsx
@@ -19,7 +19,7 @@ export default function SignupPage({
   turnstileSiteKey,
 }: SignupFormProps) {
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 to-white'>
+    <div className='min-h-screen bg-gradient-to-br from-muted to-background'>
       <LandingHeader />
       <div className='flex min-h-[calc(100vh-180px)] items-center justify-center p-4'>
         <Card className='flex w-full max-w-md flex-col'>

--- a/application/apps/web/src/client/routes/terms-of-service/page.tsx
+++ b/application/apps/web/src/client/routes/terms-of-service/page.tsx
@@ -4,10 +4,10 @@ import { Heading1, Heading2, Paragraph } from '../../components/ui/typography/le
 
 export default function TermsOfServicePage() {
   return (
-    <div className='min-h-screen bg-gradient-to-br from-slate-50 to-white'>
+    <div className='min-h-screen bg-gradient-to-br from-muted to-background'>
       <LandingHeader />
       <main className='mx-auto max-w-3xl px-4 py-12'>
-        <article className='text-slate-700'>
+        <article className='text-foreground'>
           <Heading1>利用規約</Heading1>
           <Paragraph>
             本利用規約（以下「本規約」）は、TrendDiary（以下「本サービス」）の利用条件を定めるものです。ユーザーは本サービスを利用することにより、本規約に同意したものとみなされます。
@@ -168,9 +168,9 @@ export default function TermsOfServicePage() {
             本サービスに関して紛争が生じた場合、当事者間で誠実に協議するものとします。
           </Paragraph>
 
-          <hr className='my-8 border-slate-200' />
+          <hr className='my-8 border-border' />
 
-          <p className='text-sm text-slate-600'>
+          <p className='text-sm text-muted-foreground'>
             <strong>制定日：</strong> 2025年1月16日
             <br />
             <strong>最終更新日：</strong> 2025年1月16日

--- a/application/apps/web/src/client/routes/trends._index/page.tsx
+++ b/application/apps/web/src/client/routes/trends._index/page.tsx
@@ -26,7 +26,7 @@ const SKELETON_KEYS = Array.from({ length: 8 }, (_, i) => `skeleton-${i}`)
 
 const getPaginationClass = (isDisabled: boolean) =>
   twMerge(
-    'border-solid border border-b-slate-400 cursor-pointer',
+    'border-solid border border-b-border cursor-pointer',
     isDisabled ? 'opacity-50 cursor-not-allowed' : '',
   )
 
@@ -108,7 +108,7 @@ export default function TrendsPage({
   }
 
   return (
-    <div className='relative min-h-screen bg-gradient-to-br from-gray-100 to-gray-200 p-6'>
+    <div className='relative min-h-screen bg-gradient-to-br from-muted to-background p-6'>
       <h1 className='pb-4 text-xl italic'>- {toJaDateString(date)} -</h1>
       {/* 適用済みフィルタが外部（URL 等）で変わったら draft を初期化したいので key で再マウントする。
           key はフィールド追加時の付け忘れを防ぐため applied の値から導出する */}
@@ -132,7 +132,7 @@ export default function TrendsPage({
       ) : hasError ? (
         <FetchErrorAlert onRetry={onRetry} />
       ) : articles.length === 0 ? (
-        <div className='text-gray-500'>
+        <div className='text-muted-foreground'>
           <p>記事がありません</p>
           {hasActiveFilters && (
             <Button


### PR DESCRIPTION
<!-- Product Backlogから参照できるようにする -->

# 概要
- close: #900
- ダークモード（OS 設定連動＋手動切替）に対応しました。CSS 基盤（`styles.css` の `.dark` 変数、shadcn の `dark:` バリアント）は既にあったものの、テーマを発火させる仕組みが無かったため、`ThemeProvider` と切替トグルを追加しました。

主な変更点:
- `next-themes` ベースの `ThemeProvider`（`features/theme`）を `root.tsx` の `<body>` 内にマウントし、初期状態で OS 設定に追従（`defaultTheme="system"` / `enableSystem`）
- 設定画面にライト / ダーク / システムを切り替えるトグルを追加（`next-themes` により選択を `localStorage` に永続化）
- 既存の `useTheme` 利用箇所である Toaster（sonner）も、固定していた `theme='system'` を外してアプリのテーマに連動
- SSR での FOUC（初回描画時のちらつき）対策として、`next-themes` がハイドレーション前に `<html>` へ `dark` クラスを付与する前提で `<html>` に `suppressHydrationWarning` を付与
- 各画面（LP・認証・trends・inbox・diary・analytics・settings・法務ページ）と共通レイアウトで、ハードコードされていた neutral 色（`gray` / `slate` / `white`）をセマンティックトークン（`bg-background` / `bg-card` / `text-foreground` / `text-muted-foreground` / `border-border` 等）へ置換し、ダーク時の視認性を確保

## 動作確認(スクリーンショットなど)

- ローカルでの自動テストにて確認済み
  - `pnpm vitest run --project client` … 39 files / 231 tests 全て pass
  - 追加した `ThemeToggle` / 設定画面のテストが pass
- ブラウザ実機でのダーク表示の目視確認（各画面・Recharts の配色）は、レビュー時に併せてご確認いただけると助かります

### UIテスト
<!-- 特になし -->
- 本環境では Storybook（Playwright ブラウザ）実行環境が未整備のため、Storybook テストの実行結果は未添付です

## レビュー観点

### 内部品質
- **アーキテクチャ**: テーマ機能は `client/features/theme/`（`ThemeProvider` / `ThemeToggle` / `index.ts`）に集約し、既存の feature 構成（passkey 等）に倣いました
- **配色のトークン化**: ブランド色（`blue` / `purple` 等のアクセント）とダーク前提のフッターは意図的に据え置き、neutral 色のみをセマンティックトークンへ置換しています
- **テスト**: `ThemeToggle` は `next-themes` をモックして選択状態と `setTheme` 呼び出しを検証。設定画面テストにテーマセクションの表示確認を追加

### 外部品質
- **FOUC / 可用性**: `suppressHydrationWarning` と `next-themes` のスクリプトにより初回描画のちらつきを回避

## その他・参考情報
- `next-themes` は既存依存として導入済みで、これまで Toaster でのみ利用されていました


---
_Generated by [Claude Code](https://claude.ai/code/session_01BcGmCBDkeEKS89JJooLRFm)_