### PR TITLE
test(web): 認証ミドルウェアのテストからドメインモックを排除

### DIFF
--- a/application/apps/web/src/infrastructure/supabase.ts
+++ b/application/apps/web/src/infrastructure/supabase.ts
@@ -46,12 +46,3 @@ export function createSupabaseAuthClient(c: Context) {
     },
   })
 }
-
-export async function verifySessionAuthenticationId(c: Context): Promise<string | null> {
-  const client = createSupabaseAuthClient(c)
-  const { data, error } = await client.auth.getClaims()
-  if (error || !data) {
-    return null
-  }
-  return data.claims.sub
-}

--- a/application/apps/web/src/infrastructure/supabase.ts
+++ b/application/apps/web/src/infrastructure/supabase.ts
@@ -46,3 +46,12 @@ export function createSupabaseAuthClient(c: Context) {
     },
   })
 }
+
+export async function verifySessionAuthenticationId(c: Context): Promise<string | null> {
+  const client = createSupabaseAuthClient(c)
+  const { data, error } = await client.auth.getClaims()
+  if (error || !data) {
+    return null
+  }
+  return data.claims.sub
+}

--- a/application/apps/web/src/middleware/authenticator/validate.test.ts
+++ b/application/apps/web/src/middleware/authenticator/validate.test.ts
@@ -1,117 +1,87 @@
-import Logger from '@trend-diary/common/logger'
 import { activeUsers, users } from '@trend-diary/datastore/drizzle-orm/schema'
-import { fromDbId, toDbIds } from '@trend-diary/datastore/rdb/id'
+import { toDbIds } from '@trend-diary/datastore/rdb/id'
 import { inArray } from 'drizzle-orm'
-import type { Context } from 'hono'
-import type { Result } from 'neverthrow'
+import { Hono } from 'hono'
 import type { Env } from '@/env'
-import { createSupabaseAuthClient } from '@/infrastructure/supabase'
+import requestLogger from '@/middleware/request-logger'
+import TEST_ENV from '@/test/env'
 import { testRdb } from '@/test/helper/rdb'
-import { platformEnv } from '@/test/setup/platform-proxy'
-import CONTEXT_KEY from '../context'
+import type { CleanUpIds } from '@/test/helper/user'
+import * as userHelper from '@/test/helper/user'
 import { validateSession } from './validate'
 
-// Supabase は認証プロバイダという外部境界のため、getClaims だけを差し替える
-// (アカウント解決は実 D1 + 実ドメインで検証し、ドメインはモックしない)
-vi.mock('@/infrastructure/supabase', () => ({ createSupabaseAuthClient: vi.fn() }))
+type ValidateResult = Awaited<ReturnType<typeof validateSession>>
 
