### PR TITLE
ci: setup-cliをv2.1.1へ更新しNode.js 20非推奨警告を解消

### DIFF
--- a/.github/actions/setup_supabase/action.yaml
+++ b/.github/actions/setup_supabase/action.yaml
@@ -12,7 +12,7 @@ runs:
   steps:
     - name: Supabase CLIのセットアップ
       # versionをpinしないとlatestが浮動で入りDockerイメージのtagも変わってキャッシュが安定しないため明示的に固定する
-      uses: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51 # v1
+      uses: supabase/setup-cli@3c2f5e2ae34c34e428e8e206e2c4d21fa2d20fbf # v2.1.1
       with:
         version: ${{ inputs.cli-version }}
 


### PR DESCRIPTION
# 概要
## 課題
E2Eワークフローで以下のNode.js 20非推奨警告が出ていた。

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: supabase/setup-cli@b60b5899c73b63a2d2d651b1e90db8d4c9392f51.

`supabase/setup-cli@v1` は `action.yml` で `using: node20` を宣言しており、GitHub ActionsランナーがNode.js 20の非推奨警告を出していた（参考: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/ ）。

## 修正内容
- fix: `.github/actions/setup_supabase/action.yaml` の `supabase/setup-cli` を `v1`（`b60b5899...` / `using: node20`）から `v2.1.1`（`3c2f5e2a...`）へ更新
- v2.1.1はcomposite action化されており node ランタイム宣言そのものがなくなるため、Node.js 20非推奨警告が解消される
- v3系はCLIのインストール元がGitHub releasesからnpmへ変わる挙動変更を含むため、変更を最小に抑える目的で挙動が従来通りのv2系最新（v2.1.1）を選択した
- v2.1.1も `version` インプットを引き続き受け付けるため、CLIバージョンのpin（`inputs.cli-version`）およびそれをキーにしたDockerイメージキャッシュには影響しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017CqhuXMnoPAfGdBQjfryY1)_