### PR TITLE
fix(web): メインのランドマークを各ページに設定する

### DIFF
--- a/application/apps/web/src/client/components/ui/layout/page-container/index.tsx
+++ b/application/apps/web/src/client/components/ui/layout/page-container/index.tsx
@@ -7,10 +7,11 @@ type Props = PropsWithChildren<{
 
 // app-layout（ヘッダーあり）配下では min-h-screen だとヘッダー(h-16)分ページが viewport を
 // はみ出し不要なスクロールが出るため、残り高さを埋める flex-1 をこの共通ラッパーに集約する
+// スクリーンリーダーがページ本文へ直接移動できるよう、本文の外枠を main ランドマークにする
 export default function PageContainer({ className, children }: Props) {
   return (
-    <div className={cn('flex-1 bg-gradient-to-br from-muted to-background p-6', className)}>
+    <main className={cn('flex-1 bg-gradient-to-br from-muted to-background p-6', className)}>
       {children}
-    </div>
+    </main>
   )
 }

--- a/application/apps/web/src/client/components/ui/layout/page-container/page-container.stories.tsx
+++ b/application/apps/web/src/client/components/ui/layout/page-container/page-container.stories.tsx
@@ -19,6 +19,8 @@ export const Default: Story = {
   play: async ({ canvas }) => {
     const content = canvas.getByText('本文コンテンツ')
     await expect(content).toBeInTheDocument()
+    // スクリーンリーダー向けに本文を main ランドマークとして公開することを確認する
+    await expect(canvas.getByRole('main')).toContainElement(content)
     // 残り高さを埋める flex-1 が付いていることを確認する
     await expect(content.parentElement).toHaveClass('flex-1')
   },

--- a/application/apps/web/src/client/routes/_index/page.test.ts
+++ b/application/apps/web/src/client/routes/_index/page.test.ts
@@ -8,6 +8,12 @@ function renderTopPage(isLoggedIn: boolean) {
 }
 
 describe('TopPage', () => {
+  it('スクリーンリーダー向けに本文を main ランドマークとして公開する', () => {
+    renderTopPage(false)
+
+    expect(screen.getByRole('main')).toBeInTheDocument()
+  })
+
   describe('未ログイン時', () => {
     it('ヘッダーにログイン・アカウント作成の導線を表示しメニューは表示しない', () => {
       renderTopPage(false)

--- a/application/apps/web/src/client/routes/_index/page.tsx
+++ b/application/apps/web/src/client/routes/_index/page.tsx
@@ -13,160 +13,166 @@ export default function TopPage({ isLoggedIn }: Props) {
     <div className='min-h-screen bg-gradient-to-br from-muted to-background'>
       <LandingHeader isLoggedIn={isLoggedIn} />
 
-      {/* Hero Section */}
-      <section className='relative overflow-hidden'>
-        <div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24'>
-          <div className='text-center'>
-            <div className='flex justify-center mb-8'>
-              <div className='relative'>
-                <div className='flex items-center space-x-2 bg-blue-50 rounded-full px-6 py-2 border border-blue-200'>
-                  <Calendar className='h-5 w-5 text-blue-600' />
-                  <span className='text-blue-800 font-medium'>技術トレンドを日記のように管理</span>
+      <main>
+        {/* Hero Section */}
+        <section className='relative overflow-hidden'>
+          <div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24'>
+            <div className='text-center'>
+              <div className='flex justify-center mb-8'>
+                <div className='relative'>
+                  <div className='flex items-center space-x-2 bg-blue-50 rounded-full px-6 py-2 border border-blue-200'>
+                    <Calendar className='h-5 w-5 text-blue-600' />
+                    <span className='text-blue-800 font-medium'>
+                      技術トレンドを日記のように管理
+                    </span>
+                  </div>
                 </div>
               </div>
+
+              <h1 className='text-5xl sm:text-6xl font-bold text-foreground tracking-tight mb-6'>
+                技術トレンドを
+                <ClipText text='効率的に追跡' className='mt-2' />
+              </h1>
+
+              <p className='text-xl text-muted-foreground max-w-3xl mx-auto mb-10 leading-relaxed'>
+                QiitaやZennの記事を読んだかどうかを管理し、技術トレンドを見逃さない。
+                日々のキャッチアップを日記のように記録できるブラウザアプリです。
+              </p>
+
+              <div className='flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center items-center'>
+                <AnchorLink
+                  to='/trends'
+                  className='inline-flex w-44 sm:w-auto items-center justify-center px-4 py-2.5 sm:px-8 sm:py-4 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-lg text-base sm:text-lg font-semibold hover:bg-blue-700 transition-all duration-200 shadow-lg hover:shadow-xl'
+                >
+                  今すぐ始める
+                </AnchorLink>
+                <AnchorLink
+                  to={isLoggedIn ? '/trends' : '/login'}
+                  className='inline-flex w-44 sm:w-auto items-center justify-center px-4 py-2.5 sm:px-8 sm:py-4 border-2 border-border text-foreground rounded-lg text-base sm:text-lg font-semibold hover:bg-muted transition-all duration-200'
+                >
+                  {isLoggedIn ? 'トレンド一覧へ' : 'ログイン'}
+                </AnchorLink>
+              </div>
+            </div>
+          </div>
+
+          {/* Background Decoration */}
+          <div className='absolute inset-0 -z-10'>
+            <div className='absolute top-20 left-10 w-72 h-72 bg-blue-200 rounded-full mix-blend-multiply filter blur-xl opacity-30 animate-pulse'></div>
+            <div
+              className='absolute top-40 right-10 w-72 h-72 bg-purple-200 rounded-full mix-blend-multiply filter blur-xl opacity-30 animate-pulse'
+              style={{ animationDelay: '2s' }}
+            ></div>
+          </div>
+        </section>
+
+        {/* Features Section */}
+        <section className='py-20 bg-card'>
+          <div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'>
+            <div className='text-center mb-16'>
+              <h2 className='text-3xl font-bold text-foreground mb-4'>
+                なぜTrendDiaryを選ぶのか？
+              </h2>
+              <p className='text-lg text-muted-foreground max-w-2xl mx-auto'>
+                Slack
+                RSSフィードとは違って特定のアプリに依存せず、Webブラウザからトレンド記事を確認できます。
+              </p>
             </div>
 
-            <h1 className='text-5xl sm:text-6xl font-bold text-foreground tracking-tight mb-6'>
-              技術トレンドを
-              <ClipText text='効率的に追跡' className='mt-2' />
-            </h1>
+            <div className='grid grid-cols-1 md:grid-cols-3 gap-8'>
+              <div className='text-center p-6 rounded-xl border border-border hover:border-blue-300 hover:shadow-lg transition-all duration-200'>
+                <div className='w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mx-auto mb-4'>
+                  <BookOpen className='h-6 w-6 text-blue-600' />
+                </div>
+                <h3 className='text-xl font-semibold text-foreground mb-2'>読書状況の管理</h3>
+                <p className='text-muted-foreground'>
+                  記事を読んだかどうかを簡単に記録し、読み逃しを防げます。
+                </p>
+              </div>
 
-            <p className='text-xl text-muted-foreground max-w-3xl mx-auto mb-10 leading-relaxed'>
-              QiitaやZennの記事を読んだかどうかを管理し、技術トレンドを見逃さない。
-              日々のキャッチアップを日記のように記録できるブラウザアプリです。
+              <div className='text-center p-6 rounded-xl border border-border hover:border-blue-300 hover:shadow-lg transition-all duration-200'>
+                <div className='w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center mx-auto mb-4'>
+                  <TrendingUp className='h-6 w-6 text-green-600' />
+                </div>
+                <h3 className='text-xl font-semibold text-foreground mb-2'>トレンド追跡</h3>
+                <p className='text-muted-foreground'>
+                  QiitaやZennの最新技術トレンドを効率的にキャッチアップできます
+                </p>
+              </div>
+
+              <div className='text-center p-6 rounded-xl border border-border hover:border-blue-300 hover:shadow-lg transition-all duration-200'>
+                <div className='w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center mx-auto mb-4'>
+                  <Users className='h-6 w-6 text-purple-600' />
+                </div>
+                <h3 className='text-xl font-semibold text-foreground mb-2'>技術者向け</h3>
+                <p className='text-muted-foreground'>
+                  技術者のニーズに特化した、使いやすいインターフェース
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* System Requirements */}
+        <section className='py-20 bg-muted'>
+          <div className='max-w-4xl mx-auto px-4 sm:px-6 lg:px-8'>
+            <div className='text-center mb-12'>
+              <h2 className='text-3xl font-bold text-foreground mb-4'>対応環境</h2>
+              <p className='text-lg text-muted-foreground'>
+                スマートフォンとデスクトップの両方に対応しています
+              </p>
+            </div>
+
+            <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
+              <div className='bg-card rounded-2xl shadow-sm border border-border p-8 text-center'>
+                <div className='w-20 h-20 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-6'>
+                  <Smartphone className='size-10 text-blue-600' />
+                </div>
+                <h3 className='text-2xl font-semibold text-foreground mb-4'>スマートフォン</h3>
+                <p className='text-muted-foreground'>
+                  移動中や隙間時間に、未読の記事を1件ずつ手軽に消化できます。
+                  主要な操作はモバイル向けに最適化しています。
+                </p>
+              </div>
+
+              <div className='bg-card rounded-2xl shadow-sm border border-border p-8 text-center'>
+                <div className='w-20 h-20 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-6'>
+                  <Monitor className='size-10 text-blue-600' />
+                </div>
+                <h3 className='text-2xl font-semibold text-foreground mb-4'>デスクトップ</h3>
+                <p className='text-muted-foreground'>
+                  記事一覧をサイドバー形式で表示するため、
+                  広い画面ではより多くの情報を一度に確認できます。
+                </p>
+              </div>
+            </div>
+
+            <div className='mt-6 p-4 bg-blue-50 rounded-lg'>
+              <p className='text-center text-sm text-blue-800'>
+                ※ 最新版の Google Chrome / Safari でのご利用を推奨しています
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* CTA Section */}
+        <section className='py-20 bg-gradient-to-r from-blue-600 to-purple-600'>
+          <div className='max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center'>
+            <h2 className='text-3xl font-bold text-white mb-4'>
+              今すぐ技術トレンドの管理を始めましょう
+            </h2>
+            <p className='text-xl text-blue-100 mb-8 max-w-2xl mx-auto'>
+              効率的な技術トレンドのキャッチアップを体験してください
             </p>
-
-            <div className='flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center items-center'>
-              <AnchorLink
-                to='/trends'
-                className='inline-flex w-44 sm:w-auto items-center justify-center px-4 py-2.5 sm:px-8 sm:py-4 bg-gradient-to-r from-blue-600 to-purple-600 text-white rounded-lg text-base sm:text-lg font-semibold hover:bg-blue-700 transition-all duration-200 shadow-lg hover:shadow-xl'
-              >
-                今すぐ始める
-              </AnchorLink>
-              <AnchorLink
-                to={isLoggedIn ? '/trends' : '/login'}
-                className='inline-flex w-44 sm:w-auto items-center justify-center px-4 py-2.5 sm:px-8 sm:py-4 border-2 border-border text-foreground rounded-lg text-base sm:text-lg font-semibold hover:bg-muted transition-all duration-200'
-              >
-                {isLoggedIn ? 'トレンド一覧へ' : 'ログイン'}
-              </AnchorLink>
-            </div>
+            <AnchorLink
+              to={isLoggedIn ? '/trends' : '/signup'}
+              className='inline-flex items-center justify-center px-6 py-3 sm:px-8 sm:py-4 bg-white text-blue-600 rounded-lg text-base sm:text-lg font-semibold hover:bg-blue-50 transition-all duration-200 shadow-lg hover:shadow-xl'
+            >
+              <ClipText text={isLoggedIn ? 'トレンド一覧へ' : '無料でアカウントを作成'} />
+            </AnchorLink>
           </div>
-        </div>
-
-        {/* Background Decoration */}
-        <div className='absolute inset-0 -z-10'>
-          <div className='absolute top-20 left-10 w-72 h-72 bg-blue-200 rounded-full mix-blend-multiply filter blur-xl opacity-30 animate-pulse'></div>
-          <div
-            className='absolute top-40 right-10 w-72 h-72 bg-purple-200 rounded-full mix-blend-multiply filter blur-xl opacity-30 animate-pulse'
-            style={{ animationDelay: '2s' }}
-          ></div>
-        </div>
-      </section>
-
-      {/* Features Section */}
-      <section className='py-20 bg-card'>
-        <div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'>
-          <div className='text-center mb-16'>
-            <h2 className='text-3xl font-bold text-foreground mb-4'>なぜTrendDiaryを選ぶのか？</h2>
-            <p className='text-lg text-muted-foreground max-w-2xl mx-auto'>
-              Slack
-              RSSフィードとは違って特定のアプリに依存せず、Webブラウザからトレンド記事を確認できます。
-            </p>
-          </div>
-
-          <div className='grid grid-cols-1 md:grid-cols-3 gap-8'>
-            <div className='text-center p-6 rounded-xl border border-border hover:border-blue-300 hover:shadow-lg transition-all duration-200'>
-              <div className='w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mx-auto mb-4'>
-                <BookOpen className='h-6 w-6 text-blue-600' />
-              </div>
-              <h3 className='text-xl font-semibold text-foreground mb-2'>読書状況の管理</h3>
-              <p className='text-muted-foreground'>
-                記事を読んだかどうかを簡単に記録し、読み逃しを防げます。
-              </p>
-            </div>
-
-            <div className='text-center p-6 rounded-xl border border-border hover:border-blue-300 hover:shadow-lg transition-all duration-200'>
-              <div className='w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center mx-auto mb-4'>
-                <TrendingUp className='h-6 w-6 text-green-600' />
-              </div>
-              <h3 className='text-xl font-semibold text-foreground mb-2'>トレンド追跡</h3>
-              <p className='text-muted-foreground'>
-                QiitaやZennの最新技術トレンドを効率的にキャッチアップできます
-              </p>
-            </div>
-
-            <div className='text-center p-6 rounded-xl border border-border hover:border-blue-300 hover:shadow-lg transition-all duration-200'>
-              <div className='w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center mx-auto mb-4'>
-                <Users className='h-6 w-6 text-purple-600' />
-              </div>
-              <h3 className='text-xl font-semibold text-foreground mb-2'>技術者向け</h3>
-              <p className='text-muted-foreground'>
-                技術者のニーズに特化した、使いやすいインターフェース
-              </p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* System Requirements */}
-      <section className='py-20 bg-muted'>
-        <div className='max-w-4xl mx-auto px-4 sm:px-6 lg:px-8'>
-          <div className='text-center mb-12'>
-            <h2 className='text-3xl font-bold text-foreground mb-4'>対応環境</h2>
-            <p className='text-lg text-muted-foreground'>
-              スマートフォンとデスクトップの両方に対応しています
-            </p>
-          </div>
-
-          <div className='grid grid-cols-1 md:grid-cols-2 gap-6'>
-            <div className='bg-card rounded-2xl shadow-sm border border-border p-8 text-center'>
-              <div className='w-20 h-20 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-6'>
-                <Smartphone className='size-10 text-blue-600' />
-              </div>
-              <h3 className='text-2xl font-semibold text-foreground mb-4'>スマートフォン</h3>
-              <p className='text-muted-foreground'>
-                移動中や隙間時間に、未読の記事を1件ずつ手軽に消化できます。
-                主要な操作はモバイル向けに最適化しています。
-              </p>
-            </div>
-
-            <div className='bg-card rounded-2xl shadow-sm border border-border p-8 text-center'>
-              <div className='w-20 h-20 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-6'>
-                <Monitor className='size-10 text-blue-600' />
-              </div>
-              <h3 className='text-2xl font-semibold text-foreground mb-4'>デスクトップ</h3>
-              <p className='text-muted-foreground'>
-                記事一覧をサイドバー形式で表示するため、
-                広い画面ではより多くの情報を一度に確認できます。
-              </p>
-            </div>
-          </div>
-
-          <div className='mt-6 p-4 bg-blue-50 rounded-lg'>
-            <p className='text-center text-sm text-blue-800'>
-              ※ 最新版の Google Chrome / Safari でのご利用を推奨しています
-            </p>
-          </div>
-        </div>
-      </section>
-
-      {/* CTA Section */}
-      <section className='py-20 bg-gradient-to-r from-blue-600 to-purple-600'>
-        <div className='max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center'>
-          <h2 className='text-3xl font-bold text-white mb-4'>
-            今すぐ技術トレンドの管理を始めましょう
-          </h2>
-          <p className='text-xl text-blue-100 mb-8 max-w-2xl mx-auto'>
-            効率的な技術トレンドのキャッチアップを体験してください
-          </p>
-          <AnchorLink
-            to={isLoggedIn ? '/trends' : '/signup'}
-            className='inline-flex items-center justify-center px-6 py-3 sm:px-8 sm:py-4 bg-white text-blue-600 rounded-lg text-base sm:text-lg font-semibold hover:bg-blue-50 transition-all duration-200 shadow-lg hover:shadow-xl'
-          >
-            <ClipText text={isLoggedIn ? 'トレンド一覧へ' : '無料でアカウントを作成'} />
-          </AnchorLink>
-        </div>
-      </section>
+        </section>
+      </main>
 
       <Footer />
     </div>

--- a/application/apps/web/src/client/routes/login/page.tsx
+++ b/application/apps/web/src/client/routes/login/page.tsx
@@ -20,7 +20,7 @@ export default function LoginPage({
   return (
     <div className='min-h-screen bg-gradient-to-br from-muted to-background'>
       <LandingHeader />
-      <div className='flex min-h-[calc(100vh-180px)] items-center justify-center p-4'>
+      <main className='flex min-h-[calc(100vh-180px)] items-center justify-center p-4'>
         <Card className='flex w-full max-w-md flex-col'>
           <CardHeader className='space-y-1'>
             <CardTitle className='text-2xl font-bold'>ログイン</CardTitle>
@@ -51,7 +51,7 @@ export default function LoginPage({
             </div>
           </CardFooter>
         </Card>
-      </div>
+      </main>
       <Footer />
     </div>
   )

--- a/application/apps/web/src/client/routes/signup/page.tsx
+++ b/application/apps/web/src/client/routes/signup/page.tsx
@@ -21,7 +21,7 @@ export default function SignupPage({
   return (
     <div className='min-h-screen bg-gradient-to-br from-muted to-background'>
       <LandingHeader />
-      <div className='flex min-h-[calc(100vh-180px)] items-center justify-center p-4'>
+      <main className='flex min-h-[calc(100vh-180px)] items-center justify-center p-4'>
         <Card className='flex w-full max-w-md flex-col'>
           <CardHeader className='space-y-1'>
             <CardTitle className='text-2xl font-bold'>アカウント作成</CardTitle>
@@ -45,7 +45,7 @@ export default function SignupPage({
             </div>
           </CardFooter>
         </Card>
-      </div>
+      </main>
       <Footer />
     </div>
   )


### PR DESCRIPTION
# 概要
## 課題
アクセシビリティ監査で「ドキュメントにメインのランドマークが設定されていません」と指摘されていた。`main` ランドマークが1つあると、スクリーンリーダーのユーザーがヘッダーやナビゲーションを飛ばしてページ本文へ直接移動できる。

## 修正内容
- fix: #966

`main` ランドマークが未設定だったページに設定した。

- **app-layout（ヘッダーあり）配下**（`/trends` `/inbox` `/diary` `/analytics` `/settings`）: 共通ラッパー `PageContainer` の外枠を `div` から `main` に変更。`PageCard` も `PageContainer` 経由で `main` を持つため、これらのページはすべて1箇所の変更でカバーされる
- **ヘッダーなしページ**: トップ（`/`）・ログイン（`/login`）・アカウント作成（`/signup`）の本文を `main` で囲った（プライバシーポリシー・利用規約は既に `main` を持つため変更不要）

いずれのページも `main` はページごとに1つだけになるよう配置している（`SidebarInset` は未使用のため重複しない）。

## テスト
- `PageContainer` のストーリーに本文が `main` ランドマークとして公開されることの検証を追加
- トップページのテストに `main` ランドマークの存在検証を追加
- 既存の app-layout 各ページのテスト（30件）が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3aRGUp7nfpk44WPq8yAz5)_