### PR TITLE
fix(web): ページネーションの前へ/次へを button で描画しユーザー補助ツリーを是正

### DIFF
--- a/application/apps/web/src/client/components/shadcn/pagination.tsx
+++ b/application/apps/web/src/client/components/shadcn/pagination.tsx
@@ -30,23 +30,50 @@ function PaginationItem({ ...props }: React.ComponentProps<'li'>) {
 
 type PaginationLinkProps = {
   isActive?: boolean
+  disabled?: boolean
 } & Pick<React.ComponentProps<typeof Button>, 'size'> &
   React.ComponentProps<'a'>
 
-function PaginationLink({ className, isActive, size = 'icon', ...props }: PaginationLinkProps) {
+function PaginationLink({
+  className,
+  isActive,
+  disabled,
+  size = 'icon',
+  href,
+  ...props
+}: PaginationLinkProps) {
+  const sharedClassName = cn(
+    buttonVariants({
+      variant: isActive ? 'outline' : 'ghost',
+      size,
+    }),
+    'cursor-pointer',
+    className,
+  )
+
+  // href が無い場合はページ遷移ではなくクリックハンドラで処理する操作ボタンのため、<a> ではなく <button> で描画する。
+  // href の無い <a> は generic ロールとなり aria-disabled 等の ARIA 属性が許可されず、ユーザー補助ツリーの監査で不適格になる
+  if (href === undefined) {
+    return (
+      <button
+        type='button'
+        disabled={disabled}
+        aria-current={isActive ? 'page' : undefined}
+        data-slot='pagination-link'
+        data-active={isActive}
+        className={sharedClassName}
+        {...(props as React.ComponentProps<'button'>)}
+      />
+    )
+  }
+
   return (
     <a
+      href={href}
       aria-current={isActive ? 'page' : undefined}
       data-slot='pagination-link'
       data-active={isActive}
-      className={cn(
-        buttonVariants({
-          variant: isActive ? 'outline' : 'ghost',
-          size,
-        }),
-        'cursor-pointer',
-        className,
-      )}
+      className={sharedClassName}
       {...props}
     />
   )

--- a/application/apps/web/src/client/components/shadcn/pagination.tsx
+++ b/application/apps/web/src/client/components/shadcn/pagination.tsx
@@ -51,9 +51,10 @@ function PaginationLink({
     className,
   )
 
-  // href が無い場合はページ遷移ではなくクリックハンドラで処理する操作ボタンのため、<a> ではなく <button> で描画する。
-  // href の無い <a> は generic ロールとなり aria-disabled 等の ARIA 属性が許可されず、ユーザー補助ツリーの監査で不適格になる
-  if (href === undefined) {
+  // href が無い（クリックハンドラで処理する操作）場合、または disabled の場合は <a> ではなく <button> で描画する。
+  // href の無い <a> は generic ロールとなり aria-disabled 等の ARIA 属性が許可されず監査で不適格になる。
+  // また <a> は native disabled を持たないため、disabled 指定時も <button> にしないと無効化の表現・挙動が成立しない
+  if (href === undefined || disabled) {
     return (
       <button
         type='button'

--- a/application/apps/web/src/client/routes/trends._index/page.test.ts
+++ b/application/apps/web/src/client/routes/trends._index/page.test.ts
@@ -3,6 +3,9 @@ import { type ComponentProps, createElement } from 'react'
 import { ALL_MEDIA, type Article } from '@/client/features/article'
 import TrendsPage from './page'
 
+// ページ送りクリックで呼ばれる scrollToTop（window.scrollTo）を jsdom 向けに補う
+Object.defineProperty(window, 'scrollTo', { writable: true, value: vi.fn() })
+
 // FilterPanel が参照する matchMedia を jsdom 向けに補う
 Object.defineProperty(window, 'matchMedia', {
   writable: true,

--- a/application/apps/web/src/client/routes/trends._index/page.test.ts
+++ b/application/apps/web/src/client/routes/trends._index/page.test.ts
@@ -106,4 +106,71 @@ describe('TrendsPage', () => {
     expect(screen.queryByText('記事がありません')).not.toBeInTheDocument()
     expect(screen.queryByRole('button', { name: '再試行' })).not.toBeInTheDocument()
   })
+
+  // ページ送りは遷移リンクではなくクリック操作のため、ユーザー補助ツリー上も button ロールで露出させ aria 属性の不整合を避ける
+  describe('ページネーション', () => {
+    it('前へ・次へは button ロールで公開される', () => {
+      render(
+        createElement(
+          TrendsPage,
+          buildProps({ articles: [buildArticle()], page: 2, totalPages: 3 }),
+        ),
+      )
+
+      expect(screen.getByRole('button', { name: 'Go to previous page' })).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'Go to next page' })).toBeInTheDocument()
+    })
+
+    it('先頭ページでは前へが無効・次へが有効になる', () => {
+      render(
+        createElement(
+          TrendsPage,
+          buildProps({ articles: [buildArticle()], page: 1, totalPages: 3 }),
+        ),
+      )
+
+      expect(screen.getByRole('button', { name: 'Go to previous page' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'Go to next page' })).toBeEnabled()
+    })
+
+    it('最終ページでは次へが無効・前へが有効になる', () => {
+      render(
+        createElement(
+          TrendsPage,
+          buildProps({ articles: [buildArticle()], page: 3, totalPages: 3 }),
+        ),
+      )
+
+      expect(screen.getByRole('button', { name: 'Go to next page' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'Go to previous page' })).toBeEnabled()
+    })
+
+    it('次へを押すと次ページへ遷移する', () => {
+      const toNextPage = vi.fn()
+      render(
+        createElement(
+          TrendsPage,
+          buildProps({ articles: [buildArticle()], page: 1, totalPages: 3, toNextPage }),
+        ),
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Go to next page' }))
+
+      expect(toNextPage).toHaveBeenCalledWith(1)
+    })
+
+    it('前へを押すと前ページへ遷移する', () => {
+      const toPreviousPage = vi.fn()
+      render(
+        createElement(
+          TrendsPage,
+          buildProps({ articles: [buildArticle()], page: 2, totalPages: 3, toPreviousPage }),
+        ),
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'Go to previous page' }))
+
+      expect(toPreviousPage).toHaveBeenCalledWith(2)
+    })
+  })
 })

--- a/application/apps/web/src/client/routes/trends._index/page.tsx
+++ b/application/apps/web/src/client/routes/trends._index/page.tsx
@@ -1,5 +1,4 @@
 import { toJaDateString } from '@trend-diary/common/locale'
-import { twMerge } from 'tailwind-merge'
 import { Button } from '@/client/components/shadcn/button'
 import {
   Pagination,
@@ -26,11 +25,8 @@ import { scrollToTop } from '@/client/lib/scroll'
 // ローディング中に一覧領域を埋めるスケルトン枚数。1ページの件数に近い枚数で領域の急な伸縮を抑える
 const SKELETON_KEYS = Array.from({ length: 8 }, (_, i) => `skeleton-${i}`)
 
-const getPaginationClass = (isDisabled: boolean) =>
-  twMerge(
-    'border-solid border border-b-border cursor-pointer',
-    isDisabled ? 'opacity-50 cursor-not-allowed' : '',
-  )
+// 無効時の淡色化・クリック抑止は buttonVariants の disabled: スタイルが担うため、ここでは枠線とカーソルのみ指定する
+const PAGINATION_LINK_CLASS = 'border-solid border border-b-border cursor-pointer'
 
 const DEFAULT_FILTERS: FilterParams = {
   media: ALL_MEDIA,
@@ -152,17 +148,13 @@ function ArticleList({
   const isNextDisabled = page >= totalPages
 
   const handlePrevPageClick = () => {
-    if (!isPrevDisabled) {
-      toPreviousPage(page)
-      scrollToTop()
-    }
+    toPreviousPage(page)
+    scrollToTop()
   }
 
   const handleNextPageClick = () => {
-    if (!isNextDisabled) {
-      toNextPage(page)
-      scrollToTop()
-    }
+    toNextPage(page)
+    scrollToTop()
   }
 
   return (
@@ -183,7 +175,7 @@ function ArticleList({
           <PaginationItem>
             <PaginationPrevious
               disabled={isPrevDisabled}
-              className={getPaginationClass(isPrevDisabled)}
+              className={PAGINATION_LINK_CLASS}
               onClick={handlePrevPageClick}
             />
           </PaginationItem>
@@ -195,7 +187,7 @@ function ArticleList({
           <PaginationItem>
             <PaginationNext
               disabled={isNextDisabled}
-              className={getPaginationClass(isNextDisabled)}
+              className={PAGINATION_LINK_CLASS}
               onClick={handleNextPageClick}
             />
           </PaginationItem>

--- a/application/apps/web/src/client/routes/trends._index/page.tsx
+++ b/application/apps/web/src/client/routes/trends._index/page.tsx
@@ -182,7 +182,7 @@ function ArticleList({
         <PaginationContent>
           <PaginationItem>
             <PaginationPrevious
-              aria-disabled={isPrevDisabled}
+              disabled={isPrevDisabled}
               className={getPaginationClass(isPrevDisabled)}
               onClick={handlePrevPageClick}
             />
@@ -194,7 +194,7 @@ function ArticleList({
           </PaginationItem>
           <PaginationItem>
             <PaginationNext
-              aria-disabled={isNextDisabled}
+              disabled={isNextDisabled}
               className={getPaginationClass(isNextDisabled)}
               onClick={handleNextPageClick}
             />


### PR DESCRIPTION
# 概要

トレンド一覧のページネーション（前へ/次へ）に対するユーザー補助ツリー（アクセシビリティツリー）の監査で「ユーザー補助ツリーの形式が不適切です（Elements must only use permitted ARIA attributes）」が不合格になっていた問題を修正する。

Closes #964

## 問題のあった領域
<!-- どの領域に問題があったかチェックを入れてください -->

- [x] フロントエンド
  - [x] UIの描画(レンダリング)
  - [ ] ビジネスロジック（状態管理、非同期処理、エラーハンドリングなど）
  - [ ] バックエンドとの整合ミス
- [ ] バックエンド
  - [ ] API（プレゼン層）
  - [ ] ビジネスロジック
  - [ ] データアクセス（DB・SQL）
  - [ ] 脆弱性
- [ ] その他
    - [ ] CI/CD（GitHub Actionsやクラウド上のCI/CD関連）
    - [ ] インフラ（パブリッククラウドの設定・技術詳細）

### 要因の詳細
<!-- 詳しく事象を記載してください -->

`PaginationLink`（`PaginationPrevious` / `PaginationNext`）は `href` を持たない `<a>` として描画されていた。`href` の無い `<a>` はリンクロールを持たず generic ロールになるため、`aria-disabled` などの ARIA 属性が許可されず、監査で以下の要素が不合格になっていた。

```html
<a data-slot="pagination-link" ... aria-label="Go to previous page" aria-disabled="true">
```

ページ送りは実際にはページ遷移リンクではなく、クリックハンドラで状態を更新する操作ボタンとして使われている（`href` は付与していない）。

### 再現手順

1. トレンド一覧（`/trends`）を表示する
2. Lighthouse 等でユーザー補助（アクセシビリティ）監査を実行する
3. 「ユーザー補助ツリーの形式が不適切です」でページネーションの前へ/次へが不合格になる

## 修正方針
<!-- 方針を網羅的に記載し、修正判断を下した理由を記載してください -->

- `PaginationLink` を、`href` が無い場合は `<a>` ではなく `<button type="button">` で描画するように変更した。button ロールは `aria-disabled` 等の ARIA 属性を許可するため監査に適合する。
- トレンド一覧では無効化を `aria-disabled` ではなく button ネイティブの `disabled` 属性で表現するようにした。これによりキーボード操作・スクリーンリーダーからも正しく無効状態として扱われる。
- 既存の読書履歴ページネーション（`DiaryReadPagination`）は既に `<button disabled>` を用いており、その実装方針に揃えた。
- `href` を渡した場合は従来どおり `<a>` として描画するため、リンクとしての利用も引き続き可能。

### その方針を選んだ理由

`href` の無い操作要素を `<a>` のまま ARIA 属性だけ足しても generic ロールのままで監査に適合しない。クリック操作の実体に合わせて button ロールへ露出させるのが標準に沿った是正であり、ネイティブ `disabled` を使うことで無効状態の伝達も含めてアクセシビリティが担保できるため。

## その他、参考情報

- テスト: `trends._index/page.test.ts` に、前へ/次へが button ロールで公開されること、先頭/最終ページでの無効・有効状態、クリックでページ遷移コールバックが呼ばれることを追加した。
- 影響範囲: shadcn `Pagination` を利用するのはトレンド一覧のみ。分析・日記ページは別コンポーネント（button ベース）を利用しており影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVgbrLtPaMBfMWHEfGjTxK)_