### PR TITLE
refactor(web): ログインのinvalid-credentials判定をerror.codeのみに一本化

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,9 +135,9 @@ jobs:
           node-version-file: ${{ env.NODE_VERSION_FILE }}
 
       - name: Supabase Emulator のセットアップ
-        uses: rin2yh/supa-emu@016f0d78acb92f8f188d12cb670d69ffc117b4de # v0.1.4
+        uses: rin2yh/supa-emu@2cdf06de6d58bee6e22adaf6e4c2dad55e414977 # v0.1.8
         with:
-          version: v0.1.4
+          version: v0.1.8
           addr: 127.0.0.1:54321
           webauthn-rp-id: 127.0.0.1
 

--- a/application/apps/web/src/server/auth/handler/login.test.ts
+++ b/application/apps/web/src/server/auth/handler/login.test.ts
@@ -1,8 +1,6 @@
-import type { AuthError } from '@supabase/supabase-js'
 import { apiRequest } from '@/test/helper/request'
 import type { CleanUpIds } from '@/test/helper/user'
 import * as userHelper from '@/test/helper/user'
-import { isInvalidCredentialsError } from './login'
 
 describe('POST /api/auth/login', () => {
   const TEST_EMAIL = 'login-test@example.com'
@@ -67,37 +65,6 @@ describe('POST /api/auth/login', () => {
         const res = await requestLogin(JSON.stringify(testCase.input))
         expect(res.status).toBe(testCase.status)
       })
-    })
-  })
-})
-
-describe('isInvalidCredentialsError', () => {
-  // 本番GoTrueとsupa-emuで返るエラー形が異なっても、資格情報の誤りを同一に判定できることを担保する
-  const testCases: Array<{
-    name: string
-    error: Pick<AuthError, 'code' | 'message'>
-    expected: boolean
-  }> = [
-    {
-      name: '準正常系: 本番GoTrue(code=invalid_credentials)を資格情報エラーと判定する',
-      error: { code: 'invalid_credentials', message: 'Invalid login credentials' },
-      expected: true,
-    },
-    {
-      name: '準正常系: supa-emu(codeなし・OAuth形式)を資格情報エラーと判定する',
-      error: { code: undefined, message: 'Invalid login credentials' },
-      expected: true,
-    },
-    {
-      name: '異常系: 資格情報エラー以外は判定しない',
-      error: { code: 'over_request_rate_limit', message: 'Request rate limit reached' },
-      expected: false,
-    },
-  ]
-
-  testCases.forEach((testCase) => {
-    it(testCase.name, () => {
-      expect(isInvalidCredentialsError(testCase.error)).toBe(testCase.expected)
     })
   })
 })

--- a/application/apps/web/src/server/auth/handler/login.test.ts
+++ b/application/apps/web/src/server/auth/handler/login.test.ts
@@ -1,6 +1,8 @@
+import type { AuthError } from '@supabase/supabase-js'
 import { apiRequest } from '@/test/helper/request'
 import type { CleanUpIds } from '@/test/helper/user'
 import * as userHelper from '@/test/helper/user'
+import { isInvalidCredentialsError } from './login'
 
 describe('POST /api/auth/login', () => {
   const TEST_EMAIL = 'login-test@example.com'
@@ -65,6 +67,37 @@ describe('POST /api/auth/login', () => {
         const res = await requestLogin(JSON.stringify(testCase.input))
         expect(res.status).toBe(testCase.status)
       })
+    })
+  })
+})
+
+describe('isInvalidCredentialsError', () => {
+  // 本番GoTrueとsupa-emuで返るエラー形が異なっても、資格情報の誤りを同一に判定できることを担保する
+  const testCases: Array<{
+    name: string
+    error: Pick<AuthError, 'code' | 'message'>
+    expected: boolean
+  }> = [
+    {
+      name: '準正常系: 本番GoTrue(code=invalid_credentials)を資格情報エラーと判定する',
+      error: { code: 'invalid_credentials', message: 'Invalid login credentials' },
+      expected: true,
+    },
+    {
+      name: '準正常系: supa-emu(codeなし・OAuth形式)を資格情報エラーと判定する',
+      error: { code: undefined, message: 'Invalid login credentials' },
+      expected: true,
+    },
+    {
+      name: '異常系: 資格情報エラー以外は判定しない',
+      error: { code: 'over_request_rate_limit', message: 'Request rate limit reached' },
+      expected: false,
+    },
+  ]
+
+  testCases.forEach((testCase) => {
+    it(testCase.name, () => {
+      expect(isInvalidCredentialsError(testCase.error)).toBe(testCase.expected)
     })
   })
 })

