### PR TITLE
feat: テーマ設定を端末間で同期する

### DIFF
--- a/application/apps/web/src/client/features/theme/index.ts
+++ b/application/apps/web/src/client/features/theme/index.ts
@@ -1,3 +1,4 @@
 // テーマ機能の公開口
 export { default as ThemeProvider } from './theme-provider'
+export { default as ThemeSync } from './theme-sync'
 export { default as ThemeToggle } from './theme-toggle'

--- a/application/apps/web/src/client/features/theme/theme-sync.test.ts
+++ b/application/apps/web/src/client/features/theme/theme-sync.test.ts
@@ -1,0 +1,66 @@
+import { render, waitFor } from '@testing-library/react'
+import { createElement, type ReactNode } from 'react'
+import { SWRConfig } from 'swr'
+import type { MockedFunction } from 'vitest'
+import getApiClientForClient from '@/infrastructure/api'
+import ThemeSync from './theme-sync'
+
+const setThemeMock = vi.fn()
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ setTheme: setThemeMock }),
+}))
+
+const mockApiClient = {
+  auth: {
+    me: {
+      $get: vi.fn(),
+    },
+  },
+}
+
+// oxlint-disable-next-line typescript/no-explicit-any, typescript/consistent-type-assertions -- Hono client を返す関数のモックで、ネストした実型に合わせず一部のみをモックするためアサーションで橋渡しする
+const mockGetApiClient = getApiClientForClient as MockedFunction<any>
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    SWRConfig,
+    { value: { provider: () => new Map(), dedupingInterval: 0 } },
+    children,
+  )
+}
+
+describe('ThemeSync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetApiClient.mockReturnValue(mockApiClient)
+  })
+
+  describe('正常系', () => {
+    it('サーバーのテーマを取得してnext-themesへ反映する', async () => {
+      mockApiClient.auth.me.$get.mockResolvedValue({
+        ok: true,
+        json: async () => ({ user: { displayName: null, theme: 'dark' } }),
+      })
+
+      render(createElement(ThemeSync), { wrapper })
+
+      await waitFor(() => {
+        expect(setThemeMock).toHaveBeenCalledWith('dark')
+      })
+    })
+  })
+
+  describe('準正常系', () => {
+    it('未ログイン(401)ではテーマを適用しない', async () => {
+      mockApiClient.auth.me.$get.mockResolvedValue({ ok: false, status: 401 })
+
+      render(createElement(ThemeSync), { wrapper })
+
+      await waitFor(() => {
+        expect(mockApiClient.auth.me.$get).toHaveBeenCalled()
+      })
+      expect(setThemeMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/application/apps/web/src/client/features/theme/theme-sync.tsx
+++ b/application/apps/web/src/client/features/theme/theme-sync.tsx
@@ -1,0 +1,16 @@
+import { useTheme } from 'next-themes'
+import { useEffect } from 'react'
+import useThemePreference from './use-theme-preference'
+
+// サーバーに保存されたテーマ(外部システム)をnext-themesへ同期する。
+// 別端末で変更した設定を読み込み時に反映するための購読なのでuseEffectで扱う
+export default function ThemeSync() {
+  const { setTheme } = useTheme()
+  const { serverTheme } = useThemePreference()
+
+  useEffect(() => {
+    if (serverTheme) setTheme(serverTheme)
+  }, [serverTheme, setTheme])
+
+  return null
+}

--- a/application/apps/web/src/client/features/theme/theme-toggle.test.ts
+++ b/application/apps/web/src/client/features/theme/theme-toggle.test.ts
@@ -1,6 +1,9 @@
-import { fireEvent, render, screen } from '@testing-library/react'
-import { createElement } from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { createElement, type ReactNode } from 'react'
+import { SWRConfig } from 'swr'
+import type { MockedFunction } from 'vitest'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import getApiClientForClient from '@/infrastructure/api'
 import ThemeToggle from './theme-toggle'
 
 const setThemeMock = vi.fn()
@@ -10,17 +13,54 @@ vi.mock('next-themes', () => ({
   useTheme: () => ({ theme: themeState.theme, setTheme: setThemeMock }),
 }))
 
+const mockApiClient = {
+  auth: {
+    me: {
+      $get: vi.fn(),
+      theme: {
+        $put: vi.fn(),
+      },
+    },
+  },
+}
+
+// oxlint-disable-next-line typescript/no-explicit-any, typescript/consistent-type-assertions -- Hono client を返す関数のモックで、ネストした実型に合わせず一部のみをモックするためアサーションで橋渡しする
+const mockGetApiClient = getApiClientForClient as MockedFunction<any>
+
+// テスト間でSWRキャッシュを共有しないよう、毎回新しいproviderで包む
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    SWRConfig,
+    { value: { provider: () => new Map(), dedupingInterval: 0 } },
+    children,
+  )
+}
+
+function renderToggle() {
+  return render(createElement(ThemeToggle), { wrapper })
+}
+
 describe('ThemeToggle', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     themeState.theme = 'system'
+    mockGetApiClient.mockReturnValue(mockApiClient)
+    // 設定画面はログイン時のみ表示されるため既定はテーマ取得成功とする
+    mockApiClient.auth.me.$get.mockResolvedValue({
+      ok: true,
+      json: async () => ({ user: { displayName: null, theme: 'system' } }),
+    })
+    mockApiClient.auth.me.theme.$put.mockResolvedValue({
+      ok: true,
+      json: async () => ({ theme: 'light' }),
+    })
   })
 
   describe('正常系', () => {
     it('現在のテーマのボタンにのみ選択スタイルが当たる', () => {
       themeState.theme = 'dark'
 
-      render(createElement(ThemeToggle))
+      renderToggle()
 
       expect(screen.getByRole('button', { name: 'ダーク' })).toHaveAttribute('aria-pressed', 'true')
       expect(screen.getByRole('button', { name: 'システム' })).toHaveAttribute(
@@ -34,11 +74,21 @@ describe('ThemeToggle', () => {
     })
 
     it('ボタンを押すと選択したテーマでsetThemeが呼ばれる', () => {
-      render(createElement(ThemeToggle))
+      renderToggle()
 
       fireEvent.click(screen.getByRole('button', { name: 'ライト' }))
 
       expect(setThemeMock).toHaveBeenCalledWith('light')
+    })
+
+    it('ボタンを押すと選択したテーマをサーバーにも保存する', async () => {
+      renderToggle()
+
+      fireEvent.click(screen.getByRole('button', { name: 'ライト' }))
+
+      await waitFor(() => {
+        expect(mockApiClient.auth.me.theme.$put).toHaveBeenCalledWith({ json: { theme: 'light' } })
+      })
     })
   })
 })

--- a/application/apps/web/src/client/features/theme/theme-toggle.tsx
+++ b/application/apps/web/src/client/features/theme/theme-toggle.tsx
@@ -1,7 +1,9 @@
+import { themeSchema } from '@trend-diary/domain/user'
 import { Monitor, Moon, Sun } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import { useEffect, useState } from 'react'
 import { ToggleGroup, type ToggleOption } from '@/client/components/ui/input/toggle-group'
+import useThemePreference from './use-theme-preference'
 
 const themeOptions: readonly ToggleOption<string>[] = [
   { value: 'system', label: 'システム', icon: <Monitor className='size-4' /> },
@@ -11,6 +13,7 @@ const themeOptions: readonly ToggleOption<string>[] = [
 
 export default function ThemeToggle() {
   const { theme, setTheme } = useTheme()
+  const { saveTheme } = useThemePreference()
   const [mounted, setMounted] = useState(false)
 
   // サーバー描画時はテーマが未確定のため、ハイドレーション不一致を避けてマウント後に選択状態を反映する
@@ -18,11 +21,18 @@ export default function ThemeToggle() {
     setMounted(true)
   }, [])
 
+  const handleSelect = (value: string) => {
+    // 端末内の表示を即時反映しつつ、端末間共有のためサーバーにも保存する
+    setTheme(value)
+    const parsed = themeSchema.safeParse(value)
+    if (parsed.success) void saveTheme(parsed.data)
+  }
+
   return (
     <ToggleGroup
       options={themeOptions}
       selectedValue={mounted ? (theme ?? 'system') : ''}
-      onSelect={setTheme}
+      onSelect={handleSelect}
       className='sm:shrink-0'
     />
   )

--- a/application/apps/web/src/client/features/theme/use-theme-preference.test.ts
+++ b/application/apps/web/src/client/features/theme/use-theme-preference.test.ts
@@ -1,8 +1,8 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import { createElement, type ReactNode } from 'react'
+import { toast } from 'sonner'
 import { SWRConfig } from 'swr'
 import type { MockedFunction } from 'vitest'
-import { toast } from 'sonner'
 import getApiClientForClient from '@/infrastructure/api'
 import useThemePreference from './use-theme-preference'
 

--- a/application/apps/web/src/client/features/theme/use-theme-preference.test.ts
+++ b/application/apps/web/src/client/features/theme/use-theme-preference.test.ts
@@ -1,0 +1,95 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { createElement, type ReactNode } from 'react'
+import { SWRConfig } from 'swr'
+import type { MockedFunction } from 'vitest'
+import { toast } from 'sonner'
+import getApiClientForClient from '@/infrastructure/api'
+import useThemePreference from './use-theme-preference'
+
+const mockApiClient = {
+  auth: {
+    me: {
+      $get: vi.fn(),
+      theme: {
+        $put: vi.fn(),
+      },
+    },
+  },
+}
+
+// oxlint-disable-next-line typescript/no-explicit-any, typescript/consistent-type-assertions -- Hono client を返す関数のモックで、ネストした実型に合わせず一部のみをモックするためアサーションで橋渡しする
+const mockGetApiClient = getApiClientForClient as MockedFunction<any>
+
+// テスト間でSWRキャッシュを共有しないよう、毎回新しいproviderで包む
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(
+    SWRConfig,
+    { value: { provider: () => new Map(), dedupingInterval: 0 } },
+    children,
+  )
+}
+
+describe('useThemePreference', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetApiClient.mockReturnValue(mockApiClient)
+  })
+
+  describe('正常系', () => {
+    it('/meのテーマを取得してserverThemeに反映する', async () => {
+      mockApiClient.auth.me.$get.mockResolvedValue({
+        ok: true,
+        json: async () => ({ user: { displayName: null, theme: 'dark' } }),
+      })
+
+      const { result } = renderHook(() => useThemePreference(), { wrapper })
+
+      await waitFor(() => {
+        expect(result.current.serverTheme).toBe('dark')
+      })
+    })
+
+    it('saveThemeで選択テーマをサーバーに保存する', async () => {
+      mockApiClient.auth.me.$get.mockResolvedValue({
+        ok: true,
+        json: async () => ({ user: { displayName: null, theme: 'system' } }),
+      })
+      mockApiClient.auth.me.theme.$put.mockResolvedValue({
+        ok: true,
+        json: async () => ({ theme: 'light' }),
+      })
+
+      const { result } = renderHook(() => useThemePreference(), { wrapper })
+
+      const saved = await result.current.saveTheme('light')
+
+      expect(saved).toBe(true)
+      expect(mockApiClient.auth.me.theme.$put).toHaveBeenCalledWith({ json: { theme: 'light' } })
+    })
+  })
+
+  describe('準正常系', () => {
+    it('未ログイン(401)ではserverThemeがnullになる', async () => {
+      mockApiClient.auth.me.$get.mockResolvedValue({ ok: false, status: 401 })
+
+      const { result } = renderHook(() => useThemePreference(), { wrapper })
+
+      await waitFor(() => {
+        expect(mockApiClient.auth.me.$get).toHaveBeenCalled()
+      })
+      expect(result.current.serverTheme).toBeNull()
+    })
+
+    it('保存に失敗するとfalseを返しエラートーストを出す', async () => {
+      mockApiClient.auth.me.$get.mockResolvedValue({ ok: false, status: 401 })
+      mockApiClient.auth.me.theme.$put.mockResolvedValue({ ok: false, status: 500 })
+
+      const { result } = renderHook(() => useThemePreference(), { wrapper })
+
+      const saved = await result.current.saveTheme('dark')
+
+      expect(saved).toBe(false)
+      expect(toast.error).toHaveBeenCalled()
+    })
+  })
+})

--- a/application/apps/web/src/client/features/theme/use-theme-preference.ts
+++ b/application/apps/web/src/client/features/theme/use-theme-preference.ts
@@ -1,0 +1,40 @@
+import type { Theme } from '@trend-diary/domain/user'
+import { toast } from 'sonner'
+import useSWR from 'swr'
+import getApiClientForClient from '@/client/infrastructure/api'
+
+export const THEME_PREFERENCE_SWR_KEY = 'api/auth/me/theme'
+
+// サーバーに保存された端末間共有テーマを取得・更新する。
+// 未ログインはAPIが401で表現するため、例外にせずnullに落とす
+export default function useThemePreference() {
+  const { data, mutate } = useSWR<Theme | null>(THEME_PREFERENCE_SWR_KEY, async () => {
+    const client = getApiClientForClient()
+    const res = await client.auth.me.$get()
+    if (!res.ok) return null
+    const body = await res.json()
+    return body.user.theme
+  })
+
+  const saveTheme = async (theme: Theme) => {
+    const client = getApiClientForClient()
+    try {
+      // 保存前に楽観的にキャッシュを更新し、失敗時はロールバックする
+      await mutate(
+        async () => {
+          const res = await client.auth.me.theme.$put({ json: { theme } })
+          if (!res.ok) throw new Error('failed to save theme')
+          const body = await res.json()
+          return body.theme
+        },
+        { optimisticData: theme, revalidate: false, rollbackOnError: true },
+      )
+      return true
+    } catch {
+      toast.error('テーマの保存に失敗しました')
+      return false
+    }
+  }
+
+  return { serverTheme: data ?? null, saveTheme, mutate }
+}

--- a/application/apps/web/src/client/features/theme/use-theme-preference.ts
+++ b/application/apps/web/src/client/features/theme/use-theme-preference.ts
@@ -36,5 +36,5 @@ export default function useThemePreference() {
     }
   }
 
