### PR TITLE
モバイル体験を改善する（ちらつき解消・LP更新・E2E拡充）

### DIFF
--- a/application/apps/web/src/client/components/shadcn/hooks/use-mobile.test.ts
+++ b/application/apps/web/src/client/components/shadcn/hooks/use-mobile.test.ts
@@ -1,0 +1,81 @@
+import { act, renderHook } from '@testing-library/react'
+import { useIsMobile } from './use-mobile'
+
+type MediaQueryListener = (event: MediaQueryListEvent) => void
+
+// matchMedia の change を発火できるよう、登録されたリスナーを保持するモックを用意する
+function mockMatchMedia() {
+  const listeners = new Set<MediaQueryListener>()
+
+  // jsdom は matchMedia を実装しないため、フックが購読するAPIを差し替える
+  vi.stubGlobal('matchMedia', (query: string) => {
+    return {
+      matches: window.innerWidth < 768,
+      media: query,
+      onchange: null,
+      addEventListener: (_type: string, listener: MediaQueryListener) => {
+        listeners.add(listener)
+      },
+      removeEventListener: (_type: string, listener: MediaQueryListener) => {
+        listeners.delete(listener)
+      },
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+    } as unknown as MediaQueryList
+  })
+
+  return {
+    // 実際の viewport 変更を模して innerWidth を書き換えてから change を通知する
+    resize(width: number) {
+      Object.defineProperty(window, 'innerWidth', { value: width, configurable: true })
+      for (const listener of listeners) {
+        listener({} as MediaQueryListEvent)
+      }
+    },
+  }
+}
+
+describe('useIsMobile', () => {
+  const originalInnerWidth = window.innerWidth
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    Object.defineProperty(window, 'innerWidth', { value: originalInnerWidth, configurable: true })
+  })
+
+  describe('正常系', () => {
+    it.each([
+      { width: 375, expected: true, label: 'モバイル幅ではtrueを返す' },
+      { width: 767, expected: true, label: 'ブレークポイント未満ではtrueを返す' },
+      { width: 768, expected: false, label: 'ブレークポイント以上ではfalseを返す' },
+      { width: 1280, expected: false, label: 'デスクトップ幅ではfalseを返す' },
+    ])('$label', ({ width, expected }) => {
+      Object.defineProperty(window, 'innerWidth', { value: width, configurable: true })
+      mockMatchMedia()
+
+      const { result } = renderHook(() => useIsMobile())
+
+      // 初回レンダーで確定し、副作用後の再レンダー（ちらつき）を伴わない
+      expect(result.current).toBe(expected)
+    })
+
+    it('viewportの変化に追従して値を更新する', () => {
+      Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true })
+      const { resize } = mockMatchMedia()
+
+      const { result } = renderHook(() => useIsMobile())
+      expect(result.current).toBe(false)
+
+      act(() => {
+        resize(375)
+      })
+      expect(result.current).toBe(true)
+
+      act(() => {
+        resize(1024)
+      })
+      expect(result.current).toBe(false)
+    })
+  })
+})

--- a/application/apps/web/src/client/components/shadcn/hooks/use-mobile.ts
+++ b/application/apps/web/src/client/components/shadcn/hooks/use-mobile.ts
@@ -1,19 +1,24 @@
-import * as React from 'react'
+import { useSyncExternalStore } from 'react'
 
 const MOBILE_BREAKPOINT = 768
 
+function subscribe(onStoreChange: () => void) {
+  const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+  mql.addEventListener('change', onStoreChange)
+  return () => {
+    mql.removeEventListener('change', onStoreChange)
+  }
+}
+
+function getSnapshot() {
+  return window.innerWidth < MOBILE_BREAKPOINT
+}
+
+// SSR ではデスクトップ扱いにし、クライアント側の初回スナップショットと突き合わせる
+function getServerSnapshot() {
+  return false
+}
+
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    }
-    mql.addEventListener('change', onChange)
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener('change', onChange)
-  }, [])
-
-  return !!isMobile
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
 }

--- a/application/apps/web/src/client/routes/_index.tsx
+++ b/application/apps/web/src/client/routes/_index.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, Calendar, Monitor, TrendingUp, Users } from 'lucide-react'
+import { BookOpen, Calendar, Monitor, Smartphone, TrendingUp, Users } from 'lucide-react'
 import type { MetaFunction } from 'react-router'
 import { mergeMeta, pageMeta } from '@/client/lib/meta'
 import Footer from '../components/ui/layout/footer'