--- a/application/apps/web/src/server/auth/handler/login.ts
+++ b/application/apps/web/src/server/auth/handler/login.ts
@@ -1,4 +1,3 @@
-import type { AuthError } from '@supabase/supabase-js'
 import { ClientError, handleError, ServerError } from '@trend-diary/common/errors'
 import { wrapAsyncCall } from '@trend-diary/common/result'
 import getRdbClient from '@trend-diary/datastore/rdb'
@@ -7,17 +6,6 @@ import { createSupabaseAuthClient } from '@/infrastructure/supabase'
 import CONTEXT_KEY from '@/middleware/context'
 import type { ZodValidatedContext } from '@/middleware/zod-validator'
 import { verifyTurnstile } from '../captcha'
-
-// 資格情報の誤りは環境を問わずGoTrue由来のAuthApiErrorとして返る（SDKが投げるAuthInvalidCredentialsErrorは
-// メール/電話番号の入力欠落時のみで、ここには到達しない）。本番GoTrueはcode=invalid_credentialsを返すが、
-// supa-emuはOAuth形式(error=invalid_grant)でcodeを持たない。両者ともメッセージは"Invalid login credentials"で一致するため、
-// version差に強いcodeを優先しつつ、code非対応のsupa-emu向けに同一メッセージをfallbackとして環境差を吸収する
-export function isInvalidCredentialsError(error: Pick<AuthError, 'code' | 'message'>): boolean {
-  return (
-    error.code === 'invalid_credentials' ||
-    error.message.toLowerCase().includes('invalid login credentials')
-  )
-}
 
 export default async function login(c: ZodValidatedContext<AuthInput>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
@@ -38,7 +26,8 @@ export default async function login(c: ZodValidatedContext<AuthInput>) {
 
   const { data, error } = loginResult.value
   if (error) {
-    if (isInvalidCredentialsError(error)) {
+    // 本番GoTrue・supa-emuともに資格情報の誤りはerror.code=invalid_credentialsで返るため、codeのみで判定する
+    if (error.code === 'invalid_credentials') {
       throw handleError(new ClientError('Invalid email or password', 401), logger)
     }
     throw handleError(new ServerError(`Authentication service error: ${error.message}`), logger)

--- a/application/apps/web/src/server/auth/handler/login.ts
+++ b/application/apps/web/src/server/auth/handler/login.ts
@@ -26,7 +26,6 @@ export default async function login(c: ZodValidatedContext<AuthInput>) {
 
   const { data, error } = loginResult.value
   if (error) {
-    // 本番GoTrue・supa-emuともに資格情報の誤りはerror.code=invalid_credentialsで返るため、codeのみで判定する
     if (error.code === 'invalid_credentials') {
       throw handleError(new ClientError('Invalid email or password', 401), logger)
     }

--- a/application/apps/web/src/server/auth/handler/login.ts
+++ b/application/apps/web/src/server/auth/handler/login.ts
@@ -1,4 +1,4 @@
-import { AuthInvalidCredentialsError } from '@supabase/supabase-js'
+import type { AuthError } from '@supabase/supabase-js'
 import { ClientError, handleError, ServerError } from '@trend-diary/common/errors'
 import { wrapAsyncCall } from '@trend-diary/common/result'
 import getRdbClient from '@trend-diary/datastore/rdb'
@@ -7,6 +7,17 @@ import { createSupabaseAuthClient } from '@/infrastructure/supabase'
 import CONTEXT_KEY from '@/middleware/context'
 import type { ZodValidatedContext } from '@/middleware/zod-validator'
 import { verifyTurnstile } from '../captcha'
+
+// 資格情報の誤りは環境を問わずGoTrue由来のAuthApiErrorとして返る（SDKが投げるAuthInvalidCredentialsErrorは
+// メール/電話番号の入力欠落時のみで、ここには到達しない）。本番GoTrueはcode=invalid_credentialsを返すが、
+// supa-emuはOAuth形式(error=invalid_grant)でcodeを持たない。両者ともメッセージは"Invalid login credentials"で一致するため、
+// version差に強いcodeを優先しつつ、code非対応のsupa-emu向けに同一メッセージをfallbackとして環境差を吸収する
+export function isInvalidCredentialsError(error: Pick<AuthError, 'code' | 'message'>): boolean {
+  return (
+    error.code === 'invalid_credentials' ||
+    error.message.toLowerCase().includes('invalid login credentials')
+  )
+}
 
 export default async function login(c: ZodValidatedContext<AuthInput>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
@@ -27,13 +38,7 @@ export default async function login(c: ZodValidatedContext<AuthInput>) {
 
   const { data, error } = loginResult.value
   if (error) {
-    // 認証情報の不正はinstanceofとメッセージの両方で判定（ローカルと本番で挙動が異なり得るため）
-    const message = error.message.toLowerCase()
-    const isInvalidCredentials =
-      error instanceof AuthInvalidCredentialsError ||
-      message.includes('invalid login credentials') ||
-      message.includes('invalid credentials')
-    if (isInvalidCredentials) {
+    if (isInvalidCredentialsError(error)) {
       throw handleError(new ClientError('Invalid email or password', 401), logger)
     }
     throw handleError(new ServerError(`Authentication service error: ${error.message}`), logger)


### PR DESCRIPTION
# 概要

## 課題

<!-- 改善したい課題を記載する -->

close #950

ログインの invalid-credentials 判定が、ローカル(supa-emu)と本番で分岐していた（現在は main のリファクタにより `toLoginError` に移動）。

```ts
error instanceof AuthInvalidCredentialsError ||
message.includes('invalid login credentials') ||
message.includes('invalid credentials')
```

調査の結果、以下が判明した。

- `AuthInvalidCredentialsError` は SDK がメール/電話番号の**入力欠落時のみ**に throw する例外で、資格情報の誤り（誤パスワード・存在しないユーザー）では発生しない。誤った資格情報は環境を問わず GoTrue 由来の `AuthApiError`（基底 `AuthError`）として返るため、この `instanceof` 分岐は**デッドコード**だった。
- 本番 GoTrue は `error.code = "invalid_credentials"` を返す。
- 一方 supa-emu（〜v0.1.7）は OAuth 形式 `{"error":"invalid_grant","error_description":"..."}` を返し、`code` を持たなかった。このため `code` だけでは supa-emu を判定できず、message fallback で環境差を吸収するしかなかった。

## 修正内容

- fix: #950

<!-- 修正方針とその方針を取った理由を記載する -->

環境差の**根本原因（supa-emu が error_code を返さない点）を supa-emu 側で解消**し、判定を `error.code` のみに一本化した。

- **supa-emu v0.1.8**（[rin2yh/supa-emu#18](https://github.com/rin2yh/supa-emu/pull/18)）で、資格情報エラーを本番 GoTrue 互換の `{"error_code":"invalid_credentials","msg":"Invalid login credentials"}`（HTTP 400）に変更。auth-js がこれを `error.code = "invalid_credentials"` にマップする。
- これにより本番・ローカルの双方で `error.code === 'invalid_credentials'` が成立するため、`toLoginError` の判定を単一条件に簡素化した。`.code` へ型安全にアクセスするため基底 `AuthError` で narrow する（誤パスワードが返す `AuthApiError` もこれに該当）。

```ts
function toLoginError(error: Error): Error {
  const isInvalidCredentials = error instanceof AuthError && error.code === 'invalid_credentials'
  return isInvalidCredentials
    ? new ClientError('Invalid email or password', 401)
    : new ServerError(`Authentication service error: ${error.message}`)
}
```

- デッドコードの `instanceof AuthInvalidCredentialsError` と message fallback を撤去。環境による判定分岐は解消。
- CI の supa-emu 参照を `v0.1.8`（`uses:` の SHA と `version:` 入力の両方）へ更新。action がリリース版バイナリを DL する方式のため、両方の更新が必要。
- 既存の結合テスト（誤パスワード・存在しないユーザー → 401）は、v0.1.8 の supa-emu 相手に `code` 経路を実地検証する。挙動は不変。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MCvCnLz6PrdiHNKypQET8q