-  return { serverTheme: data ?? null, saveTheme, mutate }
+  return { serverTheme: data ?? null, saveTheme }
 }

--- a/application/apps/web/src/client/root.tsx
+++ b/application/apps/web/src/client/root.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-router'
 import './styles.css'
 import { AnchorLink } from '@/client/components/ui/navigation/link'
-import { ThemeProvider } from '@/client/features/theme'
+import { ThemeProvider, ThemeSync } from '@/client/features/theme'
 import { SITE_URL } from '@/client/lib/meta'
 import { Toaster } from './components/shadcn/sonner'
 
@@ -56,6 +56,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
       </head>
       <body>
         <ThemeProvider>
+          <ThemeSync />
           {children}
           <ScrollRestoration />
           <Scripts />

--- a/application/apps/web/src/env.ts
+++ b/application/apps/web/src/env.ts
@@ -1,12 +1,14 @@
 import type { WorkerBindings } from '@trend-diary/common/env'
 import type { LoggerType } from '@trend-diary/common/logger'
 import type { Nullable } from '@trend-diary/common/types/utility'
+import type { Theme } from '@trend-diary/domain/user'
 import type CONTEXT_KEY from './middleware/context'
 
 export interface SessionUser {
   activeUserId: bigint
   displayName?: Nullable<string>
   email: string
+  theme: Theme
 }
 
 // Cloudflare Workers の Rate Limiting バインディングの型（workers-typesに含まれないため定義する）

