### PR TITLE
fix(web): Zod JITの無効化をルートモジュール先頭へ移しCSP eval違反を実際に止める

### DIFF
--- a/application/apps/web/src/client/entry.client.tsx
+++ b/application/apps/web/src/client/entry.client.tsx
@@ -8,10 +8,6 @@
 import { StrictMode, startTransition } from 'react'
 import { hydrateRoot } from 'react-dom/client'
 import { HydratedRouter } from 'react-router/dom'
-import { disableZodJitForStrictCsp } from '@/client/lib/zod'
-
-// ハイドレーション前に呼び、最初の parse より先に Zod の eval 試行を止める
-disableZodJitForStrictCsp()
 
 startTransition(() => {
   hydrateRoot(

--- a/application/apps/web/src/client/lib/configure-zod.test.ts
+++ b/application/apps/web/src/client/lib/configure-zod.test.ts
@@ -1,9 +1,16 @@
 import { z } from 'zod'
 
 describe('configure-zod', () => {
+  // 副作用適用前の状態へ戻し、各テストの独立性を保つ
+  beforeEach(() => {
+    z.config({ jitless: false })
+  })
+
   describe('正常系', () => {
     it('副作用としての読み込みでZodのjitlessが有効になる', async () => {
-      await import('./configure-zod')
+      // ESMのモジュールキャッシュを避けて副作用を確実に再評価させる。
+      // クエリ付き動的importはViteの静的解析対象外のため @vite-ignore で素の動的importに委ねる
+      await import(/* @vite-ignore */ `./configure-zod?bust=${Math.random()}`)
 
       expect(z.config().jitless).toBe(true)
     })

--- a/application/apps/web/src/client/lib/configure-zod.test.ts
+++ b/application/apps/web/src/client/lib/configure-zod.test.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod'
+
+describe('configure-zod', () => {
+  describe('正常系', () => {
+    it('副作用としての読み込みでZodのjitlessが有効になる', async () => {
+      await import('./configure-zod')
+
+      expect(z.config().jitless).toBe(true)
+    })
+  })
+})

--- a/application/apps/web/src/client/lib/configure-zod.test.ts
+++ b/application/apps/web/src/client/lib/configure-zod.test.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 describe('configure-zod', () => {
-  // 副作用適用前の状態へ戻し、各テストの独立性を保つ
+  // 各テストの独立性を保つ
   beforeEach(() => {
     z.config({ jitless: false })
   })

--- a/application/apps/web/src/client/lib/configure-zod.test.ts
+++ b/application/apps/web/src/client/lib/configure-zod.test.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod'
 
 describe('configure-zod', () => {
-  // 各テストの独立性を保つ
   beforeEach(() => {
     z.config({ jitless: false })
   })

--- a/application/apps/web/src/client/lib/configure-zod.ts
+++ b/application/apps/web/src/client/lib/configure-zod.ts
@@ -1,7 +1,7 @@
 import { disableZodJitForStrictCsp } from './zod'
 
-// 副作用モジュール。ルートモジュールの先頭で読み込むことで、いずれかのルートチャンクが
-// トップレベルで z.object() を構築するより前に JIT を無効化し、CSP(unsafe-eval なし)下での
-// new Function 由来 securitypolicyviolation を防ぐ。import 副作用は本体より先に評価されるため、
-// ルートモジュール内の他 import がスキーマを構築しても間に合う。
+// ルートモジュールの先頭で読み込むことで、いずれかのルートチャンクが z.object() を構築するより
+// 前に JIT を無効化し、CSP(unsafe-eval なし)下での new Function 由来 securitypolicyviolation を防ぐ。
+// import 副作用は取り込み側の本体より先に評価されるため、ルートモジュール内の他 import が
+// スキーマを構築しても間に合う。
 disableZodJitForStrictCsp()

--- a/application/apps/web/src/client/lib/configure-zod.ts
+++ b/application/apps/web/src/client/lib/configure-zod.ts
@@ -1,0 +1,7 @@
+import { disableZodJitForStrictCsp } from './zod'
+
+// 副作用モジュール。ルートモジュールの先頭で読み込むことで、いずれかのルートチャンクが
+// トップレベルで z.object() を構築するより前に JIT を無効化し、CSP(unsafe-eval なし)下での
+// new Function 由来 securitypolicyviolation を防ぐ。import 副作用は本体より先に評価されるため、
+// ルートモジュール内の他 import がスキーマを構築しても間に合う。
+disableZodJitForStrictCsp()

--- a/application/apps/web/src/client/lib/zod.ts
+++ b/application/apps/web/src/client/lib/zod.ts
@@ -1,11 +1,12 @@
 import { z } from 'zod'
 
 /**
- * Zod v4 はバリデータをJITコンパイルするため、起動後最初の parse で eval 可否を
- * `Function('')` により試行する。script-src に 'unsafe-eval' を持たない本CSPでは、
+ * Zod v4 は最初の `z.object()` 構築時に、eval 可否を `new Function` の実行で判定する
+ * （成否はメモ化され一度きり）。script-src に 'unsafe-eval' を持たない本CSPでは、
  * その試行が try/catch で握りつぶされても securitypolicyviolation として DevTools に報告される。
- * jitless を有効化して試行自体を止める。試行結果はメモ化され一度きりのため、
- * 最初の parse より前（クライアント起動の最初）に呼ぶ必要がある。
+ * jitless を有効化すると判定自体を止められる。ただしメモ化前、すなわち最初のスキーマ構築より
+ * 前に呼ぶ必要がある。ルートモジュールは他ルートのモジュールより先に評価されるため、
+ * その先頭で副作用として呼ぶ（configure-zod 経由）。
  */
 export function disableZodJitForStrictCsp(): void {
   z.config({ jitless: true })

--- a/application/apps/web/src/client/root.tsx
+++ b/application/apps/web/src/client/root.tsx
@@ -1,3 +1,5 @@
+// Zod の JIT を最初のスキーマ構築より前に無効化する。ルートモジュールは最初に評価されるため先頭で読み込む
+import '@/client/lib/configure-zod'
 import React from 'react'
 import type { LoaderFunctionArgs, MetaFunction } from 'react-router'
 import {

--- a/application/apps/web/src/client/root.tsx
+++ b/application/apps/web/src/client/root.tsx
@@ -1,4 +1,4 @@
-// Zod の JIT を最初のスキーマ構築より前に無効化する。ルートモジュールは最初に評価されるため先頭で読み込む
+// スキーマ構築より前に効かせる必要があり、他ルートより先に評価される root の先頭で読み込む
 import '@/client/lib/configure-zod'
 import React from 'react'
 import type { LoaderFunctionArgs, MetaFunction } from 'react-router'


### PR DESCRIPTION
# 概要

CSP(unsafe-eval なし)下で、本番ビルドのハイドレーション時に `securitypolicyviolation`（eval blocked / `script-src`）が発生し続けていた問題を修正する。DevTools 上の発生元は `auth-DonavtJU.js` のようなルートチャンクとして報告される。

## 問題のあった領域

- [x] フロントエンド
  - [x] ビジネスロジック（状態管理、非同期処理、エラーハンドリングなど）
  - [x] 脆弱性（CSP / セキュリティヘッダ運用）

### 要因の詳細

- Zod v4 は最初の `z.object()` **構築時**に、eval 可否を `new Function` の実行で判定する（`allowsEval` probe、結果はメモ化）。`script-src` に `'unsafe-eval'` を持たない本 CSP では、この試行が `try/catch` で握りつぶされても `securitypolicyviolation` として報告される（Zod 自身のソースコメントにも明記）。
- 既存の `disableZodJitForStrictCsp()` は `entry.client.tsx` の本体で呼んでいた。しかし本番ビルドでは React Router のブートストラップ用インラインスクリプトが、ルートモジュール（`root` → 現在ルート → その配下の `auth` チャンク）を **`entry.client` の動的 import より前に静的 import** する。そのため `authInputSchema = z.object({...})` の構築（＝probe 発火）が `disableZodJitForStrictCsp()` の実行より先に起こり、無効化が手遅れになっていた。
- dev サーバーではモジュール評価順が異なるため再現せず、この取りこぼしに気付きにくかった。

### 再現手順

1. 本番ビルド（`pnpm build`）を wrangler 等で配信する。
2. strict CSP（`script-src 'self' 'nonce-…' 'strict-dynamic' https://challenges.cloudflare.com`）下で `/login` を開く。
3. `securitypolicyviolation`（`blockedURI: "eval"`, `sourceFile: auth-*.js`）が 1 件発生する。

## 修正方針

- 最初に評価されるルートモジュール（`root`）の**先頭**で、副作用モジュール `configure-zod` を読み込み、いずれのルートチャンクが `z.object()` を構築するよりも前に `z.config({ jitless: true })` を適用する。
- 効果を失っていた `entry.client.tsx` 側の呼び出しは削除する。
- `disableZodJitForStrictCsp()` のドキュメントコメントを実挙動（parse ではなくスキーマ**構築**時に判定・メモ化される点）に合わせて修正する。

### その方針を選んだ理由

- probe はグローバル設定 `globalConfig.jitless` のみを見て構築時に発火するため、防ぐには「最初のスキーマ構築より前」にグローバル無効化する以外にない。
- `import` の副作用は取り込み側モジュールの本体より先に評価される。ルートモジュールは他ルートのモジュールより先に評価されるため、その先頭に置けば全ルートのスキーマ構築より前に確実に走る。

## 動作確認

本番ビルドを wrangler で配信し、strict CSP 下で Chromium(headless) から `securitypolicyviolation` を観測して確認した。

| 経路 | 修正前 | 修正後 |
|---|---|---|
| `/login` | eval 違反 1 件（`auth-*.js`） | 0 件 |
| `/signup` | - | 0 件 |
| `/`（トップ） | - | 0 件 |

- 単体テスト: `zod.test.ts` / `configure-zod.test.ts` / `security-headers.test.ts` すべて green
- `oxlint` / `oxfmt --check` / `tsc --noEmit` 通過

## その他、参考情報

- Zod 4.4.3 `v4/core/util.js` の `allowsEval` に、strict CSP では握りつぶした `new Function` が `securitypolicyviolation` として報告される旨のコメントがある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016jpvbZdJdXi6WBm5UCmawY)_