### PR TITLE
fix(web): キャッシュヒット時の記事一覧 API で 5xx を修正

### DIFF
--- a/application/apps/web/src/middleware/article-cache.test.ts
+++ b/application/apps/web/src/middleware/article-cache.test.ts
@@ -1,3 +1,4 @@
+import type { Context } from 'hono'
 import { Hono } from 'hono'
 import type { Mock } from 'vitest'
 import type { Env } from '@/env'
@@ -95,6 +96,36 @@ describe('articleCache ミドルウェア', () => {
       expect(match).toHaveBeenCalledOnce()
       expect(handler).not.toHaveBeenCalled()
       expect(await res.text()).toBe('cached-body')
+    })
+
+    it('キャッシュヒット時はヘッダが可変な Response を返すこと', async () => {
+      // Cache API が返す Response はヘッダが immutable。これをそのまま返すと後続の
+      // secureHeaders がヘッダを付与できず "Can't modify immutable headers" で 5xx になる。
+      // workerd では Response.redirect のヘッダが immutable になるため Cache API 応答の代用にする
+      const immutable = Response.redirect('https://example.com/redirect', 302)
+      vi.stubGlobal('caches', {
+        default: { match: vi.fn(async () => immutable), put: vi.fn() },
+      })
+
+      // ヒット経路のみを検証するため、ミドルウェアを直接呼び出して戻り値の Response を得る
+      const next = vi.fn(async () => {})
+      const mockContext = {
+        env: { ...TEST_ENV, EDGE_CACHE_DISABLED: undefined },
+        req: { method: 'GET', url: ARTICLES_URL, header: () => undefined },
+        executionCtx: { waitUntil: vi.fn() },
+      }
+      // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-restricted-types -- ヒット経路が参照する最小限のフィールドのみを持つモックを Context として渡すため
+      const c = mockContext as unknown as Context<Env>
+
+      const res = await articleCache(c, next)
+
+      expect(next).not.toHaveBeenCalled()
+      expect(res).toBeInstanceOf(Response)
+      expect(res).not.toBe(immutable)
+      // immutable なままなら set() が例外を投げる
+      if (res instanceof Response) {
+        expect(() => res.headers.set('X-Frame-Options', 'DENY')).not.toThrow()
+      }
     })
   })
 

--- a/application/apps/web/src/middleware/article-cache.test.ts
+++ b/application/apps/web/src/middleware/article-cache.test.ts
@@ -1,4 +1,3 @@
-import type { Context } from 'hono'
 import { Hono } from 'hono'
 import type { Mock } from 'vitest'
 import type { Env } from '@/env'
@@ -98,34 +97,33 @@ describe('articleCache ミドルウェア', () => {
       expect(await res.text()).toBe('cached-body')
     })
 
-    it('キャッシュヒット時はヘッダが可変な Response を返すこと', async () => {
+    it('キャッシュヒット時は後続ミドルウェアがヘッダを変更できる応答を返すこと', async () => {
       // Cache API が返す Response はヘッダが immutable。これをそのまま返すと後続の
       // secureHeaders がヘッダを付与できず "Can't modify immutable headers" で 5xx になる。
       // workerd では Response.redirect のヘッダが immutable になるため Cache API 応答の代用にする
-      const immutable = Response.redirect('https://example.com/redirect', 302)
       vi.stubGlobal('caches', {
-        default: { match: vi.fn(async () => immutable), put: vi.fn() },
+        default: {
+          match: vi.fn(async () => Response.redirect('https://example.com/redirect', 302)),
+          put: vi.fn(),
+        },
       })
 
-      // ヒット経路のみを検証するため、ミドルウェアを直接呼び出して戻り値の Response を得る
-      const next = vi.fn(async () => {})
-      const mockContext = {
-        env: { ...TEST_ENV, EDGE_CACHE_DISABLED: undefined },
-        req: { method: 'GET', url: ARTICLES_URL, header: () => undefined },
-        executionCtx: { waitUntil: vi.fn() },
-      }
-      // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-restricted-types -- ヒット経路が参照する最小限のフィールドのみを持つモックを Context として渡すため
-      const c = mockContext as unknown as Context<Env>
+      // next 後にヘッダを付与する外側ミドルウェアで secureHeaders を模し、実際のチェーンを走らせる
+      const app = new Hono<Env>()
+        .use(async (c, next) => {
+          await next()
+          c.res.headers.set('X-Frame-Options', 'DENY')
+        })
+        .use('/api/articles/*', articleCache)
 
-      const res = await articleCache(c, next)
+      const res = await app.request(
+        ARTICLES_URL,
+        { method: 'GET' },
+        { ...TEST_ENV, EDGE_CACHE_DISABLED: undefined },
+      )
 
-      expect(next).not.toHaveBeenCalled()
-      expect(res).toBeInstanceOf(Response)
-      expect(res).not.toBe(immutable)
-      // immutable なままなら set() が例外を投げる
-      if (res instanceof Response) {
-        expect(() => res.headers.set('X-Frame-Options', 'DENY')).not.toThrow()
-      }
+      expect(res.status).toBe(302)
+      expect(res.headers.get('X-Frame-Options')).toBe('DENY')
     })
   })
 