--- a/application/apps/web/src/middleware/authenticator/authenticator.test.ts
+++ b/application/apps/web/src/middleware/authenticator/authenticator.test.ts
@@ -39,6 +39,7 @@ describe('authenticator ミドルウェア', () => {
         activeUserId: 1n,
         displayName: 'テスト太郎',
         email: 'user@example.com',
+        theme: 'system',
       }
       vi.mocked(validateSession).mockResolvedValue(ok({ sessionUser }))
 

--- a/application/apps/web/src/middleware/authenticator/optional-authenticator.test.ts
+++ b/application/apps/web/src/middleware/authenticator/optional-authenticator.test.ts
@@ -34,6 +34,7 @@ describe('optionalAuthenticator ミドルウェア', () => {
         activeUserId: 1n,
         displayName: 'テスト太郎',
         email: 'user@example.com',
+        theme: 'system',
       }
       vi.mocked(validateSession).mockResolvedValue(ok({ sessionUser }))
 

--- a/application/apps/web/src/middleware/authenticator/validate.test.ts
+++ b/application/apps/web/src/middleware/authenticator/validate.test.ts
@@ -56,7 +56,7 @@ describe('validateSession', () => {
   })
 
   describe('正常系', () => {
-    it('アクティブユーザーを認可に必要な3項目へ絞り込んで返すこと', async () => {
+    it('アクティブユーザーをSESSION_USERに必要な項目へ絞り込んで返すこと', async () => {
       // getCurrentActiveUser は authenticationId 等の内部項目も返すが、SESSION_USER には漏らさない
       const currentUser = {
         activeUserId: 123n,
@@ -64,6 +64,7 @@ describe('validateSession', () => {
         authenticationId: 'auth-abc',
         email: 'active@example.com',
         displayName: 'テスト太郎',
+        theme: 'dark' as const,
       }
       mockGetCurrentActiveUser(() => Promise.resolve(ok(currentUser)))
 
@@ -74,6 +75,7 @@ describe('validateSession', () => {
         activeUserId: 123n,
         displayName: 'テスト太郎',
         email: 'active@example.com',
+        theme: 'dark',
       })
     })
   })

--- a/application/apps/web/src/middleware/authenticator/validate.ts
+++ b/application/apps/web/src/middleware/authenticator/validate.ts
@@ -58,6 +58,7 @@ export async function validateSession(
       activeUserId: result.value.activeUserId,
       displayName: result.value.displayName,
       email: result.value.email,
+      theme: result.value.theme,
     }
 
     return ok({ sessionUser })

--- a/application/apps/web/src/server/auth/handler/me.test.ts
+++ b/application/apps/web/src/server/auth/handler/me.test.ts
@@ -31,9 +31,11 @@ describe('GET /api/auth/me', () => {
     const meRes = await requestMe(cookies)
     expect(meRes.status).toBe(200)
 
-    const body: { user: { displayName: string | null } } = await meRes.json()
+    const body: { user: { displayName: string | null; theme: string } } = await meRes.json()
     expect(body).toHaveProperty('user')
     expect(body.user).toHaveProperty('displayName')
+    // 端末間共有のため既定テーマ'system'を含めて返す
+    expect(body.user.theme).toBe('system')
   })
 
   it('準正常系: ログインしていない場合は401を返す', async () => {

--- a/application/apps/web/src/server/auth/handler/me.ts
+++ b/application/apps/web/src/server/auth/handler/me.ts
@@ -14,6 +14,7 @@ export default function me(c: Context<Env>) {
   return c.json({
     user: {
       displayName: user.displayName,
+      theme: user.theme,
     },
   })
 }

--- a/application/apps/web/src/server/auth/handler/update-theme.test.ts
+++ b/application/apps/web/src/server/auth/handler/update-theme.test.ts
@@ -1,0 +1,59 @@
+import { apiRequest } from '@/test/helper/request'
+import type { CleanUpIds } from '@/test/helper/user'
+import * as userHelper from '@/test/helper/user'
+
+describe('PUT /api/auth/me/theme', () => {
+  const TEST_EMAIL = 'update-theme-test@example.com'
+  const TEST_PASSWORD = 'Test@password123'
+  const createdIds: CleanUpIds = { userIds: [], authIds: [] }
+
+  beforeEach(async () => {
+    const { userId, authenticationId } = await userHelper.create(TEST_EMAIL, TEST_PASSWORD)
+    createdIds.userIds.push(userId)
+    createdIds.authIds.push(authenticationId)
+  })
+
+  afterEach(async () => {
+    await userHelper.cleanUp(createdIds)
+    createdIds.userIds.length = 0
+    createdIds.authIds.length = 0
+  })
+
+  function putTheme(theme: unknown, cookies?: string) {
+    return apiRequest('/api/auth/me/theme', { method: 'PUT', json: { theme }, cookies })
+  }
+
+  function requestMe(cookies?: string) {
+    return apiRequest('/api/auth/me', { method: 'GET', cookies, contentTypeJson: true })
+  }
+
+  describe('正常系', () => {
+    it('テーマを更新でき、その後の/meにも反映される', async () => {
+      const { cookies } = await userHelper.login(TEST_EMAIL, TEST_PASSWORD)
+
+      const res = await putTheme('dark', cookies)
+      expect(res.status).toBe(200)
+      const body: { theme: string } = await res.json()
+      expect(body.theme).toBe('dark')
+
+      // 別リクエスト(=別端末相当)でも更新後のテーマが取得できる
+      const meRes = await requestMe(cookies)
+      const meBody: { user: { theme: string } } = await meRes.json()
+      expect(meBody.user.theme).toBe('dark')
+    })
+  })
+
+  describe('準正常系', () => {
+    it('ログインしていない場合は401を返す', async () => {
+      const res = await putTheme('dark')
+      expect(res.status).toBe(401)
+    })
+
+    it('許可値以外のテーマは422を返す', async () => {
+      const { cookies } = await userHelper.login(TEST_EMAIL, TEST_PASSWORD)
+
+      const res = await putTheme('blue', cookies)
+      expect(res.status).toBe(422)
+    })
+  })
+})

--- a/application/apps/web/src/server/auth/handler/update-theme.ts
+++ b/application/apps/web/src/server/auth/handler/update-theme.ts
@@ -1,0 +1,23 @@
+import { handleError } from '@trend-diary/common/errors'
+import getRdbClient from '@trend-diary/datastore/rdb'
+import { createAuthUseCase, type ThemeUpdate } from '@trend-diary/domain/user'
+import { createSupabaseAuthClient } from '@/infrastructure/supabase'
+import CONTEXT_KEY from '@/middleware/context'
+import type { ZodValidatedContext } from '@/middleware/zod-validator'
+
+export default async function updateTheme(c: ZodValidatedContext<ThemeUpdate>) {
+  const logger = c.get(CONTEXT_KEY.APP_LOG)
+  const user = c.get(CONTEXT_KEY.SESSION_USER)
+  const { theme } = c.req.valid('json')
+
+  const client = createSupabaseAuthClient(c)
+  const rdb = getRdbClient(c.env.DB)
+  const useCase = createAuthUseCase(client, rdb)
+
+  const result = await useCase.updateTheme(user.activeUserId, theme)
+  if (result.isErr()) throw handleError(result.error, logger)
+
+  logger.info('update theme success', { activeUserId: user.activeUserId, theme })
+
+  return c.json({ theme: result.value.theme }, 200)
+}

--- a/application/apps/web/src/server/auth/route.ts
+++ b/application/apps/web/src/server/auth/route.ts
@@ -11,7 +11,6 @@ import zodValidator from '@/middleware/zod-validator'
 import login from './handler/login'
 import logout from './handler/logout'
 import me from './handler/me'
-import updateTheme from './handler/update-theme'
 import passkeyDisable from './handler/passkey-disable'
 import passkeyLoginStart from './handler/passkey-login-start'
 import passkeyLoginVerify from './handler/passkey-login-verify'
@@ -19,6 +18,7 @@ import passkeyRegisterStart from './handler/passkey-register-start'
 import passkeyRegisterVerify from './handler/passkey-register-verify'
 import passkeyStatus from './handler/passkey-status'
 import signup from './handler/signup'
+import updateTheme from './handler/update-theme'
 
 const app = new Hono<Env>()
   .post('/signup', rateLimiter, zodValidator('json', authInputSchema), signup)

--- a/application/apps/web/src/server/auth/route.ts
+++ b/application/apps/web/src/server/auth/route.ts
@@ -1,4 +1,8 @@
-import { authInputSchema, passkeyVerifyInputSchema } from '@trend-diary/domain/user'
+import {
+  authInputSchema,
+  passkeyVerifyInputSchema,
+  themeUpdateSchema,
+} from '@trend-diary/domain/user'
 import { Hono } from 'hono'
 import type { Env } from '@/env'
 import { authenticator } from '@/middleware/authenticator'
@@ -7,6 +11,7 @@ import zodValidator from '@/middleware/zod-validator'
 import login from './handler/login'
 import logout from './handler/logout'
 import me from './handler/me'
+import updateTheme from './handler/update-theme'
 import passkeyDisable from './handler/passkey-disable'
 import passkeyLoginStart from './handler/passkey-login-start'
 import passkeyLoginVerify from './handler/passkey-login-verify'
@@ -20,6 +25,8 @@ const app = new Hono<Env>()
   .post('/login', rateLimiter, zodValidator('json', authInputSchema), login)
   .delete('/logout', logout)
   .get('/me', authenticator, me)
+  // 端末間で共有するテーマ設定の更新(要認証)
+  .put('/me/theme', authenticator, zodValidator('json', themeUpdateSchema), updateTheme)
   // passkey認証(未認証で可)。ブラウザのWebAuthn ceremonyを挟むためstart/verifyの2段構え
   .post('/passkey/login/start', rateLimiter, passkeyLoginStart)
   .post(

--- a/application/apps/web/src/server/handler-factory.test.ts
+++ b/application/apps/web/src/server/handler-factory.test.ts
@@ -176,6 +176,7 @@ describe('createAuthenticatedApiHandler', () => {
     activeUserId: 42n,
     displayName: 'テスト太郎',
     email: 'user@example.com',
+    theme: 'system',
   }
 
   describe('正常系', () => {

--- a/application/apps/web/src/test/helper/user.ts
+++ b/application/apps/web/src/test/helper/user.ts
@@ -69,6 +69,7 @@ async function createActiveUser(email: string, authenticationId: string): Promis
     userId: fromDbId(user.userId),
     email: activeUser.email,
     displayName: activeUser.displayName,
+    theme: activeUser.theme,
     authenticationId: activeUser.authenticationId,
     createdAt: activeUser.createdAt,
     updatedAt: activeUser.updatedAt,

--- a/application/packages/datastore/migrations/0007_shocking_wilson_fisk.sql
+++ b/application/packages/datastore/migrations/0007_shocking_wilson_fisk.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `active_users` ADD `theme` text DEFAULT 'system' NOT NULL;

--- a/application/packages/datastore/migrations/meta/0007_snapshot.json
+++ b/application/packages/datastore/migrations/meta/0007_snapshot.json
@@ -1,0 +1,518 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "4a4e6e1c-b187-48e1-91a1-a4e8e0675c8a",
+  "prevId": "e91a136e-4e8a-4e81-9937-a42b6e5c51b6",
+  "tables": {
+    "articles": {
+      "name": "articles",
+      "columns": {
+        "article_id": {
+          "name": "article_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "media": {
+          "name": "media",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "created_at_norm": {
+          "name": "created_at_norm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(CASE WHEN typeof(\"created_at\") = 'integer' THEN datetime(\"created_at\" / 1000, 'unixepoch') ELSE datetime(\"created_at\") END)",
+            "type": "virtual"
+          }
+        }
+      },
+      "indexes": {
+        "articles_url_key": {
+          "name": "articles_url_key",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "idx_articles_created_at_norm": {
+          "name": "idx_articles_created_at_norm",
+          "columns": [
+            "created_at_norm"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "read_histories": {
+      "name": "read_histories",
+      "columns": {
+        "read_history_id": {
+          "name": "read_history_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_user_id": {
+          "name": "active_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_at_norm": {
+          "name": "read_at_norm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(CASE WHEN typeof(\"read_at\") = 'integer' THEN datetime(\"read_at\" / 1000, 'unixepoch') ELSE datetime(\"read_at\") END)",
+            "type": "virtual"
+          }
+        }
+      },
+      "indexes": {
+        "idx_read_histories_article_user": {
+          "name": "idx_read_histories_article_user",
+          "columns": [
+            "article_id",
+            "active_user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_read_histories_user_read_at_norm": {
+          "name": "idx_read_histories_user_read_at_norm",
+          "columns": [
+            "active_user_id",
+            "read_at_norm"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "read_histories_active_user_id_active_users_active_user_id_fk": {
+          "name": "read_histories_active_user_id_active_users_active_user_id_fk",
+          "tableFrom": "read_histories",
+          "tableTo": "active_users",
+          "columnsFrom": [
+            "active_user_id"
+          ],
+          "columnsTo": [
+            "active_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skipped_articles": {
+      "name": "skipped_articles",
+      "columns": {
+        "skipped_article_id": {
+          "name": "skipped_article_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "active_user_id": {
+          "name": "active_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at_norm": {
+          "name": "created_at_norm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "generated": {
+            "as": "(CASE WHEN typeof(\"created_at\") = 'integer' THEN datetime(\"created_at\" / 1000, 'unixepoch') ELSE datetime(\"created_at\") END)",
+            "type": "virtual"
+          }
+        }
+      },
+      "indexes": {
+        "uq_skipped_articles_article_user": {
+          "name": "uq_skipped_articles_article_user",
+          "columns": [
+            "article_id",
+            "active_user_id"
+          ],
+          "isUnique": true
+        },
+        "idx_skipped_articles_user_created_at_norm": {
+          "name": "idx_skipped_articles_user_created_at_norm",
+          "columns": [
+            "active_user_id",
+            "created_at_norm"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "skipped_articles_active_user_id_active_users_active_user_id_fk": {
+          "name": "skipped_articles_active_user_id_active_users_active_user_id_fk",
+          "tableFrom": "skipped_articles",
+          "tableTo": "active_users",
+          "columnsFrom": [
+            "active_user_id"
+          ],
+          "columnsTo": [
+            "active_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "active_users": {
+      "name": "active_users",
+      "columns": {
+        "active_user_id": {
+          "name": "active_user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'system'"
+        },
+        "authentication_id": {
+          "name": "authentication_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "active_users_email_key": {
+          "name": "active_users_email_key",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "active_users_authentication_id_key": {
+          "name": "active_users_authentication_id_key",
+          "columns": [
+            "authentication_id"
+          ],
+          "isUnique": true
+        },
+        "active_users_user_id_key": {
+          "name": "active_users_user_id_key",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "active_users_user_id_users_user_id_fk": {
+          "name": "active_users_user_id_users_user_id_fk",
+          "tableFrom": "active_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "banned_users": {
+      "name": "banned_users",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "banned_users_user_id_key": {
+          "name": "banned_users_user_id_key",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "banned_users_user_id_users_user_id_fk": {
+          "name": "banned_users_user_id_users_user_id_fk",
+          "tableFrom": "banned_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "leaved_users": {
+      "name": "leaved_users",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "leaved_users_user_id_key": {
+          "name": "leaved_users_user_id_key",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "leaved_users_user_id_users_user_id_fk": {
+          "name": "leaved_users_user_id_users_user_id_fk",
+          "tableFrom": "leaved_users",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "DATETIME",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/application/packages/datastore/migrations/meta/_journal.json
+++ b/application/packages/datastore/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1781172119772,
       "tag": "0006_flowery_luke_cage",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1783819602960,
+      "tag": "0007_shocking_wilson_fisk",
+      "breakpoints": true
     }
   ]
 }

--- a/application/packages/datastore/src/drizzle-orm/schema/user.ts
+++ b/application/packages/datastore/src/drizzle-orm/schema/user.ts
@@ -16,6 +16,10 @@ export const activeUsers = sqliteTable(
     activeUserId: integer('active_user_id').primaryKey({ autoIncrement: true }),
     email: text('email').notNull(),
     displayName: text('display_name'),
+    // 端末間で共有する画面テーマ。既定はOS設定に追従する'system'
+    theme: text('theme', { enum: ['system', 'light', 'dark'] })
+      .notNull()
+      .default('system'),
     authenticationId: text('authentication_id').notNull(),
     createdAt: dateTime('created_at')
       .notNull()

--- a/application/packages/domain/src/user/index.ts
+++ b/application/packages/domain/src/user/index.ts
@@ -3,6 +3,8 @@ import type { ActiveUser, ActiveUserInput, CurrentUser } from './schema/active-u
 import { activeUserInputSchema, activeUserSchema } from './schema/active-user-schema'
 import type { AuthenticationSession, AuthInput, PasskeyVerifyInput } from './schema/auth-schema'
 import { authInputSchema, passkeyVerifyInputSchema } from './schema/auth-schema'
+import type { Theme, ThemeUpdate } from './schema/theme-schema'
+import { themeSchema, themeUpdateSchema } from './schema/theme-schema'
 
 // 型
 export type {
@@ -12,6 +14,8 @@ export type {
   AuthInput,
   CurrentUser,
   PasskeyVerifyInput,
+  Theme,
+  ThemeUpdate,
 }
 // スキーマ
 // ファクトリ
@@ -21,4 +25,6 @@ export {
   authInputSchema,
   createAuthUseCase,
   passkeyVerifyInputSchema,
+  themeSchema,
+  themeUpdateSchema,
 }

--- a/application/packages/domain/src/user/infrastructure/command-impl.test.ts
+++ b/application/packages/domain/src/user/infrastructure/command-impl.test.ts
@@ -12,18 +12,20 @@ describe('CommandImpl', () => {
 
   // INFO: Drizzleのinsert returningは「カラム順の配列」で行を返す
   // users:        user_id, created_at
-  // active_users: active_user_id, email, display_name, authentication_id, created_at, updated_at, user_id
+  // active_users: active_user_id, email, display_name, theme, authentication_id, created_at, updated_at, user_id
   const buildUserRow = (userId: number): unknown[] => [userId, '2024-01-15T09:30:00.000Z']
   const buildActiveUserRow = (data: {
     activeUserId: number
     email: string
     displayName: string | null
+    theme?: string
     authenticationId: string | null
     userId: number
   }): unknown[] => [
     data.activeUserId,
     data.email,
     data.displayName,
+    data.theme ?? 'system',
     data.authenticationId,
     '2024-01-15T09:30:00.000Z',
     '2024-01-15T09:30:00.000Z',
@@ -263,6 +265,73 @@ describe('CommandImpl', () => {
       // Assert: 補償が成功した場合はログも通知も出さないこと
       expect(errorSpy).not.toHaveBeenCalled()
       expect(notifier.sendMessage).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('updateTheme', () => {
+    it('テーマを更新し、更新後のActiveUserを返す', async () => {
+      // Arrange: active_users update returning
+      mockRdbExecutor.mockResolvedValueOnce({
+        rows: [
+          buildActiveUserRow({
+            activeUserId: 1,
+            email: 'test@example.com',
+            displayName: '表示名',
+            theme: 'dark',
+            authenticationId: 'auth-id-123',
+            userId: 2,
+          }),
+        ],
+      })
+
+      // Act
+      const result = await useCase.updateTheme(1n, 'dark')
+
+      // Assert
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
+        expect(result.value.theme).toBe('dark')
+        expect(result.value.activeUserId).toBe(1n)
+      }
+
+      // active_usersへのupdateに新しいテーマと対象activeUserId(=1)が渡されること
+      const updateCall = mockRdbExecutor.mock.calls.find(([sql]) =>
+        sql.includes('update "active_users"'),
+      )
+      expect(updateCall).toBeDefined()
+      const [, updateParams] = updateCall ?? []
+      expect(updateParams).toContain('dark')
+      expect(updateParams).toContain(1)
+    })
+
+    it('更新対象が存在せず行が返らない場合はServerErrorを返す', async () => {
+      // Arrange: returningが空
+      mockRdbExecutor.mockResolvedValueOnce({ rows: [] })
+
+      // Act
+      const result = await useCase.updateTheme(999n, 'light')
+
+      // Assert
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(ServerError)
+        expect(result.error.message).toBe('Failed to update theme')
+      }
+    })
+
+    it('DB更新に失敗した場合はServerErrorを返す', async () => {
+      // Arrange
+      mockRdbExecutor.mockRejectedValueOnce(new Error('update failed'))
+
+      // Act
+      const result = await useCase.updateTheme(1n, 'light')
+
+      // Assert
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(ServerError)
+        expect(result.error.message).toBe('Failed to update theme')
+      }
     })
   })
 })

--- a/application/packages/domain/src/user/infrastructure/command-impl.ts
+++ b/application/packages/domain/src/user/infrastructure/command-impl.ts
@@ -3,11 +3,13 @@ import Logger from '@trend-diary/common/logger'
 import { activeUsers, users } from '@trend-diary/datastore/drizzle-orm/schema'
 import type { RdbClient } from '@trend-diary/datastore/rdb'
 import { wrapDbCall } from '@trend-diary/datastore/rdb'
+import { toDbId } from '@trend-diary/datastore/rdb/id'
 import { eq } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
 import type { Command } from '../repository'
 import { type Notifier } from '../repository'
 import type { CurrentUser } from '../schema/active-user-schema'
+import type { Theme } from '../schema/theme-schema'
 import { mapToActiveUser } from './mapper'
 
 // 補償失敗は手動対応が必要なため、デフォルトのログレベルをerrorに設定する
@@ -82,5 +84,31 @@ export default class CommandImpl implements Command {
     }
 
     return ok(mapToActiveUser(activeUser))
+  }
+
+  async updateTheme(
+    activeUserId: bigint,
+    theme: Theme,
+  ): Promise<Result<CurrentUser, ServerError>> {
+    const dbId = toDbId(activeUserId)
+    // INFO: updated_atはトリガーで自動更新されるが、createActiveと揃えて明示的にも設定する
+    const now = new Date()
+    const updateResult = await wrapDbCall(() =>
+      this.db
+        .update(activeUsers)
+        .set({ theme, updatedAt: now })
+        .where(eq(activeUsers.activeUserId, dbId))
+        .returning(),
+    )
+    if (updateResult.isErr()) {
+      return err(new ServerError('Failed to update theme'))
+    }
+
+    const updated = updateResult.value[0]
+    if (!updated) {
+      return err(new ServerError('Failed to update theme'))
+    }
+
+    return ok(mapToActiveUser(updated))
   }
 }

--- a/application/packages/domain/src/user/infrastructure/command-impl.ts
+++ b/application/packages/domain/src/user/infrastructure/command-impl.ts
@@ -86,10 +86,7 @@ export default class CommandImpl implements Command {
     return ok(mapToActiveUser(activeUser))
   }
 
-  async updateTheme(
-    activeUserId: bigint,
-    theme: Theme,
-  ): Promise<Result<CurrentUser, ServerError>> {
+  async updateTheme(activeUserId: bigint, theme: Theme): Promise<Result<CurrentUser, ServerError>> {
     const dbId = toDbId(activeUserId)
     // INFO: updated_atはトリガーで自動更新されるが、createActiveと揃えて明示的にも設定する
     const now = new Date()

--- a/application/packages/domain/src/user/infrastructure/mapper.test.ts
+++ b/application/packages/domain/src/user/infrastructure/mapper.test.ts
@@ -16,6 +16,7 @@ describe('mapToActiveUser', () => {
       userId: 67890n,
       email: 'john.doe@example.com',
       displayName: '田中太郎',
+      theme: 'system',
       authenticationId: '550e8400-e29b-41d4-a716-446655440000',
       createdAt: new Date('2023-11-20T10:15:30Z'),
       updatedAt: now,
@@ -36,6 +37,7 @@ describe('mapToActiveUser', () => {
       expect(result.userId).toBe(rdbActiveUser.userId)
       expect(result.email).toBe(rdbActiveUser.email)
       expect(result.displayName).toBe(rdbActiveUser.displayName)
+      expect(result.theme).toBe(rdbActiveUser.theme)
       expect(result.createdAt).toEqual(rdbActiveUser.createdAt)
       expect(result.updatedAt).toEqual(rdbActiveUser.updatedAt)
     })

--- a/application/packages/domain/src/user/infrastructure/mapper.ts
+++ b/application/packages/domain/src/user/infrastructure/mapper.ts
@@ -8,6 +8,7 @@ export function mapToActiveUser(activeUser: RdbActiveUser): CurrentUser {
     userId: fromDbId(activeUser.userId),
     email: activeUser.email,
     displayName: activeUser.displayName,
+    theme: activeUser.theme,
     authenticationId: activeUser.authenticationId,
     createdAt: activeUser.createdAt,
     updatedAt: activeUser.updatedAt,

--- a/application/packages/domain/src/user/infrastructure/query-impl.test.ts
+++ b/application/packages/domain/src/user/infrastructure/query-impl.test.ts
@@ -7,12 +7,13 @@ describe('QueryImpl', () => {
   let useCase: QueryImpl
 
   // INFO: Drizzleのselectは「カラム順の配列」で行を返す
-  // 並び順: active_user_id, email, display_name, authentication_id, created_at, updated_at, user_id
+  // 並び順: active_user_id, email, display_name, theme, authentication_id, created_at, updated_at, user_id
   const buildActiveUserRow = (
     overrides: Partial<{
       activeUserId: number
       email: string
       displayName: string | null
+      theme: string
       authenticationId: string | null
       createdAt: string
       updatedAt: string
@@ -23,6 +24,7 @@ describe('QueryImpl', () => {
       activeUserId: 1,
       email: 'test@example.com',
       displayName: 'テストユーザー',
+      theme: 'system',
       authenticationId: null,
       createdAt: '2024-01-15T09:30:00.000Z',
       updatedAt: '2024-01-15T09:30:00.000Z',
@@ -33,6 +35,7 @@ describe('QueryImpl', () => {
       data.activeUserId,
       data.email,
       data.displayName,
+      data.theme,
       data.authenticationId,
       data.createdAt,
       data.updatedAt,

--- a/application/packages/domain/src/user/repository.ts
+++ b/application/packages/domain/src/user/repository.ts
@@ -11,6 +11,7 @@ import type {
   RegisteredPasskey,
   VerifiedSession,
 } from './schema/auth-schema'
+import type { Theme } from './schema/theme-schema'
 
 export interface Query {
   findActiveById(id: bigint): Promise<Result<Nullable<CurrentUser>, Error>>
@@ -42,6 +43,7 @@ export interface Command {
     notifier: Notifier,
     displayName?: string | null,
   ): Promise<Result<CurrentUser, ServerError>>
+  updateTheme(activeUserId: bigint, theme: Theme): Promise<Result<CurrentUser, ServerError>>
 }
 
 /**

--- a/application/packages/domain/src/user/schema/active-user-schema.test.ts
+++ b/application/packages/domain/src/user/schema/active-user-schema.test.ts
@@ -9,6 +9,7 @@ describe('ActiveUserスキーマ', () => {
         userId: 2n,
         email: 'test@example.com',
         displayName: 'テストユーザー',
+        theme: 'dark',
         authenticationId: null,
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -45,6 +46,7 @@ describe('ActiveUserスキーマ', () => {
         activeUserId: 1n,
         userId: 2n,
         email: 'test@example.com',
+        theme: 'system',
         createdAt: new Date(),
         updatedAt: new Date(),
       }
@@ -61,6 +63,20 @@ describe('ActiveUserスキーマ', () => {
       }
 
       const result = activeUserInputSchema.safeParse(invalidData)
+      expect(result.success).toBe(false)
+    })
+
+    it('themeが許可値以外では検証に失敗する', () => {
+      const invalidData = {
+        activeUserId: 1n,
+        userId: 2n,
+        email: 'test@example.com',
+        theme: 'blue',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+
+      const result = activeUserSchema.safeParse(invalidData)
       expect(result.success).toBe(false)
     })
 

--- a/application/packages/domain/src/user/schema/active-user-schema.ts
+++ b/application/packages/domain/src/user/schema/active-user-schema.ts
@@ -1,11 +1,13 @@
 import { createdAt, updatedAt } from '@trend-diary/common/schemas'
 import { z } from 'zod'
+import { themeSchema } from './theme-schema'
 
 export const activeUserSchema = z.object({
   activeUserId: z.bigint().positive(),
   userId: z.bigint().positive(),
   email: z.string().email().max(320), // RFC 5322の最大長
   displayName: z.string().max(64).optional().nullable(), // オプションで最大長64文字
+  theme: themeSchema, // 端末間で共有する画面テーマ
   authenticationId: z.string().uuid().optional().nullable(), // Supabase AuthenticationユーザーID
   createdAt,
   updatedAt,

--- a/application/packages/domain/src/user/schema/theme-schema.test.ts
+++ b/application/packages/domain/src/user/schema/theme-schema.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { themeSchema, themeUpdateSchema } from './theme-schema'
+
+describe('themeSchema', () => {
+  describe('正常系', () => {
+    it.each(['system', 'light', 'dark'])('許可値 %s を検証できる', (value) => {
+      const result = themeSchema.safeParse(value)
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('異常系', () => {
+    it.each(['blue', '', 'SYSTEM', 'auto'])('許可値以外 %s は検証に失敗する', (value) => {
+      const result = themeSchema.safeParse(value)
+      expect(result.success).toBe(false)
+    })
+  })
+})
+
+describe('themeUpdateSchema', () => {
+  describe('正常系', () => {
+    it('themeを持つオブジェクトを検証できる', () => {
+      const result = themeUpdateSchema.safeParse({ theme: 'dark' })
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe('異常系', () => {
+    it('themeが欠けている場合は検証に失敗する', () => {
+      const result = themeUpdateSchema.safeParse({})
+      expect(result.success).toBe(false)
+    })
+
+    it('themeが許可値以外の場合は検証に失敗する', () => {
+      const result = themeUpdateSchema.safeParse({ theme: 'blue' })
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/application/packages/domain/src/user/schema/theme-schema.ts
+++ b/application/packages/domain/src/user/schema/theme-schema.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+// 端末間で共有する画面テーマ。'system'はOSの配色設定に追従する
+export const themeSchema = z.enum(['system', 'light', 'dark'])
+
+export const themeUpdateSchema = z.object({
+  theme: themeSchema,
+})
+
+export type Theme = z.infer<typeof themeSchema>
+export type ThemeUpdate = z.infer<typeof themeUpdateSchema>

--- a/application/packages/domain/src/user/use-case.test.ts
+++ b/application/packages/domain/src/user/use-case.test.ts
@@ -43,6 +43,7 @@ const mockActiveUser: CurrentUser = {
   userId: 2n,
   email: 'test@example.com',
   displayName: 'テストユーザー',
+  theme: 'system',
   createdAt: new Date(),
   updatedAt: new Date(),
 }
@@ -378,6 +379,45 @@ describe('AuthUseCase', () => {
             expect(result.error).toBeInstanceOf(ServerError)
           }
         })
+      })
+    })
+  })
+
+  describe('updateTheme', () => {
+    describe('正常系', () => {
+      it('activeUserIdとテーマをcommandに渡し、更新後のユーザーを返す', async () => {
+        // Arrange
+        const updatedUser: CurrentUser = { ...mockActiveUser, theme: 'dark' }
+        commandMock.updateTheme.mockResolvedValue(ok(updatedUser))
+
+        // Act
+        const result = await useCase.updateTheme(mockActiveUser.activeUserId, 'dark')
+
+        // Assert
+        expect(result.isOk()).toBe(true)
+        if (result.isOk()) {
+          expect(result.value.theme).toBe('dark')
+        }
+        expect(commandMock.updateTheme).toHaveBeenCalledWith(mockActiveUser.activeUserId, 'dark')
+        // 呼び出し側で検証済みのため、ここではセッションを再検証しない
+        expect(repositoryMock.verifySession).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('異常系', () => {
+      it('command失敗時、エラーを返す', async () => {
+        // Arrange
+        const dbError = new ServerError('Failed to update theme')
+        commandMock.updateTheme.mockResolvedValue(err(dbError))
+
+        // Act
+        const result = await useCase.updateTheme(mockActiveUser.activeUserId, 'light')
+
+        // Assert
+        expect(result.isErr()).toBe(true)
+        if (result.isErr()) {
+          expect(result.error).toBe(dbError)
+        }
       })
     })
   })

--- a/application/packages/domain/src/user/use-case.ts
+++ b/application/packages/domain/src/user/use-case.ts
@@ -8,6 +8,7 @@ import type {
   PasskeyRegistrationResult,
   PasskeyVerifyInput,
 } from './schema/auth-schema'
+import type { Theme } from './schema/theme-schema'
 
 /**
  * サインアップ結果
@@ -104,6 +105,15 @@ export class AuthUseCase {
     }
 
     return this.findActiveUserByAuthenticationId(sessionResult.value.authenticationId)
+  }
+
+  // 呼び出し側(authenticatorミドルウェア)でセッション検証済みのactiveUserIdを受け取る。
+  // ここで再度セッション検証すると、トークン期限切れ時にリフレッシュが二重に走り得るため行わない
+  async updateTheme(
+    activeUserId: bigint,
+    theme: Theme,
+  ): Promise<Result<CurrentUser, ClientError | ServerError>> {
+    return this.userCommand.updateTheme(activeUserId, theme)
   }
 
   async startPasskeyRegistration(): Promise<Result<PasskeyChallenge, ServerError>> {


### PR DESCRIPTION
<!-- Product Backlogから参照できるようにする -->

# 概要
- close: <!-- #{issue番号} -->
- テーマ設定（システム / ライト / ダーク）をログインユーザーに紐づけてサーバー保存し、別端末でも同じ配色で表示されるようにする
- これまでは `next-themes` の `localStorage` のみで保持しており、端末ごとに設定が独立していた。ログインユーザーに紐づけて永続化することで端末間同期を実現する

### 変更点
- **datastore**: `active_users` に `theme` カラムを追加（既定 `'system'`）。マイグレーション `0007_shocking_wilson_fisk.sql` を追加
- **domain**: `themeSchema` / `themeUpdateSchema` を追加、`activeUserSchema` に `theme` を追加。`AuthUseCase.updateTheme` と `Command.updateTheme` を追加
- **server**: `GET /auth/me` レスポンスに `theme` を含め、`PUT /auth/me/theme`（要認証）を新設。`SessionUser` に `theme` を追加
- **client**: 読み込み時にサーバー値を `next-themes` へ反映する `ThemeSync` を全体レイアウトに追加し、`ThemeToggle` 変更時にサーバーへも保存する（`useThemePreference`）

## 動作確認(スクリーンショットなど)

- 設定画面でテーマを変更 → サーバーに保存され、別端末（別セッション）で再読み込みすると同じテーマが適用されることを想定
- DOM への適用は従来どおり `next-themes`（`<html>` の `.dark` クラス）が担い、その上にサーバー永続化を重ねる構成
- 新規端末での適用は `localStorage` の値を先に描画し、`/me` 取得後にサーバー値へ収束する（差異がある場合は一瞬切り替わり得る）

### UIテスト
<!-- 特になし -->

## レビュー観点

### 内部品質
- **テスト**: 仕様をテストに記載する方針に沿い、以下を追加・更新
  - domain: `theme-schema` / `active-user-schema` / `use-case`(`updateTheme`) / `command-impl`(`updateTheme`) / `query-impl` / `mapper`
  - web(client): `use-theme-preference` / `theme-toggle` / `theme-sync`
  - web(server): `update-theme`（統合）、`me`（`theme` 応答）。既存の `SessionUser` / `CurrentUser` モックに `theme` を追加
  - domain・client・モック系サーバーテストはローカルで通過。Supabase / D1 を要する統合テスト（`update-theme` 等）はローカル環境で Docker 不可のため未実行で、CI での実行を想定
- **アーキテクチャ**: 既存の passkey（設定トグル）/ `/me` の実装パターンに合わせ、`updateTheme` は authenticator で検証済みの `activeUserId` を用いてセッションの二重検証を避けている

### 外部品質
- **セキュリティ**: `PUT /auth/me/theme` は `authenticator` + `zodValidator('json', themeUpdateSchema)` を適用。テーマは列挙値に制限し、更新対象は認証済みユーザー自身に限定

## その他・参考情報
- SQLite の `ALTER TABLE ADD` により物理カラムは末尾に追加されるが、drizzle は select/returning でカラムを明示列挙するためスキーマ定義順で正しくマッピングされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019cixcXDvQLrrH4NL4yUf6m)_