### PR TITLE
perf(web): クライアントバンドルからサーバ専用のdatastore/drizzleを除外する

### DIFF
--- a/application/apps/web/.oxlintrc.json
+++ b/application/apps/web/.oxlintrc.json
@@ -60,7 +60,10 @@
                 "message": "Client code must not import domain use-case factories (create*UseCase). Call them via the Hono API so middleware (rate limiting, CSRF, etc.) is applied."
               },
               {
-                "group": ["@trend-diary/domain/account", "@trend-diary/domain/article"],
+                "group": [
+                  "@trend-diary/domain/account{,/index}",
+                  "@trend-diary/domain/article{,/index}"
+                ],
                 "message": "Client code must not import the domain aggregate barrels; they re-export use-case factories that transitively pull server-only datastore code into the client bundle. Import the specific leaf module instead (e.g. @trend-diary/domain/account/schema/auth-schema)."
               }
             ]

--- a/application/apps/web/.oxlintrc.json
+++ b/application/apps/web/.oxlintrc.json
@@ -58,6 +58,10 @@
                 "group": ["@trend-diary/domain", "@trend-diary/domain/*"],
                 "importNamePattern": "^create\\w*UseCase$",
                 "message": "Client code must not import domain use-case factories (create*UseCase). Call them via the Hono API so middleware (rate limiting, CSRF, etc.) is applied."
+              },
+              {
+                "group": ["@trend-diary/domain/account", "@trend-diary/domain/article"],
+                "message": "Client code must not import the domain aggregate barrels; they re-export use-case factories that transitively pull server-only datastore code into the client bundle. Import the specific leaf module instead (e.g. @trend-diary/domain/account/schema/auth-schema)."
               }
             ]
           }

--- a/application/apps/web/src/client/entities/auth/model/validation.ts
+++ b/application/apps/web/src/client/entities/auth/model/validation.ts
@@ -1,4 +1,4 @@
-import { authInputSchema } from '@trend-diary/domain/account'
+import { authInputSchema } from '@trend-diary/domain/account/schema/auth-schema'
 
 export interface AuthenticateErrors {
   email?: string[]


### PR DESCRIPTION
# 概要

PageSpeed Insights（`/trends`・モバイル）で「使用していない JavaScript の削減（約 47 KiB）」が指摘され、`/trends` が読み込む `auth-*.js` チャンクに大量の未使用 JS が含まれていました。原因を調査したところ、**サーバ専用の datastore / drizzle-orm コードがクライアントバンドルに混入**していました。

## 課題

- `/trends` は記事一覧の取得（SWR）でエラーハンドリング用に `entities/auth` から `notifyFetchError` / `notifySessionExpired` 等だけを利用している。
- しかし同じ共有 `auth` チャンクに、ブラウザでは決して実行されない datastore/drizzle のコードが同梱されていた（ビルド成果物に `datetime(... 'unixepoch')` という D1/SQLite 用 SQL 文字列が含まれることを確認）。
- 結果として `/trends` の初回ロードで未使用 JS を余分にダウンロードしていた。

### 要因

- `src/client/entities/auth/model/validation.ts` が zod スキーマ `authInputSchema` を、集約バレル `@trend-diary/domain/account`（`account/index.ts`）から取得していた。
- このバレルは `createAccountUseCase` を再エクスポートしており、その先の repository 実装（`command-impl` / `query-impl`）が `@trend-diary/datastore/drizzle-orm/schema` と `@trend-diary/datastore/rdb` を**実行時 import** する。
- datastore のスキーマ定義はモジュールスコープの副作用（テーブル定義呼び出し）を持ち tree-shaking で除去できないため、バレル経由でクライアントまで巻き込まれていた。
- 既存の `no-restricted-imports`（`create*UseCase` を名指しで禁止）は、import する**名前**が `authInputSchema` だったため検知できなかった。

## 修正内容

- `validation.ts` の import をバレルから leaf モジュールへ変更し、副作用のある use-case グラフを辿らないようにした。
  - `@trend-diary/domain/account` → `@trend-diary/domain/account/schema/auth-schema`
  - 既存のクライアント側ドメイン import（`article/media` 等）と同じく粒度の細かいサブパス import に揃える方針。
- 再発防止として、クライアントからドメイン集約バレル（`@trend-diary/domain/account` / `@trend-diary/domain/article`）を import することを `no-restricted-imports` で禁止した。名前ベースの既存ルールでは今回のケースを拾えないため、バレルルート自体を塞ぐ。

### その方針を選んだ理由

- datastore はそもそもクライアントで一切実行されない（API 経由でアクセスする設計）ため、バンドルから除去するのが正しく、機能への影響がない。
- 大掛かりな chunk 分割設定に頼らず、leaf import への変更という最小・低リスクな修正で根本原因（副作用モジュールの巻き込み）を解消できる。ログイン/サインアップ画面（`validation.ts` を利用）にも同様に効く。

## レビュー観点

### 外部品質（パフォーマンス）

`pnpm build` の `auth` チャンク実測値:

| | raw | gzip |
|---|---|---|
| 修正前 | 122.62 KiB | 36.73 KiB |
| 修正後 | 90.62 KiB | 27.41 KiB |
| 差分 | **-32.00 KiB** | **-9.32 KiB** |

- ビルド成果物の `auth` チャンクから `unixepoch` を含む datastore SQL が消えたことを確認済み。
- `jsx-runtime` チャンク（React/react-router のベンダー）は別要因のため本 PR の対象外（server コードの混入なしを確認済み）。

### 内部品質

- `pnpm typecheck` 通過。
- 変更に関係する node 系ユニットテスト（`use-articles` / `notify-fetch-error`）通過。フルテストは Playwright ブラウザ未配置の環境要因で別途失敗するが、本変更とは無関係。
- 追加した lint ルールが、バレル import に対してのみエラーを出し、現行コードには違反ゼロであることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nf9hL1S6aNy1mo68DR2sQR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nf9hL1S6aNy1mo68DR2sQR)_