--- a/application/apps/web/src/middleware/article-cache.ts
+++ b/application/apps/web/src/middleware/article-cache.ts
@@ -32,7 +32,9 @@ const articleCache = createMiddleware<Env>(async (c, next) => {
   const cacheKey = new Request(c.req.url, { method: 'GET' })
 
   const hit = await cache.match(cacheKey)
-  if (hit) return hit
+  // Cache API が返す Response はヘッダが immutable のため、素通しすると後続の secureHeaders 等が
+  // ヘッダを変更できず落ちる。可変なヘッダを持つ Response に作り直して返す
+  if (hit) return new Response(hit.body, hit)
 
   await next()
 


### PR DESCRIPTION
# 概要

`GET /api/articles` が本番でエッジキャッシュヒット時に `TypeError: Can't modify immutable headers.` で 5xx を返していた不具合を修正する。

## 問題のあった領域
<!-- どの領域に問題があったかチェックを入れてください -->

- [ ] フロントエンド
  - [ ] UIの描画(レンダリング)
  - [ ] ビジネスロジック（状態管理、非同期処理、エラーハンドリングなど）
  - [ ] バックエンドとの整合ミス
- [x] バックエンド
  - [x] API（プレゼン層）
  - [ ] ビジネスロジック
  - [ ] データアクセス（DB・SQL）
  - [ ] 脆弱性
- [ ] その他
    - [ ] CI/CD（GitHub Actionsやクラウド上のCI/CD関連）
    - [ ] インフラ（パブリッククラウドの設定・技術詳細）

### 要因の詳細
<!-- 詳しく事象を記載してください -->

`articleCache` ミドルウェアは、キャッシュヒット時に Cloudflare Cache API (`caches.default.match`) が返す `Response` をそのまま返却していた。Cache API が返す `Response` はヘッダが **immutable** であるため、外側に登録された `secureHeaders()` ミドルウェアが `next()` 後にセキュリティヘッダを付与しようとした際に `TypeError: Can't modify immutable headers.` が発生し、5xx となっていた。

スタックトレース（本番）:

```
TypeError: Can't modify immutable headers.
    at setHeaders (worker.js)
    at Object.secureHeaders2 [as handler]
    ...
```

ミドルウェアの適用順は `secureHeaders()`（外側 / server.ts）→ `articleCache`（`/api/articles` ルート）であり、`secureHeaders()` は `next()` 完了後に `c.res.headers` を変更するため、キャッシュヒットで immutable な応答がそのまま伝播すると必ず失敗する。

### 再現手順

1. 未ログイン状態で `GET /api/articles` にアクセスし、応答をエッジキャッシュに載せる
2. TTL（5 分）以内に同一 URL へ再アクセスする（キャッシュヒット）
3. `secureHeaders()` がヘッダ付与に失敗し 5xx が返る

## 修正方針
<!-- 方針を網羅的に記載し、修正判断を下した理由を記載してください -->

キャッシュヒット時に、Cache API から得た `Response` を `new Response(hit.body, hit)` で作り直し、可変なヘッダを持つ `Response` として返すようにした。これにより後続の `secureHeaders()` がヘッダを変更できるようになる。

あわせて、キャッシュヒット時に可変なヘッダを持つ `Response` を返すことを検証する回帰テストを追加した（workerd では `Response.redirect` のヘッダが immutable になる性質を利用して Cache API 応答を代用）。

### その方針を選んだ理由

`new Response(body, response)` は Cloudflare Workers で immutable な応答を可変にする定石であり、ステータス・ヘッダ・ボディを維持したまま最小限の変更で解消できるため。ミドルウェアの適用順の入れ替えや `secureHeaders` 側の回避策よりも影響範囲が小さい。

## その他、参考情報

- 変更ファイル
  - `application/apps/web/src/middleware/article-cache.ts`
  - `application/apps/web/src/middleware/article-cache.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016Yz5SJBBRP6bSh3VL953Az)_