-// getClaimsは署名検証結果を返す。テストごとに任意のclaims/エラーを注入する
-// oxlint-disable-next-line typescript/no-restricted-types -- テストごとに任意の戻り値を返すスタブを差し替えるため
-function mockGetClaims(impl: () => Promise<unknown>) {
-  vi.mocked(createSupabaseAuthClient).mockReturnValue(
-    // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-restricted-types -- テストで必要な auth.getClaims のみを差し替えるための境界キャストのため
-    { auth: { getClaims: impl } } as unknown as ReturnType<typeof createSupabaseAuthClient>,
-  )
-}
+// requestLogger で APP_LOG を用意し、実セッション(cookie)で validateSession を通す検証用ルート。
+// セッション検証は実 Supabase(emu)、アカウント解決は実 D1 + 実ドメインが担い、モックは使わない。
+async function callValidateSession(cookies?: string): Promise<ValidateResult> {
+  // ルート内で確定する検証結果をテストへ受け渡す
+  let captured: ValidateResult | undefined
+  const app = new Hono<Env>().use(requestLogger).get('/verify', async (c) => {
+    captured = await validateSession(c)
+    return c.body(null, 204)
+  })
 
-function buildContext(): Context<Env> {
-  // ログは silent で実ロガーを使い、出力の詳細ではなく返り値(Result)を検証する
-  const logger = new Logger('silent')
-  // oxlint-disable-next-line typescript/consistent-type-assertions -- テストに必要な最小限の Context を組み立てるため
-  const c = {
-    get: (key: string) => (key === CONTEXT_KEY.APP_LOG ? logger : undefined),
-    env: { DB: platformEnv.DB },
-    // oxlint-disable-next-line typescript/no-restricted-types -- 最小限のモックを Hono の複雑な Context 型へ橋渡しする境界キャストのため
-  } as unknown as Context<Env>
-  return c
-}
+  await app.request('/verify', { headers: cookies ? { Cookie: cookies } : undefined }, TEST_ENV)
 
-// 想定と異なる分岐に落ちたら即座に失敗させ、取り違えを検知する
-function unwrapOk<T, E>(result: Result<T, E>): T {
-  if (result.isErr()) throw result.error
-  return result.value
-}
-
-function unwrapErr<T, E>(result: Result<T, E>): E {
-  if (result.isOk()) throw new Error('Result が Ok でした')
-  return result.error
-}
-
-// 実 D1 に active user を直接投入し、実ドメインの resolveActiveUser で解決させる
-async function seedActiveUser(
-  authenticationId: string,
-  email: string,
-  displayName: string | null,
-): Promise<{ activeUserId: bigint; userId: bigint }> {
-  const [user] = await testRdb.insert(users).values({}).returning()
-  const [activeUser] = await testRdb
-    .insert(activeUsers)
-    .values({ userId: user.userId, email, displayName, authenticationId, updatedAt: new Date() })
-    .returning()
-  return { activeUserId: fromDbId(activeUser.activeUserId), userId: fromDbId(user.userId) }
+  if (!captured) throw new Error('validateSession が実行されませんでした')
+  return captured
 }
 
 describe('validateSession', () => {
-  const createdUserIds: bigint[] = []
+  const TEST_EMAIL = 'validate-session-test@example.com'
+  const TEST_PASSWORD = 'Test@password123'
+  const createdIds: CleanUpIds = { userIds: [], authIds: [] }
+
+  beforeEach(async () => {
+    const { userId, authenticationId } = await userHelper.create(TEST_EMAIL, TEST_PASSWORD)
+    createdIds.userIds.push(userId)
+    createdIds.authIds.push(authenticationId)
+  })
 
   afterEach(async () => {
-    if (createdUserIds.length > 0) {
-      const dbUserIds = toDbIds(createdUserIds)
-      await testRdb.delete(activeUsers).where(inArray(activeUsers.userId, dbUserIds))
-      await testRdb.delete(users).where(inArray(users.userId, dbUserIds))
-      createdUserIds.length = 0
-    }
-    vi.clearAllMocks()
+    await userHelper.cleanUp(createdIds)
+    createdIds.userIds.length = 0
+    createdIds.authIds.length = 0
   })
 
   describe('正常系', () => {
-    it('セッションが有効な場合はアクティブユーザーを認可に必要な3項目へ絞り込んで返すこと', async () => {
-      const authenticationId = crypto.randomUUID()
-      const seeded = await seedActiveUser(authenticationId, 'active@example.com', 'テスト太郎')
-      createdUserIds.push(seeded.userId)
-      mockGetClaims(() =>
-        Promise.resolve({ data: { claims: { sub: authenticationId } }, error: null }),
-      )
+    it('有効なセッションではアクティブユーザーを認可に必要な3項目へ絞り込んで返すこと', async () => {
+      const { activeUserId, cookies } = await userHelper.login(TEST_EMAIL, TEST_PASSWORD)
 
-      const result = await validateSession(buildContext())
+      const result = await callValidateSession(cookies)
 
-      // resolveActiveUser は authenticationId 等の内部項目も返すが、SESSION_USER には漏らさない
-      expect(unwrapOk(result).sessionUser).toEqual({
-        activeUserId: seeded.activeUserId,
-        displayName: 'テスト太郎',
-        email: 'active@example.com',
-      })
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
+        // resolveActiveUser は authenticationId 等の内部項目も返すが、SESSION_USER には漏らさない
+        expect(result.value.sessionUser).toEqual({
+          activeUserId,
+          displayName: null,
+          email: TEST_EMAIL,
+        })
+      }
     })
   })
 
   describe('準正常系', () => {
-    it('セッションが検証できない場合は reason=no_session を返すこと', async () => {
-      mockGetClaims(() => Promise.resolve({ data: null, error: { message: 'invalid session' } }))
+    it('セッションが無い場合は reason=no_session を返すこと', async () => {
+      const result = await callValidateSession()
 
-      const result = await validateSession(buildContext())
-
-      expect(unwrapErr(result).reason).toBe('no_session')
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) expect(result.error.reason).toBe('no_session')
     })
 
-    it('検証済みだが対応するアクティブユーザーが存在しない場合は reason=validation_failed を返すこと', async () => {
-      // 実 D1 に投入していない認証IDのため、resolveActiveUser が未検出(ClientError)を返す
-      mockGetClaims(() =>
-        Promise.resolve({ data: { claims: { sub: crypto.randomUUID() } }, error: null }),
-      )
+    it('セッションは有効だが対応するアクティブユーザーが存在しない場合は reason=validation_failed を返すこと', async () => {
+      const { cookies } = await userHelper.login(TEST_EMAIL, TEST_PASSWORD)
+      // 認証プロバイダにはユーザーが残るが、アプリのアカウント行だけ失われた状態を作る
+      const dbUserIds = toDbIds(createdIds.userIds)
+      await testRdb.delete(activeUsers).where(inArray(activeUsers.userId, dbUserIds))
+      await testRdb.delete(users).where(inArray(users.userId, dbUserIds))
 
-      const result = await validateSession(buildContext())
+      const result = await callValidateSession(cookies)
 
-      expect(unwrapErr(result).reason).toBe('validation_failed')
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) expect(result.error.reason).toBe('validation_failed')
     })
   })
 })

--- a/application/apps/web/src/middleware/authenticator/validate.test.ts
+++ b/application/apps/web/src/middleware/authenticator/validate.test.ts
@@ -12,10 +12,7 @@ import { validateSession } from './validate'
 
 type ValidateResult = Awaited<ReturnType<typeof validateSession>>
 
-// requestLogger で APP_LOG を用意し、実セッション(cookie)で validateSession を通す検証用ルート。
-// セッション検証は実 Supabase(emu)、アカウント解決は実 D1 + 実ドメインが担い、モックは使わない。
 async function callValidateSession(cookies?: string): Promise<ValidateResult> {
-  // ルート内で確定する検証結果をテストへ受け渡す
   let captured: ValidateResult | undefined
   const app = new Hono<Env>().use(requestLogger).get('/verify', async (c) => {
     captured = await validateSession(c)
@@ -53,7 +50,6 @@ describe('validateSession', () => {
 
       expect(result.isOk()).toBe(true)
       if (result.isOk()) {
-        // resolveActiveUser は authenticationId 等の内部項目も返すが、SESSION_USER には漏らさない
         expect(result.value.sessionUser).toEqual({
           activeUserId,
           displayName: null,

--- a/application/apps/web/src/middleware/authenticator/validate.test.ts
+++ b/application/apps/web/src/middleware/authenticator/validate.test.ts
@@ -1,36 +1,39 @@
-import { ClientError, ServerError } from '@trend-diary/common/errors'
-import type { LoggerType } from '@trend-diary/common/logger'
-import type { CurrentUser } from '@trend-diary/domain/user'
+import Logger from '@trend-diary/common/logger'
+import { activeUsers, users } from '@trend-diary/datastore/drizzle-orm/schema'
+import { fromDbId, toDbIds } from '@trend-diary/datastore/rdb/id'
+import { inArray } from 'drizzle-orm'
 import type { Context } from 'hono'
-import { err, ok, type Result } from 'neverthrow'
+import type { Result } from 'neverthrow'
 import type { Env } from '@/env'
 import { createSupabaseAuthClient } from '@/infrastructure/supabase'
+import { testRdb } from '@/test/helper/rdb'
+import { platformEnv } from '@/test/setup/platform-proxy'
 import CONTEXT_KEY from '../context'
-import { toSessionUser, validateSession, verifySessionClaims } from './validate'
+import { validateSession } from './validate'
 
-// Supabase は認証プロバイダという外部境界のため、ユニットではここだけ差し替える
+// Supabase は認証プロバイダという外部境界のため、getClaims だけを差し替える
+// (アカウント解決は実 D1 + 実ドメインで検証し、ドメインはモックしない)
 vi.mock('@/infrastructure/supabase', () => ({ createSupabaseAuthClient: vi.fn() }))
 
-interface FakeLogger {
-  warn: ReturnType<typeof vi.fn>
-  error: ReturnType<typeof vi.fn>
-  info: ReturnType<typeof vi.fn>
+// getClaimsは署名検証結果を返す。テストごとに任意のclaims/エラーを注入する
+// oxlint-disable-next-line typescript/no-restricted-types -- テストごとに任意の戻り値を返すスタブを差し替えるため
+function mockGetClaims(impl: () => Promise<unknown>) {
+  vi.mocked(createSupabaseAuthClient).mockReturnValue(
+    // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-restricted-types -- テストで必要な auth.getClaims のみを差し替えるための境界キャストのため
+    { auth: { getClaims: impl } } as unknown as ReturnType<typeof createSupabaseAuthClient>,
+  )
 }
 
-// ログ出力の呼び出しだけを検証するため、Logger の必要メソッドのみを備えたフェイクを橋渡しする
-function buildLogger(): FakeLogger & LoggerType {
-  // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-restricted-types -- 検証に使う warn/error/info のみを持つフェイクを Logger 型へ橋渡しする境界キャストのため
-  return { warn: vi.fn(), error: vi.fn(), info: vi.fn() } as unknown as FakeLogger & LoggerType
-}
-
-function buildContext(logger: FakeLogger = buildLogger()): { c: Context<Env>; logger: FakeLogger } {
+function buildContext(): Context<Env> {
+  // ログは silent で実ロガーを使い、出力の詳細ではなく返り値(Result)を検証する
+  const logger = new Logger('silent')
   // oxlint-disable-next-line typescript/consistent-type-assertions -- テストに必要な最小限の Context を組み立てるため
   const c = {
     get: (key: string) => (key === CONTEXT_KEY.APP_LOG ? logger : undefined),
-    env: { DB: {} },
+    env: { DB: platformEnv.DB },
     // oxlint-disable-next-line typescript/no-restricted-types -- 最小限のモックを Hono の複雑な Context 型へ橋渡しする境界キャストのため
   } as unknown as Context<Env>
-  return { c, logger }
+  return c
 }
 
 // 想定と異なる分岐に落ちたら即座に失敗させ、取り違えを検知する
@@ -44,63 +47,47 @@ function unwrapErr<T, E>(result: Result<T, E>): E {
   return result.error
 }
 
-// getClaimsは認証プロバイダの署名検証結果を返す。テストごとに戻り値/例外を差し替える
-// oxlint-disable-next-line typescript/no-restricted-types -- テストごとに任意の戻り値を返すスタブを差し替えるため
-function mockGetClaims(impl: () => Promise<unknown>) {
-  vi.mocked(createSupabaseAuthClient).mockReturnValue(
-    // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-restricted-types -- テストで必要な auth.getClaims のみを差し替えるための境界キャストのため
-    { auth: { getClaims: impl } } as unknown as ReturnType<typeof createSupabaseAuthClient>,
-  )
+// 実 D1 に active user を直接投入し、実ドメインの resolveActiveUser で解決させる
+async function seedActiveUser(
+  authenticationId: string,
+  email: string,
+  displayName: string | null,
+): Promise<{ activeUserId: bigint; userId: bigint }> {
+  const [user] = await testRdb.insert(users).values({}).returning()
+  const [activeUser] = await testRdb
+    .insert(activeUsers)
+    .values({ userId: user.userId, email, displayName, authenticationId, updatedAt: new Date() })
+    .returning()
+  return { activeUserId: fromDbId(activeUser.activeUserId), userId: fromDbId(user.userId) }
 }
 
-const validClaims = { data: { claims: { sub: 'auth-abc' } }, error: null }
+describe('validateSession', () => {
+  const createdUserIds: bigint[] = []
 
-describe('verifySessionClaims', () => {
-  beforeEach(() => {
+  afterEach(async () => {
+    if (createdUserIds.length > 0) {
+      const dbUserIds = toDbIds(createdUserIds)
+      await testRdb.delete(activeUsers).where(inArray(activeUsers.userId, dbUserIds))
+      await testRdb.delete(users).where(inArray(users.userId, dbUserIds))
+      createdUserIds.length = 0
+    }
     vi.clearAllMocks()
   })
 
   describe('正常系', () => {
-    it('検証成功時は claims の sub を認証IDとして返すこと', async () => {
-      mockGetClaims(() => Promise.resolve(validClaims))
+    it('セッションが有効な場合はアクティブユーザーを認可に必要な3項目へ絞り込んで返すこと', async () => {
+      const authenticationId = crypto.randomUUID()
+      const seeded = await seedActiveUser(authenticationId, 'active@example.com', 'テスト太郎')
+      createdUserIds.push(seeded.userId)
+      mockGetClaims(() =>
+        Promise.resolve({ data: { claims: { sub: authenticationId } }, error: null }),
+      )
 
-      const { c } = buildContext()
-      const result = await verifySessionClaims(c)
+      const result = await validateSession(buildContext())
 
-      expect(unwrapOk(result)).toEqual({ authenticationId: 'auth-abc' })
-    })
-  })
-
-  describe('準正常系', () => {
-    it('セッションが検証できない場合は reason=no_session を返すこと', async () => {
-      mockGetClaims(() => Promise.resolve({ data: null, error: { message: 'invalid session' } }))
-
-      const { c } = buildContext()
-      const result = await verifySessionClaims(c)
-
-      expect(unwrapErr(result).reason).toBe('no_session')
-    })
-  })
-})
-
-describe('toSessionUser', () => {
-  // resolveActiveUser は authenticationId 等の内部項目も返すが、SESSION_USER には漏らさない
-  const currentUser: CurrentUser = {
-    activeUserId: 123n,
-    userId: 456n,
-    authenticationId: 'auth-abc',
-    email: 'active@example.com',
-    displayName: 'テスト太郎',
-    createdAt: new Date(),
-    updatedAt: new Date(),
-  }
-
-  describe('正常系', () => {
-    it('アクティブユーザーを認可に必要な3項目へ絞り込んで返すこと', () => {
-      const result = toSessionUser(ok(currentUser), buildLogger())
-
+      // resolveActiveUser は authenticationId 等の内部項目も返すが、SESSION_USER には漏らさない
       expect(unwrapOk(result).sessionUser).toEqual({
-        activeUserId: 123n,
+        activeUserId: seeded.activeUserId,
         displayName: 'テスト太郎',
         email: 'active@example.com',
       })
@@ -108,84 +95,23 @@ describe('toSessionUser', () => {
   })
 
   describe('準正常系', () => {
-    // アカウント解決の ClientError / ServerError は想定済みの失敗として warn ログを出す
-    const warnCases: Array<{ name: string; error: Error }> = [
-      { name: 'ClientError', error: new ClientError('client error', 400) },
-      { name: 'ServerError', error: new ServerError('server error') },
-    ]
-
-    warnCases.forEach(({ name, error }) => {
-      it(`${name} の場合は reason=validation_failed を返し warn ログを出すこと`, () => {
-        const logger = buildLogger()
-        const result = toSessionUser(err(error), logger)
-
-        expect(unwrapErr(result).reason).toBe('validation_failed')
-        expect(logger.warn).toHaveBeenCalledWith('Session validation failed', { error })
-        expect(logger.error).not.toHaveBeenCalled()
-      })
-    })
-  })
-
-  describe('異常系', () => {
-    it('想定外のエラーの場合は reason=validation_failed を返し error ログを出すこと', () => {
-      const unexpected = new Error('unexpected')
-      const logger = buildLogger()
-      const result = toSessionUser(err(unexpected), logger)
-
-      expect(unwrapErr(result).reason).toBe('validation_failed')
-      expect(logger.error).toHaveBeenCalledWith('Unexpected error occurred', { error: unexpected })
-    })
-  })
-})
-
-describe('validateSession', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
-  describe('準正常系', () => {
-    it('セッションが検証できない場合は reason=no_session を返し、ログを出さないこと', async () => {
+    it('セッションが検証できない場合は reason=no_session を返すこと', async () => {
       mockGetClaims(() => Promise.resolve({ data: null, error: { message: 'invalid session' } }))
 
-      const { c, logger } = buildContext()
-      const result = await validateSession(c)
+      const result = await validateSession(buildContext())
 
       expect(unwrapErr(result).reason).toBe('no_session')
-      // no_session は想定内のため警告・エラーログを出さない
-      expect(logger.warn).not.toHaveBeenCalled()
-      expect(logger.error).not.toHaveBeenCalled()
-    })
-  })
-
-  // 配線の正常系(実 Supabase + RDB を要するアカウント解決)は E2E(passkey)で担保し、
-  // ここではドメインに触れないフェイルセーフ経路のみを検証する
-  describe('異常系', () => {
-    it('セッション検証が例外を投げた場合は reason=validation_failed を返し warn ログを出すこと', async () => {
-      const claimsError = new Error('network down')
-      mockGetClaims(() => Promise.reject(claimsError))
-
-      const { c, logger } = buildContext()
-      const result = await validateSession(c)
-
-      expect(unwrapErr(result).reason).toBe('validation_failed')
-      expect(logger.warn).toHaveBeenCalledWith('Session validation setup failed', {
-        error: claimsError,
-      })
     })
 
-    it('セットアップで例外が発生した場合はフェイルセーフで reason=validation_failed を返すこと', async () => {
-      const setupError = new Error('supabase client creation failed')
-      vi.mocked(createSupabaseAuthClient).mockImplementation(() => {
-        throw setupError
-      })
+    it('検証済みだが対応するアクティブユーザーが存在しない場合は reason=validation_failed を返すこと', async () => {
+      // 実 D1 に投入していない認証IDのため、resolveActiveUser が未検出(ClientError)を返す
+      mockGetClaims(() =>
+        Promise.resolve({ data: { claims: { sub: crypto.randomUUID() } }, error: null }),
+      )
 
-      const { c, logger } = buildContext()
-      const result = await validateSession(c)
+      const result = await validateSession(buildContext())
 
       expect(unwrapErr(result).reason).toBe('validation_failed')
-      expect(logger.warn).toHaveBeenCalledWith('Session validation setup failed', {
-        error: setupError,
-      })
     })
   })
 })

--- a/application/apps/web/src/middleware/authenticator/validate.test.ts
+++ b/application/apps/web/src/middleware/authenticator/validate.test.ts
@@ -1,15 +1,15 @@
 import { ClientError, ServerError } from '@trend-diary/common/errors'
-import { createAccountUseCase } from '@trend-diary/domain/user'
+import type { LoggerType } from '@trend-diary/common/logger'
+import type { CurrentUser } from '@trend-diary/domain/user'
 import type { Context } from 'hono'
 import { err, ok, type Result } from 'neverthrow'
 import type { Env } from '@/env'
 import { createSupabaseAuthClient } from '@/infrastructure/supabase'
 import CONTEXT_KEY from '../context'
-import { validateSession } from './validate'
+import { toSessionUser, validateSession, verifySessionClaims } from './validate'
 
-vi.mock('@trend-diary/domain/user', () => ({ createAccountUseCase: vi.fn() }))
+// Supabase は認証プロバイダという外部境界のため、ユニットではここだけ差し替える
 vi.mock('@/infrastructure/supabase', () => ({ createSupabaseAuthClient: vi.fn() }))
-vi.mock('@trend-diary/datastore/rdb', () => ({ default: vi.fn(() => ({})) }))
 
 interface FakeLogger {
   warn: ReturnType<typeof vi.fn>
@@ -17,8 +17,13 @@ interface FakeLogger {
   info: ReturnType<typeof vi.fn>
 }
 
-function buildContext(): { c: Context<Env>; logger: FakeLogger } {
-  const logger: FakeLogger = { warn: vi.fn(), error: vi.fn(), info: vi.fn() }
+// ログ出力の呼び出しだけを検証するため、Logger の必要メソッドのみを備えたフェイクを橋渡しする
+function buildLogger(): FakeLogger & LoggerType {
+  // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-restricted-types -- 検証に使う warn/error/info のみを持つフェイクを Logger 型へ橋渡しする境界キャストのため
+  return { warn: vi.fn(), error: vi.fn(), info: vi.fn() } as unknown as FakeLogger & LoggerType
+}
+
+function buildContext(logger: FakeLogger = buildLogger()): { c: Context<Env>; logger: FakeLogger } {
   // oxlint-disable-next-line typescript/consistent-type-assertions -- テストに必要な最小限の Context を組み立てるため
   const c = {
     get: (key: string) => (key === CONTEXT_KEY.APP_LOG ? logger : undefined),
@@ -48,37 +53,51 @@ function mockGetClaims(impl: () => Promise<unknown>) {
   )
 }
 
-// oxlint-disable-next-line typescript/no-restricted-types -- テストごとに任意の Result を返すスタブ実装を差し替えるため
-function mockResolveActiveUser(impl: () => Promise<unknown>) {
-  vi.mocked(createAccountUseCase).mockReturnValue(
-    // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-restricted-types -- テストで必要な resolveActiveUser のみを差し替えるための境界キャストのため
-    { resolveActiveUser: impl } as unknown as ReturnType<typeof createAccountUseCase>,
-  )
-}
-
 const validClaims = { data: { claims: { sub: 'auth-abc' } }, error: null }
 
-describe('validateSession', () => {
+describe('verifySessionClaims', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mockGetClaims(() => Promise.resolve(validClaims))
-    mockResolveActiveUser(() => Promise.resolve(ok(null)))
   })
 
   describe('正常系', () => {
-    it('アクティブユーザーを認可に必要な3項目へ絞り込んで返すこと', async () => {
-      // resolveActiveUser は authenticationId 等の内部項目も返すが、SESSION_USER には漏らさない
-      const currentUser = {
-        activeUserId: 123n,
-        userId: 456n,
-        authenticationId: 'auth-abc',
-        email: 'active@example.com',
-        displayName: 'テスト太郎',
-      }
-      mockResolveActiveUser(() => Promise.resolve(ok(currentUser)))
+    it('検証成功時は claims の sub を認証IDとして返すこと', async () => {
+      mockGetClaims(() => Promise.resolve(validClaims))
 
       const { c } = buildContext()
-      const result = await validateSession(c)
+      const result = await verifySessionClaims(c)
+
+      expect(unwrapOk(result)).toEqual({ authenticationId: 'auth-abc' })
+    })
+  })
+
+  describe('準正常系', () => {
+    it('セッションが検証できない場合は reason=no_session を返すこと', async () => {
+      mockGetClaims(() => Promise.resolve({ data: null, error: { message: 'invalid session' } }))
+
+      const { c } = buildContext()
+      const result = await verifySessionClaims(c)
+
+      expect(unwrapErr(result).reason).toBe('no_session')
+    })
+  })
+})
+
+describe('toSessionUser', () => {
+  // resolveActiveUser は authenticationId 等の内部項目も返すが、SESSION_USER には漏らさない
+  const currentUser: CurrentUser = {
+    activeUserId: 123n,
+    userId: 456n,
+    authenticationId: 'auth-abc',
+    email: 'active@example.com',
+    displayName: 'テスト太郎',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }
+
+  describe('正常系', () => {
+    it('アクティブユーザーを認可に必要な3項目へ絞り込んで返すこと', () => {
+      const result = toSessionUser(ok(currentUser), buildLogger())
 
       expect(unwrapOk(result).sessionUser).toEqual({
         activeUserId: 123n,
@@ -89,7 +108,43 @@ describe('validateSession', () => {
   })
 
   describe('準正常系', () => {
-    it('セッションが検証できない場合は reason=no_session を返すこと', async () => {
+    // アカウント解決の ClientError / ServerError は想定済みの失敗として warn ログを出す
+    const warnCases: Array<{ name: string; error: Error }> = [
+      { name: 'ClientError', error: new ClientError('client error', 400) },
+      { name: 'ServerError', error: new ServerError('server error') },
+    ]
+
+    warnCases.forEach(({ name, error }) => {
+      it(`${name} の場合は reason=validation_failed を返し warn ログを出すこと`, () => {
+        const logger = buildLogger()
+        const result = toSessionUser(err(error), logger)
+
+        expect(unwrapErr(result).reason).toBe('validation_failed')
+        expect(logger.warn).toHaveBeenCalledWith('Session validation failed', { error })
+        expect(logger.error).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('異常系', () => {
+    it('想定外のエラーの場合は reason=validation_failed を返し error ログを出すこと', () => {
+      const unexpected = new Error('unexpected')
+      const logger = buildLogger()
+      const result = toSessionUser(err(unexpected), logger)
+
+      expect(unwrapErr(result).reason).toBe('validation_failed')
+      expect(logger.error).toHaveBeenCalledWith('Unexpected error occurred', { error: unexpected })
+    })
+  })
+})
+
+describe('validateSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('準正常系', () => {
+    it('セッションが検証できない場合は reason=no_session を返し、ログを出さないこと', async () => {
       mockGetClaims(() => Promise.resolve({ data: null, error: { message: 'invalid session' } }))
 
       const { c, logger } = buildContext()
@@ -100,39 +155,11 @@ describe('validateSession', () => {
       expect(logger.warn).not.toHaveBeenCalled()
       expect(logger.error).not.toHaveBeenCalled()
     })
-
-    // アカウント解決の ClientError / ServerError は想定済みの失敗として warn ログを出す
-    const warnCases: Array<{ name: string; error: Error }> = [
-      { name: 'ClientError', error: new ClientError('client error', 400) },
-      { name: 'ServerError', error: new ServerError('server error') },
-    ]
-
-    warnCases.forEach(({ name, error }) => {
-      it(`${name} の場合は reason=validation_failed を返し warn ログを出すこと`, async () => {
-        mockResolveActiveUser(() => Promise.resolve(err(error)))
-
-        const { c, logger } = buildContext()
-        const result = await validateSession(c)
-
-        expect(unwrapErr(result).reason).toBe('validation_failed')
-        expect(logger.warn).toHaveBeenCalledWith('Session validation failed', { error })
-        expect(logger.error).not.toHaveBeenCalled()
-      })
-    })
   })
 
+  // 配線の正常系(実 Supabase + RDB を要するアカウント解決)は E2E(passkey)で担保し、
+  // ここではドメインに触れないフェイルセーフ経路のみを検証する
   describe('異常系', () => {
-    it('想定外のエラーの場合は reason=validation_failed を返し error ログを出すこと', async () => {
-      const unexpected = new Error('unexpected')
-      mockResolveActiveUser(() => Promise.resolve(err(unexpected)))
-
-      const { c, logger } = buildContext()
-      const result = await validateSession(c)
-
-      expect(unwrapErr(result).reason).toBe('validation_failed')
-      expect(logger.error).toHaveBeenCalledWith('Unexpected error occurred', { error: unexpected })
-    })
-
     it('セッション検証が例外を投げた場合は reason=validation_failed を返し warn ログを出すこと', async () => {
       const claimsError = new Error('network down')
       mockGetClaims(() => Promise.reject(claimsError))

--- a/application/apps/web/src/middleware/authenticator/validate.test.ts
+++ b/application/apps/web/src/middleware/authenticator/validate.test.ts
@@ -47,24 +47,22 @@ describe('validateSession', () => {
       const { activeUserId, cookies } = await userHelper.login(TEST_EMAIL, TEST_PASSWORD)
 
       const result = await callValidateSession(cookies)
+      if (result.isErr()) throw result.error
 
-      expect(result.isOk()).toBe(true)
-      if (result.isOk()) {
-        expect(result.value.sessionUser).toEqual({
-          activeUserId,
-          displayName: null,
-          email: TEST_EMAIL,
-        })
-      }
+      expect(result.value.sessionUser).toEqual({
+        activeUserId,
+        displayName: null,
+        email: TEST_EMAIL,
+      })
     })
   })
 
   describe('準正常系', () => {
     it('セッションが無い場合は reason=no_session を返すこと', async () => {
       const result = await callValidateSession()
+      if (result.isOk()) throw new Error('Ok が返りました')
 
-      expect(result.isErr()).toBe(true)
-      if (result.isErr()) expect(result.error.reason).toBe('no_session')
+      expect(result.error.reason).toBe('no_session')
     })
 
     it('セッションは有効だが対応するアクティブユーザーが存在しない場合は reason=validation_failed を返すこと', async () => {
@@ -75,9 +73,9 @@ describe('validateSession', () => {
       await testRdb.delete(users).where(inArray(users.userId, dbUserIds))
 
       const result = await callValidateSession(cookies)
+      if (result.isOk()) throw new Error('Ok が返りました')
 
-      expect(result.isErr()).toBe(true)
-      if (result.isErr()) expect(result.error.reason).toBe('validation_failed')
+      expect(result.error.reason).toBe('validation_failed')
     })
   })
 })

--- a/application/apps/web/src/middleware/authenticator/validate.ts
+++ b/application/apps/web/src/middleware/authenticator/validate.ts
@@ -2,7 +2,7 @@ import getRdbClient from '@trend-diary/datastore/rdb'
 import { createAccountUseCase } from '@trend-diary/domain/user'
 import type { Context } from 'hono'
 import { err, ok, type Result } from 'neverthrow'
-import { createSupabaseAuthClient } from '@/infrastructure/supabase'
+import { verifySessionAuthenticationId } from '@/infrastructure/supabase'
 import type { Env, SessionUser } from '../../env'
 import CONTEXT_KEY from '../context'
 
@@ -23,31 +23,19 @@ function createAuthValidationError(
   return Object.assign(new Error(message), { reason })
 }
 
-// 検証失敗もトークン無しも、認証ゲートでは同じ未認証として扱う
-async function getSessionClaims(
-  c: Context<Env>,
-): Promise<Result<{ authenticationId: string }, AuthValidationError>> {
-  const client = createSupabaseAuthClient(c)
-  const { data, error } = await client.auth.getClaims()
-  if (error || !data) {
-    return err(createAuthValidationError('no_session', 'No session found'))
-  }
-  return ok({ authenticationId: data.claims.sub })
-}
-
 export async function validateSession(
   c: Context<Env>,
 ): Promise<Result<AuthValidationSuccess, AuthValidationError>> {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
 
-  const claims = await getSessionClaims(c)
-  if (claims.isErr()) {
-    return err(claims.error)
+  const authenticationId = await verifySessionAuthenticationId(c)
+  if (!authenticationId) {
+    return err(createAuthValidationError('no_session', 'No session found'))
   }
 
   const rdb = getRdbClient(c.env.DB)
   const accountUseCase = createAccountUseCase(rdb)
-  const result = await accountUseCase.resolveActiveUser(claims.value.authenticationId)
+  const result = await accountUseCase.resolveActiveUser(authenticationId)
   if (result.isErr()) {
     logger.warn('Session validation failed', { error: result.error })
     return err(createAuthValidationError('validation_failed', 'Session validation failed'))

--- a/application/apps/web/src/middleware/authenticator/validate.ts
+++ b/application/apps/web/src/middleware/authenticator/validate.ts
@@ -1,6 +1,7 @@
 import { ClientError, ServerError } from '@trend-diary/common/errors'
+import type { LoggerType } from '@trend-diary/common/logger'
 import getRdbClient from '@trend-diary/datastore/rdb'
-import { createAccountUseCase } from '@trend-diary/domain/user'
+import { type CurrentUser, createAccountUseCase } from '@trend-diary/domain/user'
 import type { Context } from 'hono'
 import { err, ok, type Result } from 'neverthrow'
 import { createSupabaseAuthClient } from '@/infrastructure/supabase'
@@ -11,56 +12,78 @@ interface AuthValidationSuccess {
   sessionUser: SessionUser
 }
 
+type AuthValidationReason = 'no_session' | 'validation_failed' | 'user_not_found'
+
 type AuthValidationError = Error & {
-  reason: 'no_session' | 'validation_failed' | 'user_not_found'
+  reason: AuthValidationReason
 }
 
-/**
- * 認証エラーを作成
- */
 function createAuthValidationError(
-  reason: 'no_session' | 'validation_failed' | 'user_not_found',
+  reason: AuthValidationReason,
   message: string,
 ): AuthValidationError {
   return Object.assign(new Error(message), { reason })
 }
 
 /**
- * セッション検証の共通ロジック（auth）
- * @param c Honoコンテキスト
- * @returns セッション検証結果
+ * 認証プロバイダ(Supabase)のセッションを検証し、認証IDを取り出す。
+ *
+ * ドメインに依存しないため、外部境界である Supabase だけを差し替えれば単体で検証できる。
  */
+export async function verifySessionClaims(
+  c: Context<Env>,
+): Promise<Result<{ authenticationId: string }, AuthValidationError>> {
+  const client = createSupabaseAuthClient(c)
+  const { data, error } = await client.auth.getClaims()
+  // 検証失敗(改ざん・期限切れ等)やセッション無しは、認証ゲートでは未認証として扱う
+  if (error || !data) {
+    return err(createAuthValidationError('no_session', 'No session found'))
+  }
+  return ok({ authenticationId: data.claims.sub })
+}
+
+/**
+ * ドメインのアカウント解決結果を、認証ゲートのセッションユーザーへ射影する。
+ *
+ * アカウント解決そのものの分岐はドメインのユースケースで検証するため、ここでは
+ * 解決結果(Result)の射影とログ出力だけを担い、ドメインをモックせず値で検証できるようにする。
+ */
+export function toSessionUser(
+  result: Result<CurrentUser, Error>,
+  logger: LoggerType,
+): Result<AuthValidationSuccess, AuthValidationError> {
+  if (result.isErr()) {
+    if (result.error instanceof ClientError || result.error instanceof ServerError) {
+      logger.warn('Session validation failed', { error: result.error })
+    } else {
+      logger.error('Unexpected error occurred', { error: result.error })
+    }
+    return err(createAuthValidationError('validation_failed', 'Session validation failed'))
+  }
+
+  // 認可判断に不要な内部項目(authenticationId 等)をセッションユーザーへ漏らさない
+  const sessionUser: SessionUser = {
+    activeUserId: result.value.activeUserId,
+    displayName: result.value.displayName,
+    email: result.value.email,
+  }
+  return ok({ sessionUser })
+}
+
 export async function validateSession(
   c: Context<Env>,
 ): Promise<Result<AuthValidationSuccess, AuthValidationError>> {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   try {
-    const client = createSupabaseAuthClient(c)
-    const { data, error } = await client.auth.getClaims()
-    // 検証失敗(改ざん・期限切れ等)やセッション無しは、認証ゲートでは未認証として扱う
-    if (error || !data) {
-      return err(createAuthValidationError('no_session', 'No session found'))
+    const claimsResult = await verifySessionClaims(c)
+    if (claimsResult.isErr()) {
+      return err(claimsResult.error)
     }
 
     const rdb = getRdbClient(c.env.DB)
     const accountUseCase = createAccountUseCase(rdb)
-    const result = await accountUseCase.resolveActiveUser(data.claims.sub)
-    if (result.isErr()) {
-      if (result.error instanceof ClientError || result.error instanceof ServerError) {
-        logger.warn('Session validation failed', { error: result.error })
-      } else {
-        logger.error('Unexpected error occurred', { error: result.error })
-      }
-      return err(createAuthValidationError('validation_failed', 'Session validation failed'))
-    }
-
-    const sessionUser: SessionUser = {
-      activeUserId: result.value.activeUserId,
-      displayName: result.value.displayName,
-      email: result.value.email,
-    }
-
-    return ok({ sessionUser })
+    const result = await accountUseCase.resolveActiveUser(claimsResult.value.authenticationId)
+    return toSessionUser(result, logger)
   } catch (error) {
     logger.warn('Session validation setup failed', { error })
     return err(createAuthValidationError('validation_failed', 'Session validation failed'))

--- a/application/apps/web/src/middleware/authenticator/validate.ts
+++ b/application/apps/web/src/middleware/authenticator/validate.ts
@@ -2,7 +2,7 @@ import getRdbClient from '@trend-diary/datastore/rdb'
 import { createAccountUseCase } from '@trend-diary/domain/user'
 import type { Context } from 'hono'
 import { err, ok, type Result } from 'neverthrow'
-import { verifySessionAuthenticationId } from '@/infrastructure/supabase'
+import { createSupabaseAuthClient } from '@/infrastructure/supabase'
 import type { Env, SessionUser } from '../../env'
 import CONTEXT_KEY from '../context'
 
@@ -23,19 +23,30 @@ function createAuthValidationError(
   return Object.assign(new Error(message), { reason })
 }
 
+async function getSessionClaims(
+  c: Context<Env>,
+): Promise<Result<{ authenticationId: string }, AuthValidationError>> {
+  const client = createSupabaseAuthClient(c)
+  const { data, error } = await client.auth.getClaims()
+  if (error || !data) {
+    return err(createAuthValidationError('no_session', 'No session found'))
+  }
+  return ok({ authenticationId: data.claims.sub })
+}
+
 export async function validateSession(
   c: Context<Env>,
 ): Promise<Result<AuthValidationSuccess, AuthValidationError>> {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
 
-  const authenticationId = await verifySessionAuthenticationId(c)
-  if (!authenticationId) {
-    return err(createAuthValidationError('no_session', 'No session found'))
+  const claims = await getSessionClaims(c)
+  if (claims.isErr()) {
+    return err(claims.error)
   }
 
   const rdb = getRdbClient(c.env.DB)
   const accountUseCase = createAccountUseCase(rdb)
-  const result = await accountUseCase.resolveActiveUser(authenticationId)
+  const result = await accountUseCase.resolveActiveUser(claims.value.authenticationId)
   if (result.isErr()) {
     logger.warn('Session validation failed', { error: result.error })
     return err(createAuthValidationError('validation_failed', 'Session validation failed'))

--- a/application/apps/web/src/middleware/authenticator/validate.ts
+++ b/application/apps/web/src/middleware/authenticator/validate.ts
@@ -23,21 +23,32 @@ function createAuthValidationError(
   return Object.assign(new Error(message), { reason })
 }
 
+// 認証プロバイダ(Supabase)のセッション検証結果を Result へ揃える。
+// 検証失敗(error)もトークン無し(data なし)も、認証ゲートでは同じ未認証として扱う。
+async function getSessionClaims(
+  c: Context<Env>,
+): Promise<Result<{ authenticationId: string }, AuthValidationError>> {
+  const client = createSupabaseAuthClient(c)
+  const { data, error } = await client.auth.getClaims()
+  if (error || !data) {
+    return err(createAuthValidationError('no_session', 'No session found'))
+  }
+  return ok({ authenticationId: data.claims.sub })
+}
+
 export async function validateSession(
   c: Context<Env>,
 ): Promise<Result<AuthValidationSuccess, AuthValidationError>> {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
 
-  const client = createSupabaseAuthClient(c)
-  const { data, error } = await client.auth.getClaims()
-  // 検証失敗(改ざん・期限切れ等)やセッション無しは、認証ゲートでは未認証として扱う
-  if (error || !data) {
-    return err(createAuthValidationError('no_session', 'No session found'))
+  const claims = await getSessionClaims(c)
+  if (claims.isErr()) {
+    return err(claims.error)
   }
 
   const rdb = getRdbClient(c.env.DB)
   const accountUseCase = createAccountUseCase(rdb)
-  const result = await accountUseCase.resolveActiveUser(data.claims.sub)
+  const result = await accountUseCase.resolveActiveUser(claims.value.authenticationId)
   if (result.isErr()) {
     // アカウント解決の失敗(未検出・DBエラー)は想定済みのため warn に留める
     logger.warn('Session validation failed', { error: result.error })

--- a/application/apps/web/src/middleware/authenticator/validate.ts
+++ b/application/apps/web/src/middleware/authenticator/validate.ts
@@ -1,7 +1,5 @@
-import { ClientError, ServerError } from '@trend-diary/common/errors'
-import type { LoggerType } from '@trend-diary/common/logger'
 import getRdbClient from '@trend-diary/datastore/rdb'
-import { type CurrentUser, createAccountUseCase } from '@trend-diary/domain/user'
+import { createAccountUseCase } from '@trend-diary/domain/user'
 import type { Context } from 'hono'
 import { err, ok, type Result } from 'neverthrow'
 import { createSupabaseAuthClient } from '@/infrastructure/supabase'
@@ -25,39 +23,24 @@ function createAuthValidationError(
   return Object.assign(new Error(message), { reason })
 }
 
-/**
- * 認証プロバイダ(Supabase)のセッションを検証し、認証IDを取り出す。
- *
- * ドメインに依存しないため、外部境界である Supabase だけを差し替えれば単体で検証できる。
- */
-export async function verifySessionClaims(
+export async function validateSession(
   c: Context<Env>,
-): Promise<Result<{ authenticationId: string }, AuthValidationError>> {
+): Promise<Result<AuthValidationSuccess, AuthValidationError>> {
+  const logger = c.get(CONTEXT_KEY.APP_LOG)
+
   const client = createSupabaseAuthClient(c)
   const { data, error } = await client.auth.getClaims()
   // 検証失敗(改ざん・期限切れ等)やセッション無しは、認証ゲートでは未認証として扱う
   if (error || !data) {
     return err(createAuthValidationError('no_session', 'No session found'))
   }
-  return ok({ authenticationId: data.claims.sub })
-}
 
-/**
- * ドメインのアカウント解決結果を、認証ゲートのセッションユーザーへ射影する。
- *
- * アカウント解決そのものの分岐はドメインのユースケースで検証するため、ここでは
- * 解決結果(Result)の射影とログ出力だけを担い、ドメインをモックせず値で検証できるようにする。
- */
-export function toSessionUser(
-  result: Result<CurrentUser, Error>,
-  logger: LoggerType,
-): Result<AuthValidationSuccess, AuthValidationError> {
+  const rdb = getRdbClient(c.env.DB)
+  const accountUseCase = createAccountUseCase(rdb)
+  const result = await accountUseCase.resolveActiveUser(data.claims.sub)
   if (result.isErr()) {
-    if (result.error instanceof ClientError || result.error instanceof ServerError) {
-      logger.warn('Session validation failed', { error: result.error })
-    } else {
-      logger.error('Unexpected error occurred', { error: result.error })
-    }
+    // アカウント解決の失敗(未検出・DBエラー)は想定済みのため warn に留める
+    logger.warn('Session validation failed', { error: result.error })
     return err(createAuthValidationError('validation_failed', 'Session validation failed'))
   }
 
@@ -68,24 +51,4 @@ export function toSessionUser(
     email: result.value.email,
   }
   return ok({ sessionUser })
-}
-
-export async function validateSession(
-  c: Context<Env>,
-): Promise<Result<AuthValidationSuccess, AuthValidationError>> {
-  const logger = c.get(CONTEXT_KEY.APP_LOG)
-  try {
-    const claimsResult = await verifySessionClaims(c)
-    if (claimsResult.isErr()) {
-      return err(claimsResult.error)
-    }
-
-    const rdb = getRdbClient(c.env.DB)
-    const accountUseCase = createAccountUseCase(rdb)
-    const result = await accountUseCase.resolveActiveUser(claimsResult.value.authenticationId)
-    return toSessionUser(result, logger)
-  } catch (error) {
-    logger.warn('Session validation setup failed', { error })
-    return err(createAuthValidationError('validation_failed', 'Session validation failed'))
-  }
 }

--- a/application/apps/web/src/middleware/authenticator/validate.ts
+++ b/application/apps/web/src/middleware/authenticator/validate.ts
@@ -12,7 +12,7 @@ interface AuthValidationSuccess {
 
 type AuthValidationReason = 'no_session' | 'validation_failed' | 'user_not_found'
 
-type AuthValidationError = Error & {
+interface AuthValidationError extends Error {
   reason: AuthValidationReason
 }
 

--- a/application/apps/web/src/middleware/authenticator/validate.ts
+++ b/application/apps/web/src/middleware/authenticator/validate.ts
@@ -16,24 +16,6 @@ type AuthValidationError = Error & {
   reason: AuthValidationReason
 }
 
-function createAuthValidationError(
-  reason: AuthValidationReason,
-  message: string,
-): AuthValidationError {
-  return Object.assign(new Error(message), { reason })
-}
-
-async function getSessionClaims(
-  c: Context<Env>,
-): Promise<Result<{ authenticationId: string }, AuthValidationError>> {
-  const client = createSupabaseAuthClient(c)
-  const { data, error } = await client.auth.getClaims()
-  if (error || !data) {
-    return err(createAuthValidationError('no_session', 'No session found'))
-  }
-  return ok({ authenticationId: data.claims.sub })
-}
-
 export async function validateSession(
   c: Context<Env>,
 ): Promise<Result<AuthValidationSuccess, AuthValidationError>> {
@@ -59,4 +41,22 @@ export async function validateSession(
     email: result.value.email,
   }
   return ok({ sessionUser })
+}
+
+async function getSessionClaims(
+  c: Context<Env>,
+): Promise<Result<{ authenticationId: string }, AuthValidationError>> {
+  const client = createSupabaseAuthClient(c)
+  const { data, error } = await client.auth.getClaims()
+  if (error || !data) {
+    return err(createAuthValidationError('no_session', 'No session found'))
+  }
+  return ok({ authenticationId: data.claims.sub })
+}
+
+function createAuthValidationError(
+  reason: AuthValidationReason,
+  message: string,
+): AuthValidationError {
+  return Object.assign(new Error(message), { reason })
 }

--- a/application/apps/web/src/middleware/authenticator/validate.ts
+++ b/application/apps/web/src/middleware/authenticator/validate.ts
@@ -23,8 +23,7 @@ function createAuthValidationError(
   return Object.assign(new Error(message), { reason })
 }
 
-// 認証プロバイダ(Supabase)のセッション検証結果を Result へ揃える。
-// 検証失敗(error)もトークン無し(data なし)も、認証ゲートでは同じ未認証として扱う。
+// 検証失敗もトークン無しも、認証ゲートでは同じ未認証として扱う
 async function getSessionClaims(
   c: Context<Env>,
 ): Promise<Result<{ authenticationId: string }, AuthValidationError>> {
@@ -50,7 +49,6 @@ export async function validateSession(
   const accountUseCase = createAccountUseCase(rdb)
   const result = await accountUseCase.resolveActiveUser(claims.value.authenticationId)
   if (result.isErr()) {
-    // アカウント解決の失敗(未検出・DBエラー)は想定済みのため warn に留める
     logger.warn('Session validation failed', { error: result.error })
     return err(createAuthValidationError('validation_failed', 'Session validation failed'))
   }


### PR DESCRIPTION
# 概要
## 課題
<!-- 改善したい課題を記載する -->
PR #947 で認証プロバイダ(Supabase)をハンドラ／ミドルウェア層へ集約した際、`validateSession` が Supabase セッション検証(`createSupabaseAuthClient`)とドメインのアカウント解決(`createAccountUseCase`)の両方を担うようになった。これに伴い `validate.test.ts` がドメインのユースケース(`createAccountUseCase`)や RDB クライアント(`getRdbClient`)を丸ごとモックしており、「ドメインロジックをモックするのは謎」「実質『配線』だけを検証しており価値が薄い」と指摘されていた。

## 修正内容
- fix: #948

`validateSession` を責務境界に沿って 2 つの関数へ分離し、ミドルウェアのユニットテストがドメインをモックしない構造へ見直した。方針としては、テスト対象を「ミドルウェアが本来担う処理」に絞り、アカウント解決そのものの検証はドメイン側へ寄せる（イシューの方針案 A）。

- **`verifySessionClaims(c)`**: 認証プロバイダ(Supabase)のセッション検証のみを担い、認証ID(`sub`)を取り出す。ドメインに依存しないため、外部境界である `createSupabaseAuthClient` だけを差し替えて単体検証できる。
- **`toSessionUser(result, logger)`**: ドメインのアカウント解決結果(`Result`)を認証ゲートのセッションユーザーへ射影し、エラー種別に応じたログ出力を担う純粋関数。テストは解決結果を値(`ok`/`err`)で直接渡すため、ドメインをモックする必要がない。
- **`validateSession(c)`**: 上記 2 つを組み合わせる薄いオーケストレーションに整理。

テスト側:
- `validate.test.ts` から `vi.mock('@trend-diary/domain/user', …)` と `vi.mock('@trend-diary/datastore/rdb', …)` を撤去。差し替えは外部境界の Supabase のみ。
- アカウント解決の分岐(未検出→ClientError(404)／クエリ失敗→ServerError)は既存の `packages/domain/src/user/use-case.test.ts` で担保されるため、ミドルウェア側では再検証しない。
- 配線の正常系（実 Supabase + RDB を要するアカウント解決経路）は E2E(passkey) で担保するものとし、ユニットではドメインに触れないフェイルセーフ経路のみを検証する。

### 確認
- `pnpm --filter @trend-diary/web test src/middleware/authenticator/` … 15 件パス
- `pnpm --filter @trend-diary/web typecheck` … パス
- `pnpm check`（oxlint / oxfmt）… 本変更ファイルに指摘なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvsgFDF5kDFSmvmVZR9ULF)_