### PR TITLE
fix(web): トレンド一覧のページ送りをクロール可能なリンクにする

### DIFF
--- a/application/apps/web/src/client/features/article/hooks/use-articles.test.ts
+++ b/application/apps/web/src/client/features/article/hooks/use-articles.test.ts
@@ -599,6 +599,37 @@ describe('useArticles', () => {
         { init: { credentials: 'include' } },
       )
     })
+
+    it('前へ・次へのリンク先(href)が前後のページを指す（検索エンジンがたどれるようにする）', async () => {
+      mockApiClient.articles.$get.mockResolvedValue(
+        generateFakeResponse({ page: 2, totalPages: 3 }),
+      )
+
+      const { result } = setupHook(['/?page=2'])
+
+      await waitFor(() => {
+        expect(result.current.page).toBe(2)
+      })
+
+      // page=1 は既定ページのため href からは page を落として素の URL にする
+      expect(result.current.prevPageHref).toBe('/')
+      expect(result.current.nextPageHref).toBe('/?page=3')
+    })
+
+    it('リンク先(href)は page 以外の絞り込みクエリを保持する', async () => {
+      mockApiClient.articles.$get.mockResolvedValue(
+        generateFakeResponse({ page: 2, totalPages: 3 }),
+      )
+
+      const { result } = setupHook(['/?media=qiita&page=2'])
+
+      await waitFor(() => {
+        expect(result.current.page).toBe(2)
+      })
+
+      expect(result.current.prevPageHref).toBe('/?media=qiita')
+      expect(result.current.nextPageHref).toBe('/?media=qiita&page=3')
+    })
   })
 
   describe('APIのエラーケース', () => {

--- a/application/apps/web/src/client/features/article/hooks/use-articles.ts
+++ b/application/apps/web/src/client/features/article/hooks/use-articles.ts
@@ -9,7 +9,7 @@ import {
 import { wrapAsyncCall } from '@trend-diary/common/result'
 import { isArticleMedia } from '@trend-diary/domain/article/media'
 import type { ArticleOutput } from '@trend-diary/domain/article/schema/article-schema'
-import { useSearchParams } from 'react-router'
+import { useLocation, useSearchParams } from 'react-router'
 import { toast } from 'sonner'
 import useSWR from 'swr'
 import { useIsMobile } from '@/client/components/shadcn/hooks/use-mobile'
@@ -117,8 +117,18 @@ const applyDatePresetToSearchParams = (
   params.set('to', to)
 }
 
+// page=1 は既定ページのためクエリから除き URL を素にする。1 より大きいときだけ page を持たせる
+const applyPageToSearchParams = (params: URLSearchParams, targetPage: number) => {
+  if (targetPage > 1) {
+    params.set('page', targetPage.toString())
+  } else {
+    params.delete('page')
+  }
+}
+
 export default function useArticles(isLoggedIn = false) {
   const [searchParams, setSearchParams] = useSearchParams()
+  const location = useLocation()
   const isMobile = useIsMobile()
   const { client, apiCall } = createSWRFetcher()
 
@@ -254,13 +264,19 @@ export default function useArticles(isLoggedIn = false) {
 
   const handlePageChange = (newPage: number) => {
     const newParams = new URLSearchParams(searchParams)
-    if (newPage > 1) {
-      newParams.set('page', newPage.toString())
-    } else {
-      newParams.delete('page')
-    }
+    applyPageToSearchParams(newParams, newPage)
 
     setSearchParams(newParams)
+  }
+
+  // 検索エンジンがページ送りをたどれるよう、前へ／次へに実体のある href を持たせるためのリンク先を組み立てる。
+  // SPA 遷移（setSearchParams）後の URL と一致するよう、handlePageChange と同じ page 付与ルールを使う
+  const buildPagePath = (targetPage: number) => {
+    const newParams = new URLSearchParams(searchParams)
+    applyPageToSearchParams(newParams, targetPage)
+
+    const queryString = newParams.toString()
+    return queryString ? `${location.pathname}?${queryString}` : location.pathname
   }
 
   const clearPageParam = (params: URLSearchParams) => {
@@ -311,11 +327,15 @@ export default function useArticles(isLoggedIn = false) {
     setSearchParams(newParams)
   }
 
+  const resolvedPage = data?.page || params.page
+
   return {
     date,
     articles: data?.data || [],
     updateArticleReadState,
-    page: data?.page || params.page,
+    page: resolvedPage,
+    prevPageHref: buildPagePath(resolvedPage - 1),
+    nextPageHref: buildPagePath(resolvedPage + 1),
     limit: data?.limit || params.limit,
     totalPages: data?.totalPages || 1,
     isLoading,

--- a/application/apps/web/src/client/routes/trends._index/page.test.ts
+++ b/application/apps/web/src/client/routes/trends._index/page.test.ts
@@ -42,6 +42,8 @@ const buildProps = (overrides: Partial<TrendsPageProps> = {}): TrendsPageProps =
   hasError: false,
   page: 1,
   totalPages: 1,
+  prevPageHref: '/trends',
+  nextPageHref: '/trends?page=2',
   selectedMedia: ALL_MEDIA,
   selectedReadStatus: 'all',
   selectedDatePreset: 'today',
@@ -110,21 +112,34 @@ describe('TrendsPage', () => {
     expect(screen.queryByRole('button', { name: '再試行' })).not.toBeInTheDocument()
   })
 
-  // ページ送りは遷移リンクではなくクリック操作のため、ユーザー補助ツリー上も button ロールで露出させ aria 属性の不整合を避ける
+  // 検索エンジンがページ送りをたどれるよう、遷移可能な前へ・次へは href を持つリンク（link ロール）で公開する。
+  // 遷移先の無い無効状態は button（disabled）で公開し、href 無しの <a> による aria 属性の不整合を避ける
   describe('ページネーション', () => {
-    it('前へ・次へは button ロールで公開される', () => {
+    it('遷移可能な前へ・次へは遷移先の href を持つ link ロールで公開される', () => {
       render(
         createElement(
           TrendsPage,
-          buildProps({ articles: [buildArticle()], page: 2, totalPages: 3 }),
+          buildProps({
+            articles: [buildArticle()],
+            page: 2,
+            totalPages: 3,
+            prevPageHref: '/trends',
+            nextPageHref: '/trends?page=3',
+          }),
         ),
       )
 
-      expect(screen.getByRole('button', { name: 'Go to previous page' })).toBeInTheDocument()
-      expect(screen.getByRole('button', { name: 'Go to next page' })).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Go to previous page' })).toHaveAttribute(
+        'href',
+        '/trends',
+      )
+      expect(screen.getByRole('link', { name: 'Go to next page' })).toHaveAttribute(
+        'href',
+        '/trends?page=3',
+      )
     })
 
-    it('先頭ページでは前へが無効・次へが有効になる', () => {
+    it('先頭ページでは前へが無効な button・次へが遷移可能な link になる', () => {
       render(
         createElement(
           TrendsPage,
@@ -133,10 +148,10 @@ describe('TrendsPage', () => {
       )
 
       expect(screen.getByRole('button', { name: 'Go to previous page' })).toBeDisabled()
-      expect(screen.getByRole('button', { name: 'Go to next page' })).toBeEnabled()
+      expect(screen.getByRole('link', { name: 'Go to next page' })).toBeInTheDocument()
     })
 
-    it('最終ページでは次へが無効・前へが有効になる', () => {
+    it('最終ページでは次へが無効な button・前へが遷移可能な link になる', () => {
       render(
         createElement(
           TrendsPage,
@@ -145,10 +160,10 @@ describe('TrendsPage', () => {
       )
 
       expect(screen.getByRole('button', { name: 'Go to next page' })).toBeDisabled()
-      expect(screen.getByRole('button', { name: 'Go to previous page' })).toBeEnabled()
+      expect(screen.getByRole('link', { name: 'Go to previous page' })).toBeInTheDocument()
     })
 
-    it('次へを押すと次ページへ遷移する', () => {
+    it('次へを押すと既定挙動を抑止して次ページへ SPA 遷移する', () => {
       const toNextPage = vi.fn()
       render(
         createElement(
@@ -157,12 +172,15 @@ describe('TrendsPage', () => {
         ),
       )
 
-      fireEvent.click(screen.getByRole('button', { name: 'Go to next page' }))
+      const nextLink = screen.getByRole('link', { name: 'Go to next page' })
+      const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true })
+      fireEvent(nextLink, clickEvent)
 
       expect(toNextPage).toHaveBeenCalledWith(1)
+      expect(clickEvent.defaultPrevented).toBe(true)
     })
 
-    it('前へを押すと前ページへ遷移する', () => {
+    it('前へを押すと既定挙動を抑止して前ページへ SPA 遷移する', () => {
       const toPreviousPage = vi.fn()
       render(
         createElement(
@@ -171,9 +189,33 @@ describe('TrendsPage', () => {
         ),
       )
 
-      fireEvent.click(screen.getByRole('button', { name: 'Go to previous page' }))
+      const prevLink = screen.getByRole('link', { name: 'Go to previous page' })
+      const clickEvent = new MouseEvent('click', { bubbles: true, cancelable: true })
+      fireEvent(prevLink, clickEvent)
 
       expect(toPreviousPage).toHaveBeenCalledWith(2)
+      expect(clickEvent.defaultPrevented).toBe(true)
+    })
+
+    it('修飾キー付きクリックはブラウザ標準挙動に任せ SPA 遷移へ差し替えない', () => {
+      const toNextPage = vi.fn()
+      render(
+        createElement(
+          TrendsPage,
+          buildProps({ articles: [buildArticle()], page: 1, totalPages: 3, toNextPage }),
+        ),
+      )
+
+      const nextLink = screen.getByRole('link', { name: 'Go to next page' })
+      const clickEvent = new MouseEvent('click', {
+        bubbles: true,
+        cancelable: true,
+        metaKey: true,
+      })
+      fireEvent(nextLink, clickEvent)
+
+      expect(toNextPage).not.toHaveBeenCalled()
+      expect(clickEvent.defaultPrevented).toBe(false)
     })
   })
 })

--- a/application/apps/web/src/client/routes/trends._index/page.tsx
+++ b/application/apps/web/src/client/routes/trends._index/page.tsx
@@ -1,4 +1,5 @@
 import { toJaDateString } from '@trend-diary/common/locale'
+import type { MouseEvent } from 'react'
 import { Button } from '@/client/components/shadcn/button'
 import {
   Pagination,
@@ -27,6 +28,10 @@ const SKELETON_KEYS = Array.from({ length: 8 }, (_, i) => `skeleton-${i}`)
 
 // 無効時の淡色化・クリック抑止は buttonVariants の disabled: スタイルが担うため、ここでは枠線とカーソルのみ指定する
 const PAGINATION_LINK_CLASS = 'border-solid border border-b-border cursor-pointer'
+
+// 修飾キー・中クリック等（新規タブで開く等のブラウザ標準挙動）は href に任せ、通常クリックだけ SPA 遷移に差し替える
+const isModifiedClick = (event: MouseEvent<HTMLAnchorElement>) =>
+  event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey
 
 const DEFAULT_FILTERS: FilterParams = {
   media: ALL_MEDIA,
@@ -58,6 +63,8 @@ export default function TrendsPage({
   selectedMedia,
   selectedReadStatus,
   selectedDatePreset,
+  prevPageHref,
+  nextPageHref,
   toNextPage,
   toPreviousPage,
   onApplyFilters,
@@ -101,6 +108,8 @@ export default function TrendsPage({
         isLoggedIn={isLoggedIn}
         page={page}
         totalPages={totalPages}
+        prevPageHref={prevPageHref}
+        nextPageHref={nextPageHref}
         toNextPage={toNextPage}
         toPreviousPage={toPreviousPage}
       />
@@ -119,6 +128,8 @@ interface ArticleListProps {
   isLoggedIn: boolean
   page: number
   totalPages: number
+  prevPageHref: string
+  nextPageHref: string
   toNextPage: (currentPage: number) => void
   toPreviousPage: (currentPage: number) => void
 }
@@ -134,6 +145,8 @@ function ArticleList({
   isLoggedIn,
   page,
   totalPages,
+  prevPageHref,
+  nextPageHref,
   toNextPage,
   toPreviousPage,
 }: ArticleListProps) {
@@ -147,12 +160,16 @@ function ArticleList({
   const isPrevDisabled = page <= 1
   const isNextDisabled = page >= totalPages
 
-  const handlePrevPageClick = () => {
+  const handlePrevPageClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (isModifiedClick(event)) return
+    event.preventDefault()
     toPreviousPage(page)
     scrollToTop()
   }
 
-  const handleNextPageClick = () => {
+  const handleNextPageClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    if (isModifiedClick(event)) return
+    event.preventDefault()
     toNextPage(page)
     scrollToTop()
   }
@@ -174,6 +191,7 @@ function ArticleList({
         <PaginationContent>
           <PaginationItem>
             <PaginationPrevious
+              href={prevPageHref}
               disabled={isPrevDisabled}
               className={PAGINATION_LINK_CLASS}
               onClick={handlePrevPageClick}
@@ -186,6 +204,7 @@ function ArticleList({
           </PaginationItem>
           <PaginationItem>
             <PaginationNext
+              href={nextPageHref}
               disabled={isNextDisabled}
               className={PAGINATION_LINK_CLASS}
               onClick={handleNextPageClick}

--- a/application/apps/web/src/client/routes/trends._index/route.tsx
+++ b/application/apps/web/src/client/routes/trends._index/route.tsx
@@ -29,6 +29,8 @@ export default function Trends() {
     hasError,
     page,
     totalPages,
+    prevPageHref,
+    nextPageHref,
     date,
     handleFiltersApply,
     toPreviousPage,
@@ -65,6 +67,8 @@ export default function Trends() {
         hasError={hasError}
         page={page}
         totalPages={totalPages}
+        prevPageHref={prevPageHref}
+        nextPageHref={nextPageHref}
         selectedMedia={selectedMedia}
         toPreviousPage={toPreviousPage}
         toNextPage={toNextPage}


### PR DESCRIPTION
# 概要

close #965

PageSpeed Insights のトレンド一覧（`/trends`）で「リンクはクロールできません」が指摘されていた。ページ送り（前へ／次へ）が `onClick` のみで遷移する `<button>` として描画されており、遷移先を表す `href` を持たないため、検索エンジンがページ送り先のページを発見・クロールできない状態だった。

## 問題のあった領域
<!-- どの領域に問題があったかチェックを入れてください -->

- [x] フロントエンド
  - [x] UIの描画(レンダリング)
  - [ ] ビジネスロジック（状態管理、非同期処理、エラーハンドリングなど）
  - [ ] バックエンドとの整合ミス
- [ ] バックエンド
  - [ ] API（プレゼン層）
  - [ ] ビジネスロジック
  - [ ] データアクセス（DB・SQL）
  - [ ] 脆弱性
- [ ] その他
    - [ ] CI/CD（GitHub Actionsやクラウド上のCI/CD関連）
    - [ ] インフラ（パブリッククラウドの設定・技術詳細）

### 要因の詳細
<!-- 詳しく事象を記載してください -->

- 一覧のページ送りは `?page=N` を書き換える SPA 遷移（`setSearchParams`）だけで実装されており、遷移先の URL を表す `href` を持たなかった。
- 遷移先が無い `<a>` は監査で不適格になるため、`PaginationLink` は `href` が無い場合 `<button>` で描画する。結果として前へ／次へがそもそもリンクとして存在せず、クローラがページ送り先をたどれなかった。

### 再現手順

1. `/trends` を PageSpeed Insights（または Lighthouse）で計測する。
2. 「リンクはクロールできません（Links are not crawlable）」に、ページ送りの前へ／次へが挙がる。

## 修正方針
<!-- 方針を網羅的に記載し、修正判断を下した理由を記載してください -->

- `useArticles` に遷移先 URL を組み立てる `prevPageHref` / `nextPageHref` を追加した。既存のページ書き換えと同じルール（`page=1` はクエリから落として素の URL にする）を共有し、絞り込みクエリ（`media` 等）は保持する。
- トレンド一覧の前へ／次へに実体のある `href` を渡し、遷移可能な状態では `<a href>`（`link` ロール）としてクロール可能にした。遷移先の無い無効状態は従来どおり `<button disabled>` で描画する。
- 通常クリックは `preventDefault` して従来どおり SPA 遷移（`setSearchParams`）を維持する。修飾キー・中クリック等はブラウザ標準挙動（新規タブで開く等）に委ねるためガードした。

### その方針を選んだ理由

- クローラは JS のクリック処理ではなく `href` 属性をたどるため、実体のあるリンク先を持たせることが根本対応になる。
- `PaginationLink` は既に「`href` あり＝ `<a href>` / なし・無効＝ `<button>`」の描画分岐を備えていたため、ページ側で正しい `href` を供給するだけで、コンポーネントの責務を崩さずに解決できる。
- SPA の体験（キャッシュ・スクロール制御）を損なわないよう、リンク化しつつ通常クリックのみ既存遷移に差し替える形にした。

## その他、参考情報

- 変更ファイル
  - `use-articles.ts`: `prevPageHref` / `nextPageHref` を算出・公開
  - `trends._index/page.tsx`, `route.tsx`: 前へ／次へへ `href` を配線し、クリックハンドラで SPA 遷移を維持
  - 各 `*.test.ts`: 遷移可能な前へ／次へが `href` を持つ `link` として公開されること、修飾キー付きクリックは SPA 遷移に差し替えないことを検証
- `read-pagination`（ダイアリー）は URL クエリではなく日次ダイジェスト操作のため対象外とした。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BE9NSirSbUDtzJCgHNsN62

---
_Generated by [Claude Code](https://claude.ai/code/session_01BE9NSirSbUDtzJCgHNsN62)_