@@ -119,38 +119,40 @@ const TrendDiaryTopPage = () => {
       <section className='py-20 bg-slate-50'>
         <div className='max-w-4xl mx-auto px-4 sm:px-6 lg:px-8'>
           <div className='text-center mb-12'>
-            <h2 className='text-3xl font-bold text-slate-900 mb-4'>推奨環境</h2>
-            <p className='text-lg text-slate-600'>TrendDiaryを快適にご利用いただくための推奨環境</p>
+            <h2 className='text-3xl font-bold text-slate-900 mb-4'>対応環境</h2>
+            <p className='text-lg text-slate-600'>
+              スマートフォンとデスクトップの両方に対応しています
+            </p>
           </div>
 
-          <div className='bg-white rounded-2xl shadow-sm border border-slate-200 p-8'>
-            <div className='flex justify-center'>
-              <div className='text-center max-w-md'>
-                <div className='w-20 h-20 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-6'>
-                  <Monitor className='h-10 w-10 text-blue-600' />
-                </div>
-                <h3 className='text-2xl font-semibold text-slate-900 mb-4'>推奨環境</h3>
-                <div className='space-y-3 text-slate-600'>
-                  <div className='flex items-center space-x-3'>
-                    <span className='w-2 h-2 bg-blue-500 rounded-full flex-shrink-0'></span>
-                    <span className='text-lg'>Mac</span>
-                  </div>
-                  <div className='flex items-center space-x-3'>
-                    <span className='w-2 h-2 bg-blue-500 rounded-full flex-shrink-0'></span>
-                    <span className='text-lg'>Google Chrome 最新版</span>
-                  </div>
-                  <div className='flex items-center space-x-3'>
-                    <span className='w-2 h-2 bg-blue-500 rounded-full flex-shrink-0'></span>
-                    <span className='text-lg'>画面幅 1024px 以上</span>
-                  </div>
-                </div>
-                <div className='mt-6 p-4 bg-blue-50 rounded-lg'>
-                  <p className='text-sm text-blue-800'>
-                    ※記事一覧をサイドバー形式で表示するため、十分な画面幅を推奨しています
-                  </p>
-                </div>
+          <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
+            <div className='bg-white rounded-2xl shadow-sm border border-slate-200 p-8 text-center'>
+              <div className='w-20 h-20 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-6'>
+                <Smartphone className='h-10 w-10 text-blue-600' />
               </div>
+              <h3 className='text-2xl font-semibold text-slate-900 mb-4'>スマートフォン</h3>
+              <p className='text-slate-600'>
+                移動中や隙間時間に、未読の記事を1件ずつ手軽に消化できます。
+                主要な操作はモバイル向けに最適化しています。
+              </p>
             </div>
+
+            <div className='bg-white rounded-2xl shadow-sm border border-slate-200 p-8 text-center'>
+              <div className='w-20 h-20 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-6'>
+                <Monitor className='h-10 w-10 text-blue-600' />
+              </div>
+              <h3 className='text-2xl font-semibold text-slate-900 mb-4'>デスクトップ</h3>
+              <p className='text-slate-600'>
+                記事一覧をサイドバー形式で表示するため、
+                広い画面ではより多くの情報を一度に確認できます。
+              </p>
+            </div>
+          </div>
+
+          <div className='mt-6 p-4 bg-blue-50 rounded-lg'>
+            <p className='text-center text-sm text-blue-800'>
+              ※ 最新版の Google Chrome / Safari でのご利用を推奨しています
+            </p>
           </div>
         </div>
       </section>

--- a/application/apps/web/src/client/routes/_index.tsx
+++ b/application/apps/web/src/client/routes/_index.tsx
@@ -128,7 +128,7 @@ const TrendDiaryTopPage = () => {
           <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
             <div className='bg-white rounded-2xl shadow-sm border border-slate-200 p-8 text-center'>
               <div className='w-20 h-20 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-6'>
-                <Smartphone className='h-10 w-10 text-blue-600' />
+                <Smartphone className='size-10 text-blue-600' />
               </div>
               <h3 className='text-2xl font-semibold text-slate-900 mb-4'>スマートフォン</h3>
               <p className='text-slate-600'>
@@ -139,7 +139,7 @@ const TrendDiaryTopPage = () => {
 
             <div className='bg-white rounded-2xl shadow-sm border border-slate-200 p-8 text-center'>
               <div className='w-20 h-20 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-6'>
-                <Monitor className='h-10 w-10 text-blue-600' />
+                <Monitor className='size-10 text-blue-600' />
               </div>
               <h3 className='text-2xl font-semibold text-slate-900 mb-4'>デスクトップ</h3>
               <p className='text-slate-600'>

--- a/application/e2e/src/pom/inbox-page.ts
+++ b/application/e2e/src/pom/inbox-page.ts
@@ -34,11 +34,6 @@ export class InboxPage {
     await expect(this.laterButton).toBeVisible({ timeout: TIMEOUT })
   }
 
-  currentArticleTitle(): Locator {
-    // カード内の記事タイトル(h2)。消化ごとに切り替わることの確認に使う
-    return this.page.getByRole('heading', { level: 2 }).first()
-  }
-
   async remainingCount(): Promise<number> {
     const text = await this.remainingText.textContent()
     const matched = text?.match(/(\d+)/)

--- a/application/e2e/src/pom/inbox-page.ts
+++ b/application/e2e/src/pom/inbox-page.ts
@@ -1,0 +1,74 @@
+import { expect, type Locator, type Page } from '@playwright/test'
+import { TIMEOUT } from './constants'
+
+// window.open を差し替えて「読む」で開かれた URL を検証に使うため、Window 型を拡張する
+declare global {
+  interface Window {
+    lastInboxOpenedUrl?: string
+  }
+}
+
+export class InboxPage {
+  private readonly heading: Locator
+  private readonly remainingText: Locator
+  private readonly skipButton: Locator
+  private readonly readButton: Locator
+  private readonly laterButton: Locator
+
+  constructor(private readonly page: Page) {
+    this.heading = this.page.getByRole('heading', { name: '未読消化', level: 1 })
+    this.remainingText = this.page.getByText(/^残り \d+ 件$/)
+    this.skipButton = this.page.getByRole('button', { name: 'スキップ' })
+    this.readButton = this.page.getByRole('button', { name: '読む', exact: true })
+    this.laterButton = this.page.getByRole('button', { name: '後で' })
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/inbox')
+    await expect(this.heading).toBeVisible({ timeout: TIMEOUT })
+  }
+
+  async waitForArticleCard(): Promise<void> {
+    await expect(this.skipButton).toBeVisible({ timeout: TIMEOUT })
+    await expect(this.readButton).toBeVisible({ timeout: TIMEOUT })
+    await expect(this.laterButton).toBeVisible({ timeout: TIMEOUT })
+  }
+
+  currentArticleTitle(): Locator {
+    // カード内の記事タイトル(h2)。消化ごとに切り替わることの確認に使う
+    return this.page.getByRole('heading', { level: 2 }).first()
+  }
+
+  async remainingCount(): Promise<number> {
+    const text = await this.remainingText.textContent()
+    const matched = text?.match(/(\d+)/)
+    return matched ? Number(matched[1]) : 0
+  }
+
+  async expectRemainingCount(count: number): Promise<void> {
+    await expect(this.remainingText).toHaveText(`残り ${count} 件`, { timeout: TIMEOUT })
+  }
+
+  async skipCurrent(): Promise<void> {
+    await this.skipButton.click()
+  }
+
+  async readCurrent(): Promise<void> {
+    await this.readButton.click()
+  }
+
+  async mockWindowOpen(): Promise<void> {
+    await this.page.evaluate(() => {
+      window.open = (url) => {
+        if (url) {
+          window.lastInboxOpenedUrl = url.toString()
+        }
+        return null
+      }
+    })
+  }
+
+  async getLastOpenedUrl(): Promise<string> {
+    return this.page.evaluate(() => window.lastInboxOpenedUrl ?? '')
+  }
+}

--- a/application/e2e/src/scenario/article-browse.mobile.test.ts
+++ b/application/e2e/src/scenario/article-browse.mobile.test.ts
@@ -147,7 +147,10 @@ test.describe('記事閲覧シナリオ(モバイル)', () => {
       }
       await authPage.waitForLoginPage()
       await authPage.submitLogin(email, password)
-      await authPage.waitForTrendsPage()
+
+      // モバイルでは絞り込みがハンバーガーの Sheet 内にあり、デスクトップ用の
+      // waitForTrendsPage は使えないため、URL と記事カードの表示で trends 到達を待つ
+      await expect(page).toHaveURL(/\/trends(?:\?.*)?$/, { timeout: AUTH_FLOW_TIMEOUT })
 
       // trends → ドロワー
       const trendsPage = new TrendsPage(page)

--- a/application/e2e/src/scenario/article-browse.mobile.test.ts
+++ b/application/e2e/src/scenario/article-browse.mobile.test.ts
@@ -1,11 +1,16 @@
+import { faker } from '@faker-js/faker'
 import { expect, test } from '../fixtures'
 import * as articleHelper from '../helper/article'
+import * as userHelper from '../helper/user'
+import { AuthPage } from '../pom/auth-page'
 import { ArticleDrawer } from '../pom/components/article-drawer'
-import { SUPPORTED_ARTICLE_URL_PATTERN } from '../pom/constants'
+import { AUTH_FLOW_TIMEOUT, SUPPORTED_ARTICLE_URL_PATTERN } from '../pom/constants'
+import { InboxPage } from '../pom/inbox-page'
 import { TrendsPage } from '../pom/trends-page'
 
 const ARTICLE_COUNT = 10
 const MOBILE_VIEWPORT = { width: 375, height: 667 }
+const DIGESTION_ARTICLE_COUNT = 3
 const LONG_ARTICLE_TITLE = '概要トグル確認用記事'
 const LONG_ARTICLE_DESCRIPTION =
   'TrendDiaryは技術トレンドの収集と閲覧を効率化するためのサービスであり、記事の要点を短時間で把握しながら必要に応じて元記事へ素早くアクセスできる。モバイル表示時の概要折りたたみ挙動を確認するため、この説明文は十分に長くしている。'
@@ -101,6 +106,77 @@ test.describe('記事閲覧シナリオ(モバイル)', () => {
       await drawer.expectDescriptionExpanded()
       await drawer.expectDescriptionToggle('閉じる')
       await drawer.expectReadArticleButtonVisible()
+    })
+  })
+
+  test.describe('ログインから未読消化までの主要フロー', () => {
+    const password = 'Aa1@aaaa'
+    const suffix = faker.string.alphanumeric(10).toLowerCase()
+    const email = faker.internet.email({
+      firstName: 'e2e',
+      lastName: `mobile${suffix}`,
+      provider: 'example.com',
+      allowSpecialCharacters: false,
+    })
+    const createdArticleIds: bigint[] = []
+
+    test.beforeAll(async ({ rdb }) => {
+      await Promise.all(
+        Array.from({ length: DIGESTION_ARTICLE_COUNT }, async () => {
+          const article = await articleHelper.createArticle(rdb)
+          createdArticleIds.push(article.articleId)
+        }),
+      )
+    })
+
+    test.afterAll(async ({ rdb }) => {
+      await articleHelper.cleanUp(rdb, createdArticleIds)
+      await userHelper.cleanUpByEmailPattern(rdb, email)
+    })
+
+    test('ログイン後にトレンド閲覧から未読記事を消化できる', async ({ page }) => {
+      // ログインを含む一連のフローのため、認証フローの想定時間を積み増す
+      test.setTimeout(AUTH_FLOW_TIMEOUT * 4)
+
+      const authPage = new AuthPage(page)
+      await authPage.gotoSignup()
+      const signupResult = await authPage.submitSignup(email, password)
+      if (signupResult === 'stayed') {
+        await authPage.expectSignupConflictError()
+        await authPage.gotoLogin()
+      }
+      await authPage.waitForLoginPage()
+      await authPage.submitLogin(email, password)
+      await authPage.waitForTrendsPage()
+
+      // trends → ドロワー
+      const trendsPage = new TrendsPage(page)
+      await trendsPage.waitForArticleCards()
+      await trendsPage.openFirstArticle()
+      const drawer = new ArticleDrawer(page)
+      await drawer.waitOpen()
+      await drawer.close()
+      await drawer.expectClosed()
+
+      // inbox 消化
+      const inboxPage = new InboxPage(page)
+      await inboxPage.goto()
+      await inboxPage.waitForArticleCard()
+
+      // 他テストのデータ混在で総数は一定しないため、消化ごとの相対的な減少で確認する
+      const remainingBeforeSkip = await inboxPage.remainingCount()
+      expect(remainingBeforeSkip).toBeGreaterThanOrEqual(DIGESTION_ARTICLE_COUNT)
+
+      await inboxPage.skipCurrent()
+      await inboxPage.expectRemainingCount(remainingBeforeSkip - 1)
+      await inboxPage.waitForArticleCard()
+
+      // 「読む」で実記事を開きつつ消化できることを確認する
+      await inboxPage.mockWindowOpen()
+      await inboxPage.readCurrent()
+      await inboxPage.expectRemainingCount(remainingBeforeSkip - 2)
+      const openedUrl = await inboxPage.getLastOpenedUrl()
+      expect(openedUrl).toMatch(SUPPORTED_ARTICLE_URL_PATTERN)
     })
   })
 })


### PR DESCRIPTION
<!-- Product Backlogから参照できるようにする -->

# 概要
- close: #901
- モバイル体験の改善として、以下に取り組みました。
  - **方針決定**: モバイルを正式サポートと位置づけ、LP の推奨環境の記載を更新
  - **ちらつき解消**: `useIsMobile` を `useSyncExternalStore` 化し、モバイル初回描画時の一瞬のデスクトップ UI 表示を解消
  - **E2E 拡充**: 既存の `article-browse.mobile.test.ts` に、認証込みの主要フロー（ログイン→trends→ドロワー→未読消化）を追加

## 動作確認(スクリーンショットなど)

- `pnpm oxlint` / `pnpm oxfmt --check` / `pnpm -r typecheck`: すべて通過
- `pnpm vitest run --project client`（apps/web）: 233 件すべて通過（`useIsMobile` の新規テスト 5 件を含む）
- E2E は本 PR で追加したシナリオを CI 上で確認予定です（ローカルは Supabase / wrangler 環境が必要なため）

### UIテスト
<!-- 特になし -->

## レビュー観点

### 内部品質

- **`useIsMobile` のちらつき解消（`packages`... apps/web/src/client/components/shadcn/hooks/use-mobile.ts）**
  - 従来は `useState(undefined)` + `useEffect` で、ハイドレーション後の副作用で値が確定するため、モバイル初回描画で一瞬デスクトップ版 UI が出ていました。
  - `useSyncExternalStore` に切り替え、SSR は `getServerSnapshot()` でデスクトップ扱い（従来の SSR 出力と一致）としつつ、ハイドレーション時にクライアント値との差分を同期的に反映することでちらつきを解消しています。
  - 既存 `use-document-visibility.ts` の書き方に揃えています。
- **テスト**: `use-mobile.test.ts` を新設。ブレークポイント境界（767/768px）と viewport 変化への追従を検証しています。
- **E2E**: `InboxPage` の POM を新設。未読消化のスキップ・読むが消化ごとに残件を減らすことを、他テストのデータ混在に依存しない相対比較で確認しています。要素特定はアクセシブルネーム／表示テキストで行っています。

### 外部品質

- **LP の推奨環境更新（apps/web/src/client/routes/\_index.tsx）**
  - 「画面幅 1024px 以上・Mac・Chrome 推奨」のデスクトップ限定の記載を撤廃し、スマートフォン／デスクトップの両対応を明示しました。

## その他・参考情報

- **PWA 対応（manifest / service worker）について**: 受け入れ基準の「対応する場合は別イシューに切り出す」に従い、本 PR では実装せず**別イシューへの切り出しが妥当**と判断しました。`apple-touch-icon.png` は既に存在し `root.tsx` から参照済みですが、`manifest.webmanifest` と service worker によるホーム画面追加体験は独立した検討が必要なため、別途起票を推奨します。
- **方針決定について**: モバイル正式サポート／PWA 別イシュー化は、対話での確認が取れなかったため、イシューの趣旨（「inbox の 1 件ずつ消化する UI はモバイルと相性が良く、投資対効果が高い領域」）に沿って判断しました。方針に相違があればお知らせください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ViSvxL2oRbWzP1ekreFZL

---
_Generated by [Claude Code](https://claude.ai/code/session_015ViSvxL2oRbWzP1ekreFZL)_