### PR TITLE
refactor(web): 認証ハンドラのSupabase二段エラーハンドリングを整理する

### DIFF
--- a/application/apps/web/src/server/auth/handler/login.ts
+++ b/application/apps/web/src/server/auth/handler/login.ts
@@ -1,12 +1,25 @@
 import { AuthInvalidCredentialsError } from '@supabase/supabase-js'
 import { ClientError, handleError, ServerError } from '@trend-diary/common/errors'
-import { wrapAsyncCall } from '@trend-diary/common/result'
 import getRdbClient from '@trend-diary/datastore/rdb'
 import { type AuthInput, createAccountUseCase } from '@trend-diary/domain/user'
 import { createSupabaseAuthClient } from '@/infrastructure/supabase'
 import CONTEXT_KEY from '@/middleware/context'
 import type { ZodValidatedContext } from '@/middleware/zod-validator'
 import { verifyTurnstile } from '../captcha'
+import { callSupabaseAuth } from '../supabase-auth'
+
+// 認証情報の不正は401、それ以外はサービス側の異常として500に振り分ける。
+// 判定はinstanceofとメッセージの両方で行う（ローカルと本番でエラーの表現が異なり得るため）
+function toLoginError(error: Error): Error {
+  const message = error.message.toLowerCase()
+  const isInvalidCredentials =
+    error instanceof AuthInvalidCredentialsError ||
+    message.includes('invalid login credentials') ||
+    message.includes('invalid credentials')
+  return isInvalidCredentials
+    ? new ClientError('Invalid email or password', 401)
+    : new ServerError(`Authentication service error: ${error.message}`)
+}
 
 export default async function login(c: ZodValidatedContext<AuthInput>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
@@ -20,30 +33,17 @@ export default async function login(c: ZodValidatedContext<AuthInput>) {
   }
 
   const client = createSupabaseAuthClient(c)
-  const loginResult = await wrapAsyncCall(() =>
-    client.auth.signInWithPassword({ email: valid.email, password: valid.password }),
+  const loginResult = await callSupabaseAuth(
+    () => client.auth.signInWithPassword({ email: valid.email, password: valid.password }),
+    toLoginError,
   )
-  if (loginResult.isErr()) throw handleError(new ServerError(loginResult.error), logger)
+  if (loginResult.isErr()) throw handleError(loginResult.error, logger)
 
-  const { data, error } = loginResult.value
-  if (error) {
-    // 認証情報の不正はinstanceofとメッセージの両方で判定（ローカルと本番で挙動が異なり得るため）
-    const message = error.message.toLowerCase()
-    const isInvalidCredentials =
-      error instanceof AuthInvalidCredentialsError ||
-      message.includes('invalid login credentials') ||
-      message.includes('invalid credentials')
-    if (isInvalidCredentials) {
-      throw handleError(new ClientError('Invalid email or password', 401), logger)
-    }
-    throw handleError(new ServerError(`Authentication service error: ${error.message}`), logger)
-  }
-  if (!data.user || !data.session)
-    throw handleError(new ServerError('Authentication failed'), logger)
+  const { user } = loginResult.value
 
   const rdb = getRdbClient(c.env.DB)
   const accountUseCase = createAccountUseCase(rdb)
-  const result = await accountUseCase.resolveActiveUser(data.user.id)
+  const result = await accountUseCase.resolveActiveUser(user.id)
   if (result.isErr()) throw handleError(result.error, logger)
 
   logger.info('login success', { activeUserId: result.value.activeUserId })

--- a/application/apps/web/src/server/auth/handler/login.ts
+++ b/application/apps/web/src/server/auth/handler/login.ts
@@ -8,19 +8,6 @@ import type { ZodValidatedContext } from '@/middleware/zod-validator'
 import { verifyTurnstile } from '../captcha'
 import { callSupabaseAuth } from '../supabase-auth'
 
-// 認証情報の不正は401、それ以外はサービス側の異常として500に振り分ける。
-// 判定はinstanceofとメッセージの両方で行う（ローカルと本番でエラーの表現が異なり得るため）
-function toLoginError(error: Error): Error {
-  const message = error.message.toLowerCase()
-  const isInvalidCredentials =
-    error instanceof AuthInvalidCredentialsError ||
-    message.includes('invalid login credentials') ||
-    message.includes('invalid credentials')
-  return isInvalidCredentials
-    ? new ClientError('Invalid email or password', 401)
-    : new ServerError(`Authentication service error: ${error.message}`)
-}
-
 export default async function login(c: ZodValidatedContext<AuthInput>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const valid = c.req.valid('json')
@@ -54,4 +41,17 @@ export default async function login(c: ZodValidatedContext<AuthInput>) {
     },
     200,
   )
+}
+
+// 認証情報の不正は401、それ以外はサービス側の異常として500に振り分ける。
+// 判定はinstanceofとメッセージの両方で行う（ローカルと本番でエラーの表現が異なり得るため）
+function toLoginError(error: Error): Error {
+  const message = error.message.toLowerCase()
+  const isInvalidCredentials =
+    error instanceof AuthInvalidCredentialsError ||
+    message.includes('invalid login credentials') ||
+    message.includes('invalid credentials')
+  return isInvalidCredentials
+    ? new ClientError('Invalid email or password', 401)
+    : new ServerError(`Authentication service error: ${error.message}`)
 }

--- a/application/apps/web/src/server/auth/handler/logout.ts
+++ b/application/apps/web/src/server/auth/handler/logout.ts
@@ -1,27 +1,19 @@
-import { handleError, ServerError } from '@trend-diary/common/errors'
-import { wrapAsyncCall } from '@trend-diary/common/result'
+import { handleError } from '@trend-diary/common/errors'
 import type { Context } from 'hono'
 import { createSupabaseAuthClient } from '@/infrastructure/supabase'
 import CONTEXT_KEY from '@/middleware/context'
+import { callSupabaseAuth } from '../supabase-auth'
 
 export default async function logout(c: Context) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
 
   const client = createSupabaseAuthClient(c)
-  const result = await wrapAsyncCall(() => client.auth.signOut())
-
-  // 既にログアウト済みの場合でもSupabaseはエラーを返さないため、
-  // エラーが返ってきた場合は実際の問題（ネットワークエラー、サーバーエラーなど）
-  if (result.isErr()) {
-    logger.error('logout failed', { error: result.error })
-    throw handleError(new ServerError(result.error), logger)
-  }
-
-  const { error } = result.value
-  if (error) {
-    logger.error('logout failed', { error })
-    throw handleError(new ServerError(`Logout failed: ${error.message}`), logger)
-  }
+  // 既にログアウト済みでもSupabaseはエラーを返さないため、error は通信・サーバ障害のみを表す
+  const result = await callSupabaseAuth(async () => ({
+    ...(await client.auth.signOut()),
+    data: null,
+  }))
+  if (result.isErr()) throw handleError(result.error, logger)
 
   logger.info('logout success')
 

--- a/application/apps/web/src/server/auth/handler/passkey-disable.ts
+++ b/application/apps/web/src/server/auth/handler/passkey-disable.ts
@@ -1,34 +1,27 @@
 import { handleError, ServerError } from '@trend-diary/common/errors'
-import { wrapAsyncCall } from '@trend-diary/common/result'
 import type { Context } from 'hono'
 import type { Env } from '@/env'
 import { createSupabaseAuthClient } from '@/infrastructure/supabase'
 import CONTEXT_KEY from '@/middleware/context'
+import { callSupabaseAuth } from '../supabase-auth'
 
 export default async function passkeyDisable(c: Context<Env>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
 
   const client = createSupabaseAuthClient(c)
-  const listResult = await wrapAsyncCall(() => client.auth.passkey.list())
-  if (listResult.isErr()) throw handleError(new ServerError(listResult.error), logger)
-
-  const { data, error } = listResult.value
-  if (error || !data) {
-    throw handleError(new ServerError(`Passkey list failed: ${error?.message}`), logger)
-  }
+  const listResult = await callSupabaseAuth(
+    () => client.auth.passkey.list(),
+    (error) => new ServerError(`Passkey list failed: ${error.message}`),
+  )
+  if (listResult.isErr()) throw handleError(listResult.error, logger)
 
   // トグルOFFは「パスキーを使わない」状態にすることなので、登録済みを全て削除する
-  for (const passkey of data) {
-    const deleteResult = await wrapAsyncCall(() =>
-      client.auth.passkey.delete({ passkeyId: passkey.id }),
+  for (const passkey of listResult.value) {
+    const deleteResult = await callSupabaseAuth(
+      () => client.auth.passkey.delete({ passkeyId: passkey.id }),
+      (error) => new ServerError(`Passkey deletion failed: ${error.message}`),
     )
-    if (deleteResult.isErr()) throw handleError(new ServerError(deleteResult.error), logger)
-    if (deleteResult.value.error) {
-      throw handleError(
-        new ServerError(`Passkey deletion failed: ${deleteResult.value.error.message}`),
-        logger,
-      )
-    }
+    if (deleteResult.isErr()) throw handleError(deleteResult.error, logger)
   }
 
   return c.body(null, 204)

--- a/application/apps/web/src/server/auth/handler/passkey-login-start.ts
+++ b/application/apps/web/src/server/auth/handler/passkey-login-start.ts
@@ -1,24 +1,19 @@
 import { handleError, ServerError } from '@trend-diary/common/errors'
-import { wrapAsyncCall } from '@trend-diary/common/result'
 import type { Context } from 'hono'
 import type { Env } from '@/env'
 import { createSupabaseAuthClient } from '@/infrastructure/supabase'
 import CONTEXT_KEY from '@/middleware/context'
+import { callSupabaseAuth } from '../supabase-auth'
 
 export default async function passkeyLoginStart(c: Context<Env>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
 
   const client = createSupabaseAuthClient(c)
-  const result = await wrapAsyncCall(() => client.auth.passkey.startAuthentication())
-  if (result.isErr()) throw handleError(new ServerError(result.error), logger)
+  const result = await callSupabaseAuth(
+    () => client.auth.passkey.startAuthentication(),
+    (error) => new ServerError(`Passkey authentication start failed: ${error.message}`),
+  )
+  if (result.isErr()) throw handleError(result.error, logger)
 
-  const { data, error } = result.value
-  if (error || !data) {
-    throw handleError(
-      new ServerError(`Passkey authentication start failed: ${error?.message}`),
-      logger,
-    )
-  }
-
-  return c.json({ challengeId: data.challenge_id, options: data.options }, 200)
+  return c.json({ challengeId: result.value.challenge_id, options: result.value.options }, 200)
 }

--- a/application/apps/web/src/server/auth/handler/passkey-login-verify.ts
+++ b/application/apps/web/src/server/auth/handler/passkey-login-verify.ts
@@ -2,6 +2,7 @@ import type { AuthenticationResponseJSON } from '@simplewebauthn/browser'
 import { ClientError, handleError, ServerError } from '@trend-diary/common/errors'
 import getRdbClient from '@trend-diary/datastore/rdb'
 import { createAccountUseCase } from '@trend-diary/domain/user'
+import { err, ok } from 'neverthrow'
 import { z } from 'zod'
 import { createSupabaseAuthClient } from '@/infrastructure/supabase'
 import CONTEXT_KEY from '@/middleware/context'
@@ -23,22 +24,24 @@ export default async function passkeyLoginVerify(c: ZodValidatedContext<PasskeyL
   const valid = c.req.valid('json')
 
   const client = createSupabaseAuthClient(c)
-  const verifyResult = await callSupabaseAuth(
-    () =>
-      client.auth.passkey.verifyAuthentication({
-        challengeId: valid.challengeId,
-        credential: valid.credential,
-      }),
-    () => new ClientError('Invalid passkey', 401),
+  // 成功でも user/session が空なら認証失敗として err に畳み、後段でのResult外エラー処理を無くす
+  const userResult = (
+    await callSupabaseAuth(
+      () =>
+        client.auth.passkey.verifyAuthentication({
+          challengeId: valid.challengeId,
+          credential: valid.credential,
+        }),
+      () => new ClientError('Invalid passkey', 401),
+    )
+  ).andThen(({ user, session }) =>
+    user && session ? ok(user) : err(new ServerError('Passkey authentication failed')),
   )
-  if (verifyResult.isErr()) throw handleError(verifyResult.error, logger)
-
-  const { user, session } = verifyResult.value
-  if (!user || !session) throw handleError(new ServerError('Passkey authentication failed'), logger)
+  if (userResult.isErr()) throw handleError(userResult.error, logger)
 
   const rdb = getRdbClient(c.env.DB)
   const accountUseCase = createAccountUseCase(rdb)
-  const activeUserResult = await accountUseCase.resolveActiveUser(user.id)
+  const activeUserResult = await accountUseCase.resolveActiveUser(userResult.value.id)
   if (activeUserResult.isErr()) throw handleError(activeUserResult.error, logger)
 
   logger.info('passkey login success', { activeUserId: activeUserResult.value.activeUserId })

--- a/application/apps/web/src/server/auth/handler/passkey-login-verify.ts
+++ b/application/apps/web/src/server/auth/handler/passkey-login-verify.ts
@@ -1,12 +1,12 @@
 import type { AuthenticationResponseJSON } from '@simplewebauthn/browser'
 import { ClientError, handleError, ServerError } from '@trend-diary/common/errors'
-import { wrapAsyncCall } from '@trend-diary/common/result'
 import getRdbClient from '@trend-diary/datastore/rdb'
 import { createAccountUseCase } from '@trend-diary/domain/user'
 import { z } from 'zod'
 import { createSupabaseAuthClient } from '@/infrastructure/supabase'
 import CONTEXT_KEY from '@/middleware/context'
 import type { ZodValidatedContext } from '@/middleware/zod-validator'
+import { callSupabaseAuth } from '../supabase-auth'
 
 // 真正性はSupabaseが検証するため中身の妥当性検証はプロバイダに委ね、ここは認証 ceremony 結果を素通しする
 export const passkeyLoginVerifyInputSchema = z.object({
@@ -23,23 +23,22 @@ export default async function passkeyLoginVerify(c: ZodValidatedContext<PasskeyL
   const valid = c.req.valid('json')
 
   const client = createSupabaseAuthClient(c)
-  const result = await wrapAsyncCall(() =>
-    client.auth.passkey.verifyAuthentication({
-      challengeId: valid.challengeId,
-      credential: valid.credential,
-    }),
+  const verifyResult = await callSupabaseAuth(
+    () =>
+      client.auth.passkey.verifyAuthentication({
+        challengeId: valid.challengeId,
+        credential: valid.credential,
+      }),
+    () => new ClientError('Invalid passkey', 401),
   )
-  if (result.isErr()) throw handleError(new ServerError(result.error), logger)
+  if (verifyResult.isErr()) throw handleError(verifyResult.error, logger)
 
-  const { data, error } = result.value
-  if (error) throw handleError(new ClientError('Invalid passkey', 401), logger)
-  if (!data?.user || !data.session) {
-    throw handleError(new ServerError('Passkey authentication failed'), logger)
-  }
+  const { user, session } = verifyResult.value
+  if (!user || !session) throw handleError(new ServerError('Passkey authentication failed'), logger)
 
   const rdb = getRdbClient(c.env.DB)
   const accountUseCase = createAccountUseCase(rdb)
-  const activeUserResult = await accountUseCase.resolveActiveUser(data.user.id)
+  const activeUserResult = await accountUseCase.resolveActiveUser(user.id)
   if (activeUserResult.isErr()) throw handleError(activeUserResult.error, logger)
 
   logger.info('passkey login success', { activeUserId: activeUserResult.value.activeUserId })

--- a/application/apps/web/src/server/auth/handler/passkey-register-start.ts
+++ b/application/apps/web/src/server/auth/handler/passkey-register-start.ts
@@ -1,24 +1,19 @@
 import { handleError, ServerError } from '@trend-diary/common/errors'
-import { wrapAsyncCall } from '@trend-diary/common/result'
 import type { Context } from 'hono'
 import type { Env } from '@/env'
 import { createSupabaseAuthClient } from '@/infrastructure/supabase'
 import CONTEXT_KEY from '@/middleware/context'
+import { callSupabaseAuth } from '../supabase-auth'
 
 export default async function passkeyRegisterStart(c: Context<Env>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
 
   const client = createSupabaseAuthClient(c)
-  const result = await wrapAsyncCall(() => client.auth.passkey.startRegistration())
-  if (result.isErr()) throw handleError(new ServerError(result.error), logger)
+  const result = await callSupabaseAuth(
+    () => client.auth.passkey.startRegistration(),
+    (error) => new ServerError(`Passkey registration start failed: ${error.message}`),
+  )
+  if (result.isErr()) throw handleError(result.error, logger)
 
-  const { data, error } = result.value
-  if (error || !data) {
-    throw handleError(
-      new ServerError(`Passkey registration start failed: ${error?.message}`),
-      logger,
-    )
-  }
-
-  return c.json({ challengeId: data.challenge_id, options: data.options }, 200)
+  return c.json({ challengeId: result.value.challenge_id, options: result.value.options }, 200)
 }

--- a/application/apps/web/src/server/auth/handler/passkey-register-verify.ts
+++ b/application/apps/web/src/server/auth/handler/passkey-register-verify.ts
@@ -1,10 +1,10 @@
 import type { RegistrationResponseJSON } from '@simplewebauthn/browser'
-import { ClientError, handleError, ServerError } from '@trend-diary/common/errors'
-import { wrapAsyncCall } from '@trend-diary/common/result'
+import { ClientError, handleError } from '@trend-diary/common/errors'
 import { z } from 'zod'
 import { createSupabaseAuthClient } from '@/infrastructure/supabase'
 import CONTEXT_KEY from '@/middleware/context'
 import type { ZodValidatedContext } from '@/middleware/zod-validator'
+import { callSupabaseAuth } from '../supabase-auth'
 
 // 真正性はSupabaseが検証するため中身の妥当性検証はプロバイダに委ね、ここは登録 ceremony 結果を素通しする
 export const passkeyRegisterVerifyInputSchema = z.object({
@@ -23,23 +23,17 @@ export default async function passkeyRegisterVerify(
   const valid = c.req.valid('json')
 
   const client = createSupabaseAuthClient(c)
-  const result = await wrapAsyncCall(() =>
-    client.auth.passkey.verifyRegistration({
-      challengeId: valid.challengeId,
-      credential: valid.credential,
-    }),
+  const result = await callSupabaseAuth(
+    () =>
+      client.auth.passkey.verifyRegistration({
+        challengeId: valid.challengeId,
+        credential: valid.credential,
+      }),
+    (error) => new ClientError(`Passkey registration failed: ${error.message}`, 400),
   )
-  if (result.isErr()) throw handleError(new ServerError(result.error), logger)
+  if (result.isErr()) throw handleError(result.error, logger)
 
-  const { data, error } = result.value
-  if (error || !data) {
-    throw handleError(
-      new ClientError(`Passkey registration failed: ${error?.message}`, 400),
-      logger,
-    )
-  }
+  logger.info('passkey registration success', { passkeyId: result.value.id })
 
-  logger.info('passkey registration success', { passkeyId: data.id })
-
-  return c.json({ id: data.id }, 201)
+  return c.json({ id: result.value.id }, 201)
 }

--- a/application/apps/web/src/server/auth/handler/passkey-status.ts
+++ b/application/apps/web/src/server/auth/handler/passkey-status.ts
@@ -1,21 +1,19 @@
 import { handleError, ServerError } from '@trend-diary/common/errors'
-import { wrapAsyncCall } from '@trend-diary/common/result'
 import type { Context } from 'hono'
 import type { Env } from '@/env'
 import { createSupabaseAuthClient } from '@/infrastructure/supabase'
 import CONTEXT_KEY from '@/middleware/context'
+import { callSupabaseAuth } from '../supabase-auth'
 
 export default async function passkeyStatus(c: Context<Env>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
 
   const client = createSupabaseAuthClient(c)
-  const result = await wrapAsyncCall(() => client.auth.passkey.list())
-  if (result.isErr()) throw handleError(new ServerError(result.error), logger)
+  const result = await callSupabaseAuth(
+    () => client.auth.passkey.list(),
+    (error) => new ServerError(`Passkey list failed: ${error.message}`),
+  )
+  if (result.isErr()) throw handleError(result.error, logger)
 
-  const { data, error } = result.value
-  if (error || !data) {
-    throw handleError(new ServerError(`Passkey list failed: ${error?.message}`), logger)
-  }
-
-  return c.json({ hasPasskey: data.length > 0 }, 200)
+  return c.json({ hasPasskey: result.value.length > 0 }, 200)
 }

--- a/application/apps/web/src/server/auth/handler/signup.ts
+++ b/application/apps/web/src/server/auth/handler/signup.ts
@@ -1,5 +1,4 @@
 import { AlreadyExistsError, handleError, ServerError } from '@trend-diary/common/errors'
-import { wrapAsyncCall } from '@trend-diary/common/result'
 import getRdbClient from '@trend-diary/datastore/rdb'
 import { type AuthInput, createAccountUseCase } from '@trend-diary/domain/user'
 import { DiscordWebhookClient } from '@trend-diary/notification'
@@ -7,6 +6,15 @@ import { createSupabaseAuthClient } from '@/infrastructure/supabase'
 import CONTEXT_KEY from '@/middleware/context'
 import type { ZodValidatedContext } from '@/middleware/zod-validator'
 import { verifyTurnstile } from '../captcha'
+import { callSupabaseAuth } from '../supabase-auth'
+
+// 既に存在するユーザーは409で明示する。UX上一般的でセキュリティリスクも比較的小さいと判断。
+// NOTE: Supabaseは専用エラー型を提供しないためメッセージ文字列で判定している
+function toSignupError(error: Error): Error {
+  return error.message.includes('already registered')
+    ? new AlreadyExistsError('User already exists')
+    : new ServerError(`Authentication service error: ${error.message}`)
+}
 
 export default async function signup(c: ZodValidatedContext<AuthInput>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
@@ -20,21 +28,14 @@ export default async function signup(c: ZodValidatedContext<AuthInput>) {
   }
 
   const client = createSupabaseAuthClient(c)
-  const signUpResult = await wrapAsyncCall(() =>
-    client.auth.signUp({ email: valid.email, password: valid.password }),
+  const signUpResult = await callSupabaseAuth(
+    () => client.auth.signUp({ email: valid.email, password: valid.password }),
+    toSignupError,
   )
-  if (signUpResult.isErr()) throw handleError(new ServerError(signUpResult.error), logger)
+  if (signUpResult.isErr()) throw handleError(signUpResult.error, logger)
 
-  const { data, error } = signUpResult.value
-  if (error) {
-    // 既に存在するユーザーは明示する。UX上一般的であり、セキュリティリスクも比較的小さいと判断
-    // NOTE: Supabaseは専用エラー型を提供しないためメッセージ文字列で判定している
-    if (error.message.includes('already registered')) {
-      throw handleError(new AlreadyExistsError('User already exists'), logger)
-    }
-    throw handleError(new ServerError(`Authentication service error: ${error.message}`), logger)
-  }
-  if (!data.user) throw handleError(new ServerError('User registration failed'), logger)
+  const { user } = signUpResult.value
+  if (!user) throw handleError(new ServerError('User registration failed'), logger)
 
   // ロールバック不能な認証ユーザー作成が成功したときだけ、アカウント作成のドメイン処理を呼ぶ
   // NOTE: ここで失敗すると認証側に孤児ユーザーが残る。同期補償(認証ユーザーの削除)はSupabaseの
@@ -45,8 +46,8 @@ export default async function signup(c: ZodValidatedContext<AuthInput>) {
   const accountUseCase = createAccountUseCase(rdb)
   const notifier = new DiscordWebhookClient(c.env.DISCORD_WEBHOOK_URL, logger)
   const result = await accountUseCase.registerActiveUser(
-    data.user.email ?? valid.email,
-    data.user.id,
+    user.email ?? valid.email,
+    user.id,
     notifier,
   )
   if (result.isErr()) throw handleError(result.error, logger)

--- a/application/apps/web/src/server/auth/handler/signup.ts
+++ b/application/apps/web/src/server/auth/handler/signup.ts
@@ -2,6 +2,7 @@ import { AlreadyExistsError, handleError, ServerError } from '@trend-diary/commo
 import getRdbClient from '@trend-diary/datastore/rdb'
 import { type AuthInput, createAccountUseCase } from '@trend-diary/domain/user'
 import { DiscordWebhookClient } from '@trend-diary/notification'
+import { err, ok } from 'neverthrow'
 import { createSupabaseAuthClient } from '@/infrastructure/supabase'
 import CONTEXT_KEY from '@/middleware/context'
 import type { ZodValidatedContext } from '@/middleware/zod-validator'
@@ -20,14 +21,16 @@ export default async function signup(c: ZodValidatedContext<AuthInput>) {
   }
 
   const client = createSupabaseAuthClient(c)
-  const signUpResult = await callSupabaseAuth(
-    () => client.auth.signUp({ email: valid.email, password: valid.password }),
-    toSignupError,
-  )
-  if (signUpResult.isErr()) throw handleError(signUpResult.error, logger)
+  // 成功でも user が空なら登録失敗として err に畳み、後段でのResult外エラー処理を無くす
+  const userResult = (
+    await callSupabaseAuth(
+      () => client.auth.signUp({ email: valid.email, password: valid.password }),
+      toSignupError,
+    )
+  ).andThen(({ user }) => (user ? ok(user) : err(new ServerError('User registration failed'))))
+  if (userResult.isErr()) throw handleError(userResult.error, logger)
 
-  const { user } = signUpResult.value
-  if (!user) throw handleError(new ServerError('User registration failed'), logger)
+  const user = userResult.value
 
   // ロールバック不能な認証ユーザー作成が成功したときだけ、アカウント作成のドメイン処理を呼ぶ
   // NOTE: ここで失敗すると認証側に孤児ユーザーが残る。同期補償(認証ユーザーの削除)はSupabaseの

--- a/application/apps/web/src/server/auth/handler/signup.ts
+++ b/application/apps/web/src/server/auth/handler/signup.ts
@@ -8,14 +8,6 @@ import type { ZodValidatedContext } from '@/middleware/zod-validator'
 import { verifyTurnstile } from '../captcha'
 import { callSupabaseAuth } from '../supabase-auth'
 
-// 既に存在するユーザーは409で明示する。UX上一般的でセキュリティリスクも比較的小さいと判断。
-// NOTE: Supabaseは専用エラー型を提供しないためメッセージ文字列で判定している
-function toSignupError(error: Error): Error {
-  return error.message.includes('already registered')
-    ? new AlreadyExistsError('User already exists')
-    : new ServerError(`Authentication service error: ${error.message}`)
-}
-
 export default async function signup(c: ZodValidatedContext<AuthInput>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const valid = c.req.valid('json')
@@ -55,4 +47,12 @@ export default async function signup(c: ZodValidatedContext<AuthInput>) {
   logger.info('signup success', { activeUserId: result.value.activeUserId })
 
   return c.json({}, 201)
+}
+
+// 既に存在するユーザーは409で明示する。UX上一般的でセキュリティリスクも比較的小さいと判断。
+// NOTE: Supabaseは専用エラー型を提供しないためメッセージ文字列で判定している
+function toSignupError(error: Error): Error {
+  return error.message.includes('already registered')
+    ? new AlreadyExistsError('User already exists')
+    : new ServerError(`Authentication service error: ${error.message}`)
 }

--- a/application/apps/web/src/server/auth/supabase-auth.test.ts
+++ b/application/apps/web/src/server/auth/supabase-auth.test.ts
@@ -1,0 +1,64 @@
+import { ClientError, ServerError } from '@trend-diary/common/errors'
+import { describe, expect, it } from 'vitest'
+import { callSupabaseAuth } from './supabase-auth'
+
+describe('callSupabaseAuth', () => {
+  describe('正常系', () => {
+    it('error が null のとき data を ok として返すこと', async () => {
+      const result = await callSupabaseAuth(async () => ({
+        data: { id: 'passkey-1' },
+        error: null,
+      }))
+
+      expect(result.isOk()).toBe(true)
+      if (result.isOk()) {
+        expect(result.value).toEqual({ id: 'passkey-1' })
+      }
+    })
+  })
+
+  describe('準正常系', () => {
+    it('業務エラー({ error })を既定で ServerError に写して err を返すこと', async () => {
+      const result = await callSupabaseAuth(async () => ({
+        data: null,
+        error: new Error('service down'),
+      }))
+
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(ServerError)
+        expect(result.error.message).toBe('service down')
+      }
+    })
+
+    it('業務エラーは mapError で任意のドメインエラーへ写せること', async () => {
+      const result = await callSupabaseAuth(
+        async () => ({ data: null, error: new Error('invalid credentials') }),
+        () => new ClientError('Invalid', 401),
+      )
+
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(ClientError)
+      }
+    })
+  })
+
+  describe('異常系', () => {
+    it('例外は mapError を経由せず常に ServerError として err を返すこと', async () => {
+      const result = await callSupabaseAuth(
+        async () => {
+          throw new Error('network down')
+        },
+        // 例外はここを通らないことを、ClientError にならないことで確認する
+        () => new ClientError('should not be used', 401),
+      )
+
+      expect(result.isErr()).toBe(true)
+      if (result.isErr()) {
+        expect(result.error).toBeInstanceOf(ServerError)
+        expect(result.error.message).toBe('network down')
+      }
+    })
+  })
+})

--- a/application/apps/web/src/server/auth/supabase-auth.ts
+++ b/application/apps/web/src/server/auth/supabase-auth.ts
@@ -2,24 +2,21 @@ import { ServerError } from '@trend-diary/common/errors'
 import { wrapAsyncCall } from '@trend-diary/common/result'
 import { err, ok, type Result } from 'neverthrow'
 
-// Supabase Auth の戻り値。成功時は data を持ち error は null、失敗時は error を持つ判別可能ユニオン。
-interface SupabaseAuthResponse {
-  // oxlint-disable-next-line typescript/no-restricted-types -- SDKごとにdata形状が異なる制約用の器で、具体型は呼び出し時のTResponseが確定するため
-  data: unknown
-  error: Error | null
-}
-
-// 成功ブランチ(error が null)の data 型だけを取り出す。ユニオンを分配し失敗ブランチを never へ畳む。
+// Supabase Auth の戻り値のうち成功ブランチ(error が null)の data 型だけを取り出す。
+// ユニオンを分配し失敗ブランチを never へ畳む。
 type SupabaseAuthData<TResponse> = TResponse extends { error: null; data: infer TData }
   ? TData
   : never
 
 // Supabase Auth SDK は失敗を2経路で表す。通信断など基盤レベルの失敗は例外を投げ、資格情報エラー等の
 // 業務的な失敗は戻り値 { error } で返す。この2経路を単一の Result に畳むことで、ハンドラ側の
-// 「wrapAsyncCall で例外を見た上に { error } も個別に見る」二段分岐を無くし、成功パスを直列に保つ。
-// 例外は原因を特定できないため常に ServerError とし、業務エラーのみ mapError でドメインエラーへ写す
-// （既定は ServerError。401/409 等へ振り分けたいハンドラだけが mapError を渡す）。
-export async function callSupabaseAuth<TResponse extends SupabaseAuthResponse>(
+// 「wrapAsyncCall で例外を見た上に { error } も個別に見る」二段分岐を無くし、エラーは Result(err)
+// でのみ扱えるようにする。例外は原因を特定できないため常に ServerError とし、業務エラーのみ mapError
+// でドメインエラーへ写す（既定は ServerError。401/409 等へ振り分けたいハンドラだけが mapError を渡す）。
+export async function callSupabaseAuth<
+  // oxlint-disable-next-line typescript/no-restricted-types -- SDKごとにdata形状が異なる制約用で、具体型は呼び出し時のTResponseが確定するため
+  TResponse extends { data: unknown; error: Error | null },
+>(
   call: () => Promise<TResponse>,
   mapError: (error: Error) => Error = (error) => new ServerError(error),
 ): Promise<Result<SupabaseAuthData<TResponse>, Error>> {

--- a/application/apps/web/src/server/auth/supabase-auth.ts
+++ b/application/apps/web/src/server/auth/supabase-auth.ts
@@ -2,17 +2,12 @@ import { ServerError } from '@trend-diary/common/errors'
 import { wrapAsyncCall } from '@trend-diary/common/result'
 import { err, ok, type Result } from 'neverthrow'
 
-// Supabase Auth の戻り値のうち成功ブランチ(error が null)の data 型だけを取り出す。
-// ユニオンを分配し失敗ブランチを never へ畳む。
 type SupabaseAuthData<TResponse> = TResponse extends { error: null; data: infer TData }
   ? TData
   : never
 
-// Supabase Auth SDK は失敗を2経路で表す。通信断など基盤レベルの失敗は例外を投げ、資格情報エラー等の
-// 業務的な失敗は戻り値 { error } で返す。この2経路を単一の Result に畳むことで、ハンドラ側の
-// 「wrapAsyncCall で例外を見た上に { error } も個別に見る」二段分岐を無くし、エラーは Result(err)
-// でのみ扱えるようにする。例外は原因を特定できないため常に ServerError とし、業務エラーのみ mapError
-// でドメインエラーへ写す（既定は ServerError。401/409 等へ振り分けたいハンドラだけが mapError を渡す）。
+// Supabase Auth SDK は失敗を例外(通信断など基盤の失敗)と戻り値 { error }(業務エラー)の2経路で返す。
+// 例外は原因を特定できないため一律 ServerError とし、区別できる業務エラーのみ mapError に委ねる。
 export async function callSupabaseAuth<
   // oxlint-disable-next-line typescript/no-restricted-types -- SDKごとにdata形状が異なる制約用で、具体型は呼び出し時のTResponseが確定するため
   TResponse extends { data: unknown; error: Error | null },
@@ -26,8 +21,6 @@ export async function callSupabaseAuth<
   const response = called.value
   if (response.error) return err(mapError(response.error))
 
-  // error が null に絞れた時点で成功ブランチだが、ジェネリックなユニオンは戻り値型へ自動で絞り込め
-  // ないため、成功 data 型として明示する
-  // oxlint-disable-next-line typescript/consistent-type-assertions -- 上記のとおりジェネリックユニオンの絞り込みを型で表現できないため
+  // oxlint-disable-next-line typescript/consistent-type-assertions -- ジェネリックなユニオンは error=null 判定後も戻り値型へ絞り込めないため
   return ok(response.data as SupabaseAuthData<TResponse>)
 }

--- a/application/apps/web/src/server/auth/supabase-auth.ts
+++ b/application/apps/web/src/server/auth/supabase-auth.ts
@@ -1,0 +1,36 @@
+import { ServerError } from '@trend-diary/common/errors'
+import { wrapAsyncCall } from '@trend-diary/common/result'
+import { err, ok, type Result } from 'neverthrow'
+
+// Supabase Auth の戻り値。成功時は data を持ち error は null、失敗時は error を持つ判別可能ユニオン。
+interface SupabaseAuthResponse {
+  // oxlint-disable-next-line typescript/no-restricted-types -- SDKごとにdata形状が異なる制約用の器で、具体型は呼び出し時のTResponseが確定するため
+  data: unknown
+  error: Error | null
+}
+
+// 成功ブランチ(error が null)の data 型だけを取り出す。ユニオンを分配し失敗ブランチを never へ畳む。
+type SupabaseAuthData<TResponse> = TResponse extends { error: null; data: infer TData }
+  ? TData
+  : never
+
+// Supabase Auth SDK は失敗を2経路で表す。通信断など基盤レベルの失敗は例外を投げ、資格情報エラー等の
+// 業務的な失敗は戻り値 { error } で返す。この2経路を単一の Result に畳むことで、ハンドラ側の
+// 「wrapAsyncCall で例外を見た上に { error } も個別に見る」二段分岐を無くし、成功パスを直列に保つ。
+// 例外は原因を特定できないため常に ServerError とし、業務エラーのみ mapError でドメインエラーへ写す
+// （既定は ServerError。401/409 等へ振り分けたいハンドラだけが mapError を渡す）。
+export async function callSupabaseAuth<TResponse extends SupabaseAuthResponse>(
+  call: () => Promise<TResponse>,
+  mapError: (error: Error) => Error = (error) => new ServerError(error),
+): Promise<Result<SupabaseAuthData<TResponse>, Error>> {
+  const called = await wrapAsyncCall(call)
+  if (called.isErr()) return err(new ServerError(called.error))
+
+  const response = called.value
+  if (response.error) return err(mapError(response.error))
+
+  // error が null に絞れた時点で成功ブランチだが、ジェネリックなユニオンは戻り値型へ自動で絞り込め
+  // ないため、成功 data 型として明示する
+  // oxlint-disable-next-line typescript/consistent-type-assertions -- 上記のとおりジェネリックユニオンの絞り込みを型で表現できないため
+  return ok(response.data as SupabaseAuthData<TResponse>)
+}


### PR DESCRIPTION
# 概要
## 課題
close #949

PR #947 で Supabase 呼び出しを各ハンドラへ直書きした結果、`login` / `signup` / `passkey-*` で以下が頻出し読みづらかった。

- `throw handleError(...)` の多用で正常フローが分断される
- Supabase 呼び出しを `wrapAsyncCall` で包んだ上に戻り値 `{ error }` も個別判定する二段構え（例: `passkey-register-verify.ts` の `isErr()` 後に `error || !data` を再判定）

## 修正内容
- fix: #949

薄いヘルパ `callSupabaseAuth`（`apps/web/src/server/auth/supabase-auth.ts`）を追加し、Supabase Auth SDK の2つの失敗経路を単一の `Result` に畳んだ。

- **例外（通信断など基盤レベルの失敗）**: SDK が投げる例外。原因を特定できないため常に `ServerError`。
- **業務エラー（`{ error }`）**: 資格情報エラー等。既定は `ServerError`。401/409 等へ振り分けたいハンドラだけが `mapError` を渡す。

これにより各ハンドラは Supabase 呼び出しごとに `if (result.isErr()) throw handleError(...)` の1段だけになり、二段分岐と `throw handleError` の多用が解消され、成功パスが直列に読めるようになった。

### 方針の理由

- **抽象の作りすぎを避ける**: 新規の仕組みは「2経路を Result に畳む」1点に絞り、エラーの業務的分類（invalid credentials → 401、already registered → 409 等）はハンドラ固有のため各ハンドラ側の小さな named 関数（`toLoginError` / `toSignupError`）や `mapError` 引数に留めた。
- **例外と業務エラーの扱いを統一**: 例外は必ず `ServerError`、業務エラーのみ `mapError` を通す設計にし、両者の意図をヘルパのシグネチャで表現した。既存の `wrapAsyncCall`（例外捕捉の既存イディオム）を内部で再利用している。
- **既存挙動を維持**: SDK の判別可能ユニオン（成功時 data 非 null）に沿って、成功時に必ず非 null となる `login` の `user`/`session` guard など到達不能なチェックのみ削除し、`signup` の `user` や `passkey-login-verify` の `user`/`session` のように成功時も null になり得る guard は残した。レスポンスの HTTP ステータスは変更なし。

### 変更ファイル
- 追加: `supabase-auth.ts`（ヘルパ）/ `supabase-auth.test.ts`（正常系・準正常系・異常系のユニットテスト）
- 適用: `login` / `signup` / `logout` / `passkey-status` / `passkey-register-start` / `passkey-login-start` / `passkey-register-verify` / `passkey-login-verify` / `passkey-disable`

### 確認
- `pnpm -r typecheck` / `oxlint` / `oxfmt --check` パス
- `supabase-auth.test.ts` および passkey verify スキーマのユニットテストパス（バックエンド不要分）
- ハンドラの結合テストは CI で実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XrDBBA4a15o6GhsHPbUCKW)_