### PR TITLE
refactor(web): ZodValidated*Context 型を単一の汎用型へ集約する

### DIFF
--- a/application/apps/web/src/client/features/diary/hooks/use-diary-api.test.ts
+++ b/application/apps/web/src/client/features/diary/hooks/use-diary-api.test.ts
@@ -86,7 +86,8 @@ describe('useDiaryApi', () => {
           query: {
             from: targetDate,
             to: targetDate,
-            page: 2,
+            // クエリはURL上文字列で送られるため、検証前の入力型（string）で渡す
+            page: '2',
           },
         },
         { init: { credentials: 'include' } },

--- a/application/apps/web/src/client/features/diary/hooks/use-diary-api.ts
+++ b/application/apps/web/src/client/features/diary/hooks/use-diary-api.ts
@@ -52,7 +52,8 @@ export default function useDiaryApi() {
           query: {
             from: date,
             to: date,
-            page,
+            // クエリはURL上文字列で送られるため、検証前の入力型（string）に合わせる
+            page: String(page),
           },
         },
         { init: { credentials: 'include' } },

--- a/application/apps/web/src/client/features/diary/hooks/use-diary-api.ts
+++ b/application/apps/web/src/client/features/diary/hooks/use-diary-api.ts
@@ -53,7 +53,7 @@ export default function useDiaryApi() {
             from: date,
             to: date,
             // クエリはURL上文字列で送られるため、検証前の入力型（string）に合わせる
-            page: String(page),
+            page: page.toString(),
           },
         },
         { init: { credentials: 'include' } },

--- a/application/apps/web/src/middleware/zod-validator.ts
+++ b/application/apps/web/src/middleware/zod-validator.ts
@@ -26,10 +26,12 @@ export default zodValidator
 type ValidatedFields = Partial<Record<keyof ValidationTargets, object>>
 
 // 検証対象（query / param / json）→ 型のマップで in / out を指定する単一の汎用型。
-// transform でリクエスト時（z.input）と検証後（z.output）の型が分かれる場合のみ Out を明示する
+// transform でリクエスト時（z.input）と検証後（z.output）の型が分かれる場合のみ Out を明示する。
+// In 側は自己参照制約で値を object（undefined 抜き）に固定し、Out には In と同じキーを型で強制して
+// in / out のキー取り違え（例: In は param + json なのに Out が param のみ）を防ぐ
 export type ZodValidatedContext<
-  In extends ValidatedFields,
-  Out extends ValidatedFields = In,
+  In extends ValidatedFields & { [K in keyof In]: object },
+  Out extends { [K in keyof In]: object } = In,
   Path extends string = '',
 > = Context<
   Env,

--- a/application/apps/web/src/middleware/zod-validator.ts
+++ b/application/apps/web/src/middleware/zod-validator.ts
@@ -23,65 +23,19 @@ const zodValidator = <Target extends keyof ValidationTargets, T extends ZodSchem
 export default zodValidator
 
 // zodValidatorの型は自動推論が厳しかったため、何度も書きそうなベタガキを共通化
-type ZodValidatedContextBase<T, K extends keyof ValidationTargets, P extends string = ''> = Context<
-  Env,
-  P,
-  {
-    in: {
-      [Key in K]: T
-    }
-    out: {
-      [Key in K]: T
-    }
-  }
->
+type ValidatedFields = Partial<Record<keyof ValidationTargets, object>>
 
-export type ZodValidatedContext<T, P extends string = ''> = ZodValidatedContextBase<T, 'json', P>
-
-export type ZodValidatedQueryContext<T, P extends string = ''> = ZodValidatedContextBase<
-  T,
-  'query',
-  P
->
-
-export type ZodValidatedParamContext<T, P extends string = ''> = ZodValidatedContextBase<
-  T,
-  'param',
-  P
->
-
-export type ZodValidatedParamQueryContext<P, Q, Path extends string = ''> = Context<
+// 検証対象（query / param / json）→ 型のマップで in / out を指定する単一の汎用型。
+// transform でリクエスト時（z.input）と検証後（z.output）の型が分かれる場合のみ Out を明示する
+export type ZodValidatedContext<
+  In extends ValidatedFields,
+  Out extends ValidatedFields = In,
+  Path extends string = '',
+> = Context<
   Env,
   Path,
   {
-    in: {
-      param: P
-      query: Q
-    }
-    out: {
-      param: P
-      query: Q
-    }
-  }
->
-
-// param は transform でリクエスト時の型（z.input）と検証後の型（z.output）が異なりうるため、
-// Hono client の RPC 型推論にはスキーマから in / out を別々に導く必要がある
-export type ZodValidatedParamJsonContext<
-  ParamSchema extends ZodSchema,
-  JsonSchema extends ZodSchema,
-  P extends string = '',
-> = Context<
-  Env,
-  P,
-  {
-    in: {
-      param: z.input<ParamSchema>
-      json: z.input<JsonSchema>
-    }
-    out: {
-      param: z.output<ParamSchema>
-      json: z.output<JsonSchema>
-    }
+    in: In
+    out: Out
   }
 >

--- a/application/apps/web/src/middleware/zod-validator.ts
+++ b/application/apps/web/src/middleware/zod-validator.ts
@@ -28,18 +28,13 @@ export default zodValidator
 type InferValidatorInput<V> =
   V extends MiddlewareHandler<HonoEnv, string, infer I extends Input> ? I : never
 
-type MergeIn<Validators extends readonly MiddlewareHandler[]> = Validators extends readonly [
-  infer Head,
-  ...infer Rest extends readonly MiddlewareHandler[],
-]
-  ? (InferValidatorInput<Head> extends { in: infer I } ? I : {}) & MergeIn<Rest>
-  : {}
-
-type MergeOut<Validators extends readonly MiddlewareHandler[]> = Validators extends readonly [
-  infer Head,
-  ...infer Rest extends readonly MiddlewareHandler[],
-]
-  ? (InferValidatorInput<Head> extends { out: infer O } ? O : {}) & MergeOut<Rest>
+// チェーン内の各 validator の in / out を Dir で切り替えて畳み込む
+type MergeValidatedInput<
+  Validators extends readonly MiddlewareHandler[],
+  Dir extends 'in' | 'out',
+> = Validators extends readonly [infer Head, ...infer Rest extends readonly MiddlewareHandler[]]
+  ? (InferValidatorInput<Head> extends { [K in Dir]: infer T } ? T : {}) &
+      MergeValidatedInput<Rest, Dir>
   : {}
 
 export type ZodValidatedContext<
@@ -49,7 +44,7 @@ export type ZodValidatedContext<
   Env,
   Path,
   {
-    in: MergeIn<Validators>
-    out: MergeOut<Validators>
+    in: MergeValidatedInput<Validators, 'in'>
+    out: MergeValidatedInput<Validators, 'out'>
   }
 >

--- a/application/apps/web/src/middleware/zod-validator.ts
+++ b/application/apps/web/src/middleware/zod-validator.ts
@@ -1,5 +1,5 @@
 import { zValidator } from '@hono/zod-validator'
-import type { Context, ValidationTargets } from 'hono'
+import type { Context, Env as HonoEnv, Input, MiddlewareHandler, ValidationTargets } from 'hono'
 import { HTTPException } from 'hono/http-exception'
 import type { ZodSchema } from 'zod'
 import { z } from 'zod'
@@ -22,22 +22,34 @@ const zodValidator = <Target extends keyof ValidationTargets, T extends ZodSchem
 
 export default zodValidator
 
-// zodValidatorの型は自動推論が厳しかったため、何度も書きそうなベタガキを共通化
-type ValidatedFields = Partial<Record<keyof ValidationTargets, object>>
+// ルートに適用した zodValidator のチェーンから、検証済みハンドラーの Context を導出する。
+// 各 validator が持つ in / out（param の transform 等で両者が分かれる場合も含む）を統合するため、
+// ハンドラー側で対象と型のマップを手書きせず、適用した validator の型から一意に決まる
+type InferValidatorInput<V> =
+  V extends MiddlewareHandler<HonoEnv, string, infer I extends Input> ? I : never
 
-// 検証対象（query / param / json）→ 型のマップで in / out を指定する単一の汎用型。
-// transform でリクエスト時（z.input）と検証後（z.output）の型が分かれる場合のみ Out を明示する。
-// In 側は自己参照制約で値を object（undefined 抜き）に固定し、Out には In と同じキーを型で強制して
-// in / out のキー取り違え（例: In は param + json なのに Out が param のみ）を防ぐ
+type MergeIn<Validators extends readonly MiddlewareHandler[]> = Validators extends readonly [
+  infer Head,
+  ...infer Rest extends readonly MiddlewareHandler[],
+]
+  ? (InferValidatorInput<Head> extends { in: infer I } ? I : {}) & MergeIn<Rest>
+  : {}
+
+type MergeOut<Validators extends readonly MiddlewareHandler[]> = Validators extends readonly [
+  infer Head,
+  ...infer Rest extends readonly MiddlewareHandler[],
+]
+  ? (InferValidatorInput<Head> extends { out: infer O } ? O : {}) & MergeOut<Rest>
+  : {}
+
 export type ZodValidatedContext<
-  In extends ValidatedFields & { [K in keyof In]: object },
-  Out extends { [K in keyof In]: object } = In,
+  Validators extends readonly MiddlewareHandler[],
   Path extends string = '',
 > = Context<
   Env,
   Path,
   {
-    in: In
-    out: Out
+    in: MergeIn<Validators>
+    out: MergeOut<Validators>
   }
 >

--- a/application/apps/web/src/server/article/handler/get-articles.ts
+++ b/application/apps/web/src/server/article/handler/get-articles.ts
@@ -10,7 +10,7 @@ import {
 } from '@trend-diary/domain/article/schema/query-schema'
 import { z } from 'zod'
 import CONTEXT_KEY from '@/middleware/context'
-import type { ZodValidatedContext } from '@/middleware/zod-validator'
+import zodValidator, { type ZodValidatedContext } from '@/middleware/zod-validator'
 import { handleError } from '@/server/error/handle-error'
 import { type ArticleResponse, toArticleResponse } from '../article-response'
 
@@ -27,6 +27,8 @@ export const apiArticleQuerySchema = baseArticleSearchSchema
 
 export type ApiQueryParams = z.infer<typeof apiArticleQuerySchema>
 
+export const apiArticleQueryValidator = zodValidator('query', apiArticleQuerySchema)
+
 export type { ArticleResponse }
 
 export type ArticleWithReadStatusResponse = ArticleResponse & {
@@ -35,7 +37,9 @@ export type ArticleWithReadStatusResponse = ArticleResponse & {
 
 export type ArticleListResponse = OffsetPaginationResult<ArticleResponse>
 
-export default async function getArticles(c: ZodValidatedContext<{ query: ApiQueryParams }>) {
+export default async function getArticles(
+  c: ZodValidatedContext<[typeof apiArticleQueryValidator]>,
+) {
   const transformedParams = c.req.valid('query')
   const logger = c.get(CONTEXT_KEY.APP_LOG)
 

--- a/application/apps/web/src/server/article/handler/get-articles.ts
+++ b/application/apps/web/src/server/article/handler/get-articles.ts
@@ -16,7 +16,7 @@ import { type ArticleResponse, toArticleResponse } from '../article-response'
 
 const readStatusEnum = z.enum(['0', '1'])
 
-export const apiArticleQuerySchema = baseArticleSearchSchema
+const apiArticleQuerySchema = baseArticleSearchSchema
   .extend({
     read_status: readStatusEnum.optional(),
   })

--- a/application/apps/web/src/server/article/handler/get-articles.ts
+++ b/application/apps/web/src/server/article/handler/get-articles.ts
@@ -10,7 +10,7 @@ import {
 } from '@trend-diary/domain/article/schema/query-schema'
 import { z } from 'zod'
 import CONTEXT_KEY from '@/middleware/context'
-import type { ZodValidatedQueryContext } from '@/middleware/zod-validator'
+import type { ZodValidatedContext } from '@/middleware/zod-validator'
 import { handleError } from '@/server/error/handle-error'
 import { type ArticleResponse, toArticleResponse } from '../article-response'
 
@@ -35,7 +35,7 @@ export type ArticleWithReadStatusResponse = ArticleResponse & {
 
 export type ArticleListResponse = OffsetPaginationResult<ArticleResponse>
 
-export default async function getArticles(c: ZodValidatedQueryContext<ApiQueryParams>) {
+export default async function getArticles(c: ZodValidatedContext<{ query: ApiQueryParams }>) {
   const transformedParams = c.req.valid('query')
   const logger = c.get(CONTEXT_KEY.APP_LOG)
 

--- a/application/apps/web/src/server/article/handler/get-diary.ts
+++ b/application/apps/web/src/server/article/handler/get-diary.ts
@@ -11,7 +11,7 @@ import { HTTPException } from 'hono/http-exception'
 import { z } from 'zod'
 import { toTodayJstDateString } from '@/common/locale/date'
 import CONTEXT_KEY from '@/middleware/context'
-import type { ZodValidatedContext } from '@/middleware/zod-validator'
+import zodValidator, { type ZodValidatedContext } from '@/middleware/zod-validator'
 import { handleError } from '@/server/error/handle-error'
 
 const DATE_STRING_REGEX = /^\d{4}-\d{2}-\d{2}$/
@@ -44,7 +44,7 @@ export const diaryQuerySchema = z
     },
   )
 
-type DiaryQuery = z.infer<typeof diaryQuerySchema>
+export const diaryQueryValidator = zodValidator('query', diaryQuerySchema)
 
 interface DiaryRangeResponse {
   data: Array<{
@@ -75,7 +75,7 @@ interface DiaryRangeResponse {
   }
 }
 
-export default async function getDiary(c: ZodValidatedContext<{ query: DiaryQuery }>) {
+export default async function getDiary(c: ZodValidatedContext<[typeof diaryQueryValidator]>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const sessionUser = c.get(CONTEXT_KEY.SESSION_USER)!
   const query = c.req.valid('query')

--- a/application/apps/web/src/server/article/handler/get-diary.ts
+++ b/application/apps/web/src/server/article/handler/get-diary.ts
@@ -11,7 +11,7 @@ import { HTTPException } from 'hono/http-exception'
 import { z } from 'zod'
 import { toTodayJstDateString } from '@/common/locale/date'
 import CONTEXT_KEY from '@/middleware/context'
-import type { ZodValidatedQueryContext } from '@/middleware/zod-validator'
+import type { ZodValidatedContext } from '@/middleware/zod-validator'
 import { handleError } from '@/server/error/handle-error'
 
 const DATE_STRING_REGEX = /^\d{4}-\d{2}-\d{2}$/
@@ -75,7 +75,7 @@ interface DiaryRangeResponse {
   }
 }
 
-export default async function getDiary(c: ZodValidatedQueryContext<DiaryQuery>) {
+export default async function getDiary(c: ZodValidatedContext<{ query: DiaryQuery }>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const sessionUser = c.get(CONTEXT_KEY.SESSION_USER)!
   const query = c.req.valid('query')

--- a/application/apps/web/src/server/article/handler/read-article.ts
+++ b/application/apps/web/src/server/article/handler/read-article.ts
@@ -3,7 +3,7 @@ import { createArticleUseCase } from '@trend-diary/domain/article'
 import { DIARY_DAYS } from '@trend-diary/domain/article/diary'
 import { z } from 'zod'
 import CONTEXT_KEY from '@/middleware/context'
-import type { ZodValidatedParamJsonContext } from '@/middleware/zod-validator'
+import type { ZodValidatedContext } from '@/middleware/zod-validator'
 import { handleError } from '@/server/error/handle-error'
 
 const MS_PER_MINUTE = 60 * 1000
@@ -47,7 +47,16 @@ export type ArticleIdParam = z.output<typeof articleIdParamSchema>
 // param + json の同時指定ではファクトリーの戻り値型を Hono client が解決できず json が欠落するため、
 // 従来パターンで検証済みコンテキストを明示し、c.json の TypedResponse で RPC 型推論を保つ
 export default async function readArticle(
-  c: ZodValidatedParamJsonContext<typeof articleIdParamSchema, typeof createReadHistoryApiSchema>,
+  c: ZodValidatedContext<
+    {
+      param: z.input<typeof articleIdParamSchema>
+      json: z.input<typeof createReadHistoryApiSchema>
+    },
+    {
+      param: z.output<typeof articleIdParamSchema>
+      json: z.output<typeof createReadHistoryApiSchema>
+    }
+  >,
 ) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const user = c.get(CONTEXT_KEY.SESSION_USER)

--- a/application/apps/web/src/server/article/handler/read-article.ts
+++ b/application/apps/web/src/server/article/handler/read-article.ts
@@ -3,7 +3,7 @@ import { createArticleUseCase } from '@trend-diary/domain/article'
 import { DIARY_DAYS } from '@trend-diary/domain/article/diary'
 import { z } from 'zod'
 import CONTEXT_KEY from '@/middleware/context'
-import type { ZodValidatedContext } from '@/middleware/zod-validator'
+import zodValidator, { type ZodValidatedContext } from '@/middleware/zod-validator'
 import { handleError } from '@/server/error/handle-error'
 
 const MS_PER_MINUTE = 60 * 1000
@@ -44,19 +44,13 @@ export const articleIdParamSchema = z.object({
 
 export type ArticleIdParam = z.output<typeof articleIdParamSchema>
 
+export const articleIdParamValidator = zodValidator('param', articleIdParamSchema)
+export const createReadHistoryJsonValidator = zodValidator('json', createReadHistoryApiSchema)
+
 // param + json の同時指定ではファクトリーの戻り値型を Hono client が解決できず json が欠落するため、
 // 従来パターンで検証済みコンテキストを明示し、c.json の TypedResponse で RPC 型推論を保つ
 export default async function readArticle(
-  c: ZodValidatedContext<
-    {
-      param: z.input<typeof articleIdParamSchema>
-      json: z.input<typeof createReadHistoryApiSchema>
-    },
-    {
-      param: z.output<typeof articleIdParamSchema>
-      json: z.output<typeof createReadHistoryApiSchema>
-    }
-  >,
+  c: ZodValidatedContext<[typeof articleIdParamValidator, typeof createReadHistoryJsonValidator]>,
 ) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const user = c.get(CONTEXT_KEY.SESSION_USER)

--- a/application/apps/web/src/server/article/handler/unread-digestion-articles.ts
+++ b/application/apps/web/src/server/article/handler/unread-digestion-articles.ts
@@ -3,7 +3,7 @@ import { createArticleUseCase } from '@trend-diary/domain/article'
 import { mediaListSchema } from '@trend-diary/domain/article/schema/query-schema'
 import { z } from 'zod'
 import CONTEXT_KEY from '@/middleware/context'
-import type { ZodValidatedContext } from '@/middleware/zod-validator'
+import zodValidator, { type ZodValidatedContext } from '@/middleware/zod-validator'
 import { handleError } from '@/server/error/handle-error'
 import { type ArticleResponse, toArticleResponse } from '../article-response'
 
@@ -16,10 +16,10 @@ export const unreadDigestionQuerySchema = z.object({
   media: mediaListSchema,
 })
 
-type UnreadDigestionQuery = z.infer<typeof unreadDigestionQuerySchema>
+export const unreadDigestionQueryValidator = zodValidator('query', unreadDigestionQuerySchema)
 
 export default async function unreadDigestionArticles(
-  c: ZodValidatedContext<{ query: UnreadDigestionQuery }>,
+  c: ZodValidatedContext<[typeof unreadDigestionQueryValidator]>,
 ): Promise<Response> {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const sessionUser = c.get(CONTEXT_KEY.SESSION_USER)!

--- a/application/apps/web/src/server/article/handler/unread-digestion-articles.ts
+++ b/application/apps/web/src/server/article/handler/unread-digestion-articles.ts
@@ -3,7 +3,7 @@ import { createArticleUseCase } from '@trend-diary/domain/article'
 import { mediaListSchema } from '@trend-diary/domain/article/schema/query-schema'
 import { z } from 'zod'
 import CONTEXT_KEY from '@/middleware/context'
-import type { ZodValidatedQueryContext } from '@/middleware/zod-validator'
+import type { ZodValidatedContext } from '@/middleware/zod-validator'
 import { handleError } from '@/server/error/handle-error'
 import { type ArticleResponse, toArticleResponse } from '../article-response'
 
@@ -19,7 +19,7 @@ export const unreadDigestionQuerySchema = z.object({
 type UnreadDigestionQuery = z.infer<typeof unreadDigestionQuerySchema>
 
 export default async function unreadDigestionArticles(
-  c: ZodValidatedQueryContext<UnreadDigestionQuery>,
+  c: ZodValidatedContext<{ query: UnreadDigestionQuery }>,
 ): Promise<Response> {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const sessionUser = c.get(CONTEXT_KEY.SESSION_USER)!

--- a/application/apps/web/src/server/article/handler/unread-digestion-articles.ts
+++ b/application/apps/web/src/server/article/handler/unread-digestion-articles.ts
@@ -12,7 +12,7 @@ interface UnreadDigestionArticlesResponse {
   total: number
 }
 
-export const unreadDigestionQuerySchema = z.object({
+const unreadDigestionQuerySchema = z.object({
   media: mediaListSchema,
 })
 

--- a/application/apps/web/src/server/article/route.ts
+++ b/application/apps/web/src/server/article/route.ts
@@ -2,52 +2,30 @@ import { Hono } from 'hono'
 import type { Env } from '@/env'
 import articleCache from '@/middleware/article-cache'
 import { authenticator, optionalAuthenticator } from '@/middleware/authenticator'
-import zodValidator from '@/middleware/zod-validator'
-import getArticles, { apiArticleQuerySchema } from './handler/get-articles'
-import getDiary, { diaryQuerySchema } from './handler/get-diary'
+import getArticles, { apiArticleQueryValidator } from './handler/get-articles'
+import getDiary, { diaryQueryValidator } from './handler/get-diary'
 import readArticle, {
-  articleIdParamSchema,
-  createReadHistoryApiSchema,
+  articleIdParamValidator,
+  createReadHistoryJsonValidator,
 } from './handler/read-article'
 import skipArticle from './handler/skip-article'
 import unreadArticle from './handler/unread-article'
 import unreadDigestionArticles, {
-  unreadDigestionQuerySchema,
+  unreadDigestionQueryValidator,
 } from './handler/unread-digestion-articles'
 
 const app = new Hono<Env>()
-  .get(
-    '/',
-    articleCache,
-    optionalAuthenticator,
-    zodValidator('query', apiArticleQuerySchema),
-    getArticles,
-  )
-  .get('/diary', authenticator, zodValidator('query', diaryQuerySchema), getDiary)
-  .get(
-    '/unread-digestion',
-    authenticator,
-    zodValidator('query', unreadDigestionQuerySchema),
-    unreadDigestionArticles,
-  )
+  .get('/', articleCache, optionalAuthenticator, apiArticleQueryValidator, getArticles)
+  .get('/diary', authenticator, diaryQueryValidator, getDiary)
+  .get('/unread-digestion', authenticator, unreadDigestionQueryValidator, unreadDigestionArticles)
   .post(
     '/:article_id/read',
     authenticator,
-    zodValidator('param', articleIdParamSchema),
-    zodValidator('json', createReadHistoryApiSchema),
+    articleIdParamValidator,
+    createReadHistoryJsonValidator,
     readArticle,
   )
-  .post(
-    '/:article_id/skip',
-    authenticator,
-    zodValidator('param', articleIdParamSchema),
-    skipArticle,
-  )
-  .delete(
-    '/:article_id/unread',
-    authenticator,
-    zodValidator('param', articleIdParamSchema),
-    unreadArticle,
-  )
+  .post('/:article_id/skip', authenticator, articleIdParamValidator, skipArticle)
+  .delete('/:article_id/unread', authenticator, articleIdParamValidator, unreadArticle)
 
 export default app

--- a/application/apps/web/src/server/auth/handler/login.ts
+++ b/application/apps/web/src/server/auth/handler/login.ts
@@ -1,13 +1,14 @@
 import { authClientConfig, PasswordAuthClient } from '@trend-diary/authentication'
 import getRdbClient from '@trend-diary/datastore/rdb'
-import { type AuthInput, createAccountUseCase } from '@trend-diary/domain/account'
+import { createAccountUseCase } from '@trend-diary/domain/account'
 import CONTEXT_KEY from '@/middleware/context'
 import type { ZodValidatedContext } from '@/middleware/zod-validator'
+import type { authInputValidator } from '@/server/auth/validators'
 import toAuthError from '@/server/error/auth-error'
 import { handleError } from '@/server/error/handle-error'
 import { verifyTurnstile } from '../captcha'
 
-export default async function login(c: ZodValidatedContext<{ json: AuthInput }>) {
+export default async function login(c: ZodValidatedContext<[typeof authInputValidator]>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const valid = c.req.valid('json')
 

--- a/application/apps/web/src/server/auth/handler/login.ts
+++ b/application/apps/web/src/server/auth/handler/login.ts
@@ -7,7 +7,7 @@ import toAuthError from '@/server/error/auth-error'
 import { handleError } from '@/server/error/handle-error'
 import { verifyTurnstile } from '../captcha'
 
-export default async function login(c: ZodValidatedContext<AuthInput>) {
+export default async function login(c: ZodValidatedContext<{ json: AuthInput }>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const valid = c.req.valid('json')
 

--- a/application/apps/web/src/server/auth/handler/passkey-login-verify.ts
+++ b/application/apps/web/src/server/auth/handler/passkey-login-verify.ts
@@ -18,7 +18,9 @@ export const passkeyLoginVerifyInputSchema = z.object({
 
 export type PasskeyLoginVerifyInput = z.infer<typeof passkeyLoginVerifyInputSchema>
 
-export default async function passkeyLoginVerify(c: ZodValidatedContext<PasskeyLoginVerifyInput>) {
+export default async function passkeyLoginVerify(
+  c: ZodValidatedContext<{ json: PasskeyLoginVerifyInput }>,
+) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const valid = c.req.valid('json')
 

--- a/application/apps/web/src/server/auth/handler/passkey-login-verify.ts
+++ b/application/apps/web/src/server/auth/handler/passkey-login-verify.ts
@@ -4,7 +4,7 @@ import getRdbClient from '@trend-diary/datastore/rdb'
 import { createAccountUseCase } from '@trend-diary/domain/account'
 import { z } from 'zod'
 import CONTEXT_KEY from '@/middleware/context'
-import type { ZodValidatedContext } from '@/middleware/zod-validator'
+import zodValidator, { type ZodValidatedContext } from '@/middleware/zod-validator'
 import toAuthError from '@/server/error/auth-error'
 import { handleError } from '@/server/error/handle-error'
 
@@ -16,10 +16,10 @@ export const passkeyLoginVerifyInputSchema = z.object({
   ),
 })
 
-export type PasskeyLoginVerifyInput = z.infer<typeof passkeyLoginVerifyInputSchema>
+export const passkeyLoginVerifyValidator = zodValidator('json', passkeyLoginVerifyInputSchema)
 
 export default async function passkeyLoginVerify(
-  c: ZodValidatedContext<{ json: PasskeyLoginVerifyInput }>,
+  c: ZodValidatedContext<[typeof passkeyLoginVerifyValidator]>,
 ) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const valid = c.req.valid('json')

--- a/application/apps/web/src/server/auth/handler/passkey-register-verify.ts
+++ b/application/apps/web/src/server/auth/handler/passkey-register-verify.ts
@@ -17,7 +17,7 @@ export const passkeyRegisterVerifyInputSchema = z.object({
 export type PasskeyRegisterVerifyInput = z.infer<typeof passkeyRegisterVerifyInputSchema>
 
 export default async function passkeyRegisterVerify(
-  c: ZodValidatedContext<PasskeyRegisterVerifyInput>,
+  c: ZodValidatedContext<{ json: PasskeyRegisterVerifyInput }>,
 ) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const valid = c.req.valid('json')

--- a/application/apps/web/src/server/auth/handler/passkey-register-verify.ts
+++ b/application/apps/web/src/server/auth/handler/passkey-register-verify.ts
@@ -2,7 +2,7 @@ import type { RegistrationResponseJSON } from '@simplewebauthn/browser'
 import { authClientConfig, PasskeyClient } from '@trend-diary/authentication'
 import { z } from 'zod'
 import CONTEXT_KEY from '@/middleware/context'
-import type { ZodValidatedContext } from '@/middleware/zod-validator'
+import zodValidator, { type ZodValidatedContext } from '@/middleware/zod-validator'
 import toAuthError from '@/server/error/auth-error'
 import { handleError } from '@/server/error/handle-error'
 
@@ -14,10 +14,10 @@ export const passkeyRegisterVerifyInputSchema = z.object({
   ),
 })
 
-export type PasskeyRegisterVerifyInput = z.infer<typeof passkeyRegisterVerifyInputSchema>
+export const passkeyRegisterVerifyValidator = zodValidator('json', passkeyRegisterVerifyInputSchema)
 
 export default async function passkeyRegisterVerify(
-  c: ZodValidatedContext<{ json: PasskeyRegisterVerifyInput }>,
+  c: ZodValidatedContext<[typeof passkeyRegisterVerifyValidator]>,
 ) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const valid = c.req.valid('json')

--- a/application/apps/web/src/server/auth/handler/signup.ts
+++ b/application/apps/web/src/server/auth/handler/signup.ts
@@ -8,7 +8,7 @@ import toAuthError from '@/server/error/auth-error'
 import { handleError } from '@/server/error/handle-error'
 import { verifyTurnstile } from '../captcha'
 
-export default async function signup(c: ZodValidatedContext<AuthInput>) {
+export default async function signup(c: ZodValidatedContext<{ json: AuthInput }>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const valid = c.req.valid('json')
 

--- a/application/apps/web/src/server/auth/handler/signup.ts
+++ b/application/apps/web/src/server/auth/handler/signup.ts
@@ -1,14 +1,15 @@
 import { authClientConfig, PasswordAuthClient } from '@trend-diary/authentication'
 import getRdbClient from '@trend-diary/datastore/rdb'
-import { type AuthInput, createAccountUseCase } from '@trend-diary/domain/account'
+import { createAccountUseCase } from '@trend-diary/domain/account'
 import { DiscordWebhookClient } from '@trend-diary/notification'
 import CONTEXT_KEY from '@/middleware/context'
 import type { ZodValidatedContext } from '@/middleware/zod-validator'
+import type { authInputValidator } from '@/server/auth/validators'
 import toAuthError from '@/server/error/auth-error'
 import { handleError } from '@/server/error/handle-error'
 import { verifyTurnstile } from '../captcha'
 
-export default async function signup(c: ZodValidatedContext<{ json: AuthInput }>) {
+export default async function signup(c: ZodValidatedContext<[typeof authInputValidator]>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const valid = c.req.valid('json')
 

--- a/application/apps/web/src/server/auth/route.ts
+++ b/application/apps/web/src/server/auth/route.ts
@@ -1,41 +1,35 @@
-import { authInputSchema } from '@trend-diary/domain/account'
 import { Hono } from 'hono'
 import type { Env } from '@/env'
 import { authenticator } from '@/middleware/authenticator'
 import rateLimiter from '@/middleware/rate-limiter'
-import zodValidator from '@/middleware/zod-validator'
 import login from './handler/login'
 import logout from './handler/logout'
 import me from './handler/me'
 import passkeyDisable from './handler/passkey-disable'
 import passkeyLoginStart from './handler/passkey-login-start'
-import passkeyLoginVerify, { passkeyLoginVerifyInputSchema } from './handler/passkey-login-verify'
+import passkeyLoginVerify, { passkeyLoginVerifyValidator } from './handler/passkey-login-verify'
 import passkeyRegisterStart from './handler/passkey-register-start'
 import passkeyRegisterVerify, {
-  passkeyRegisterVerifyInputSchema,
+  passkeyRegisterVerifyValidator,
 } from './handler/passkey-register-verify'
 import passkeyStatus from './handler/passkey-status'
 import signup from './handler/signup'
+import { authInputValidator } from './validators'
 
 const app = new Hono<Env>()
-  .post('/signup', rateLimiter, zodValidator('json', authInputSchema), signup)
-  .post('/login', rateLimiter, zodValidator('json', authInputSchema), login)
+  .post('/signup', rateLimiter, authInputValidator, signup)
+  .post('/login', rateLimiter, authInputValidator, login)
   .delete('/logout', logout)
   .get('/me', authenticator, me)
   // passkey認証(未認証で可)。ブラウザのWebAuthn ceremonyを挟むためstart/verifyの2段構え
   .post('/passkey/login/start', rateLimiter, passkeyLoginStart)
-  .post(
-    '/passkey/login/verify',
-    rateLimiter,
-    zodValidator('json', passkeyLoginVerifyInputSchema),
-    passkeyLoginVerify,
-  )
+  .post('/passkey/login/verify', rateLimiter, passkeyLoginVerifyValidator, passkeyLoginVerify)
   // passkey登録(要認証)。ログイン中ユーザーが自分のpasskeyを登録する
   .post('/passkey/register/start', authenticator, passkeyRegisterStart)
   .post(
     '/passkey/register/verify',
     authenticator,
-    zodValidator('json', passkeyRegisterVerifyInputSchema),
+    passkeyRegisterVerifyValidator,
     passkeyRegisterVerify,
   )
   // passkey管理(要認証)。設定画面のトグルが登録状態の取得と無効化に使う

--- a/application/apps/web/src/server/auth/validators.ts
+++ b/application/apps/web/src/server/auth/validators.ts
@@ -1,0 +1,5 @@
+import { authInputSchema } from '@trend-diary/domain/account'
+import zodValidator from '@/middleware/zod-validator'
+
+// signup / login で同一スキーマを共有するため単一の validator を使い回す
+export const authInputValidator = zodValidator('json', authInputSchema)

--- a/application/apps/web/src/server/handler-factory.ts
+++ b/application/apps/web/src/server/handler-factory.ts
@@ -26,7 +26,10 @@
  * 従来パターン例:
  * ```typescript
  * export default async function updateRole(
- *   c: ZodValidatedParamJsonContext<z.infer<typeof paramSchema>, z.infer<typeof jsonSchema>>,
+ *   c: ZodValidatedContext<
+ *     { param: z.input<typeof paramSchema>; json: z.input<typeof jsonSchema> },
+ *     { param: z.output<typeof paramSchema>; json: z.output<typeof jsonSchema> }
+ *   >,
  * ) {
  *   const logger = c.get(CONTEXT_KEY.APP_LOG)
  *   const { id } = c.req.valid('param')

--- a/application/apps/web/src/server/handler-factory.ts
+++ b/application/apps/web/src/server/handler-factory.ts
@@ -26,10 +26,7 @@
  * 従来パターン例:
  * ```typescript
  * export default async function updateRole(
- *   c: ZodValidatedContext<
- *     { param: z.input<typeof paramSchema>; json: z.input<typeof jsonSchema> },
- *     { param: z.output<typeof paramSchema>; json: z.output<typeof jsonSchema> }
- *   >,
+ *   c: ZodValidatedContext<[typeof paramValidator, typeof jsonValidator]>,
  * ) {
  *   const logger = c.get(CONTEXT_KEY.APP_LOG)
  *   const { id } = c.req.valid('param')

--- a/application/apps/web/src/server/oauth/handler/callback.ts
+++ b/application/apps/web/src/server/oauth/handler/callback.ts
@@ -2,7 +2,7 @@ import { authClientConfig, OAuthClient } from '@trend-diary/authentication'
 import { ClientError } from '@trend-diary/common/errors'
 import { resolveLoginRedirectTarget } from '@trend-diary/common/sanitization'
 import getRdbClient from '@trend-diary/datastore/rdb'
-import { createAccountUseCase, type OAuthCallbackQuery } from '@trend-diary/domain/account'
+import { createAccountUseCase } from '@trend-diary/domain/account'
 import { deleteCookie, getCookie } from 'hono/cookie'
 import CONTEXT_KEY from '@/middleware/context'
 import type { ZodValidatedContext } from '@/middleware/zod-validator'
@@ -13,10 +13,13 @@ import {
   OAUTH_FLOW_COOKIE,
   OAUTH_REDIRECT_COOKIE,
 } from '@/server/oauth/redirect'
-import type { OAuthProviderParam } from '@/server/oauth/schema'
+import type {
+  oauthCallbackQueryValidator,
+  oauthProviderParamValidator,
+} from '@/server/oauth/schema'
 
 export default async function oauthCallback(
-  c: ZodValidatedContext<{ param: OAuthProviderParam; query: OAuthCallbackQuery }>,
+  c: ZodValidatedContext<[typeof oauthProviderParamValidator, typeof oauthCallbackQueryValidator]>,
 ) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const { provider } = c.req.valid('param')

--- a/application/apps/web/src/server/oauth/handler/callback.ts
+++ b/application/apps/web/src/server/oauth/handler/callback.ts
@@ -5,7 +5,7 @@ import getRdbClient from '@trend-diary/datastore/rdb'
 import { createAccountUseCase, type OAuthCallbackQuery } from '@trend-diary/domain/account'
 import { deleteCookie, getCookie } from 'hono/cookie'
 import CONTEXT_KEY from '@/middleware/context'
-import type { ZodValidatedParamQueryContext } from '@/middleware/zod-validator'
+import type { ZodValidatedContext } from '@/middleware/zod-validator'
 import { handleError } from '@/server/error/handle-error'
 import {
   OAUTH_COOKIE_OPTIONS,
@@ -16,7 +16,7 @@ import {
 import type { OAuthProviderParam } from '@/server/oauth/schema'
 
 export default async function oauthCallback(
-  c: ZodValidatedParamQueryContext<OAuthProviderParam, OAuthCallbackQuery>,
+  c: ZodValidatedContext<{ param: OAuthProviderParam; query: OAuthCallbackQuery }>,
 ) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const { provider } = c.req.valid('param')

--- a/application/apps/web/src/server/oauth/handler/link.ts
+++ b/application/apps/web/src/server/oauth/handler/link.ts
@@ -1,7 +1,7 @@
 import { authClientConfig, OAuthClient } from '@trend-diary/authentication'
 import { setCookie } from 'hono/cookie'
 import CONTEXT_KEY from '@/middleware/context'
-import type { ZodValidatedParamContext } from '@/middleware/zod-validator'
+import type { ZodValidatedContext } from '@/middleware/zod-validator'
 import toAuthError from '@/server/error/auth-error'
 import { handleError } from '@/server/error/handle-error'
 import {
@@ -13,7 +13,7 @@ import {
 } from '@/server/oauth/redirect'
 import type { OAuthProviderParam } from '@/server/oauth/schema'
 
-export default async function oauthLink(c: ZodValidatedParamContext<OAuthProviderParam>) {
+export default async function oauthLink(c: ZodValidatedContext<{ param: OAuthProviderParam }>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const { provider } = c.req.valid('param')
 

--- a/application/apps/web/src/server/oauth/handler/link.ts
+++ b/application/apps/web/src/server/oauth/handler/link.ts
@@ -11,9 +11,11 @@ import {
   OAUTH_FLOW_COOKIE,
   OAUTH_REDIRECT_COOKIE,
 } from '@/server/oauth/redirect'
-import type { OAuthProviderParam } from '@/server/oauth/schema'
+import type { oauthProviderParamValidator } from '@/server/oauth/schema'
 
-export default async function oauthLink(c: ZodValidatedContext<{ param: OAuthProviderParam }>) {
+export default async function oauthLink(
+  c: ZodValidatedContext<[typeof oauthProviderParamValidator]>,
+) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const { provider } = c.req.valid('param')
 

--- a/application/apps/web/src/server/oauth/handler/login.ts
+++ b/application/apps/web/src/server/oauth/handler/login.ts
@@ -1,6 +1,5 @@
 import { authClientConfig, OAuthClient } from '@trend-diary/authentication'
 import { resolveLoginRedirectTarget } from '@trend-diary/common/sanitization'
-import type { OAuthLoginQuery } from '@trend-diary/domain/account'
 import { deleteCookie, setCookie } from 'hono/cookie'
 import CONTEXT_KEY from '@/middleware/context'
 import type { ZodValidatedContext } from '@/middleware/zod-validator'
@@ -13,10 +12,10 @@ import {
   OAUTH_FLOW_COOKIE,
   OAUTH_REDIRECT_COOKIE,
 } from '@/server/oauth/redirect'
-import type { OAuthProviderParam } from '@/server/oauth/schema'
+import type { oauthLoginQueryValidator, oauthProviderParamValidator } from '@/server/oauth/schema'
 
 export default async function oauthLogin(
-  c: ZodValidatedContext<{ param: OAuthProviderParam; query: OAuthLoginQuery }>,
+  c: ZodValidatedContext<[typeof oauthProviderParamValidator, typeof oauthLoginQueryValidator]>,
 ) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const { provider } = c.req.valid('param')

--- a/application/apps/web/src/server/oauth/handler/login.ts
+++ b/application/apps/web/src/server/oauth/handler/login.ts
@@ -3,7 +3,7 @@ import { resolveLoginRedirectTarget } from '@trend-diary/common/sanitization'
 import type { OAuthLoginQuery } from '@trend-diary/domain/account'
 import { deleteCookie, setCookie } from 'hono/cookie'
 import CONTEXT_KEY from '@/middleware/context'
-import type { ZodValidatedParamQueryContext } from '@/middleware/zod-validator'
+import type { ZodValidatedContext } from '@/middleware/zod-validator'
 import toAuthError from '@/server/error/auth-error'
 import { handleError } from '@/server/error/handle-error'
 import {
@@ -16,7 +16,7 @@ import {
 import type { OAuthProviderParam } from '@/server/oauth/schema'
 
 export default async function oauthLogin(
-  c: ZodValidatedParamQueryContext<OAuthProviderParam, OAuthLoginQuery>,
+  c: ZodValidatedContext<{ param: OAuthProviderParam; query: OAuthLoginQuery }>,
 ) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const { provider } = c.req.valid('param')

--- a/application/apps/web/src/server/oauth/handler/status.ts
+++ b/application/apps/web/src/server/oauth/handler/status.ts
@@ -3,9 +3,11 @@ import CONTEXT_KEY from '@/middleware/context'
 import type { ZodValidatedContext } from '@/middleware/zod-validator'
 import toAuthError from '@/server/error/auth-error'
 import { handleError } from '@/server/error/handle-error'
-import type { OAuthProviderParam } from '@/server/oauth/schema'
+import type { oauthProviderParamValidator } from '@/server/oauth/schema'
 
-export default async function oauthStatus(c: ZodValidatedContext<{ param: OAuthProviderParam }>) {
+export default async function oauthStatus(
+  c: ZodValidatedContext<[typeof oauthProviderParamValidator]>,
+) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const { provider } = c.req.valid('param')
 

--- a/application/apps/web/src/server/oauth/handler/status.ts
+++ b/application/apps/web/src/server/oauth/handler/status.ts
@@ -1,11 +1,11 @@
 import { authClientConfig, OAuthClient } from '@trend-diary/authentication'
 import CONTEXT_KEY from '@/middleware/context'
-import type { ZodValidatedParamContext } from '@/middleware/zod-validator'
+import type { ZodValidatedContext } from '@/middleware/zod-validator'
 import toAuthError from '@/server/error/auth-error'
 import { handleError } from '@/server/error/handle-error'
 import type { OAuthProviderParam } from '@/server/oauth/schema'
 
-export default async function oauthStatus(c: ZodValidatedParamContext<OAuthProviderParam>) {
+export default async function oauthStatus(c: ZodValidatedContext<{ param: OAuthProviderParam }>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const { provider } = c.req.valid('param')
 

--- a/application/apps/web/src/server/oauth/handler/unlink.ts
+++ b/application/apps/web/src/server/oauth/handler/unlink.ts
@@ -1,12 +1,12 @@
 import { authClientConfig, OAuthClient } from '@trend-diary/authentication'
 import { ClientError } from '@trend-diary/common/errors'
 import CONTEXT_KEY from '@/middleware/context'
-import type { ZodValidatedParamContext } from '@/middleware/zod-validator'
+import type { ZodValidatedContext } from '@/middleware/zod-validator'
 import toAuthError from '@/server/error/auth-error'
 import { handleError } from '@/server/error/handle-error'
 import type { OAuthProviderParam } from '@/server/oauth/schema'
 
-export default async function oauthUnlink(c: ZodValidatedParamContext<OAuthProviderParam>) {
+export default async function oauthUnlink(c: ZodValidatedContext<{ param: OAuthProviderParam }>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const { provider } = c.req.valid('param')
 

--- a/application/apps/web/src/server/oauth/handler/unlink.ts
+++ b/application/apps/web/src/server/oauth/handler/unlink.ts
@@ -4,9 +4,11 @@ import CONTEXT_KEY from '@/middleware/context'
 import type { ZodValidatedContext } from '@/middleware/zod-validator'
 import toAuthError from '@/server/error/auth-error'
 import { handleError } from '@/server/error/handle-error'
-import type { OAuthProviderParam } from '@/server/oauth/schema'
+import type { oauthProviderParamValidator } from '@/server/oauth/schema'
 
-export default async function oauthUnlink(c: ZodValidatedContext<{ param: OAuthProviderParam }>) {
+export default async function oauthUnlink(
+  c: ZodValidatedContext<[typeof oauthProviderParamValidator]>,
+) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
   const { provider } = c.req.valid('param')
 

--- a/application/apps/web/src/server/oauth/route.ts
+++ b/application/apps/web/src/server/oauth/route.ts
@@ -1,15 +1,17 @@
-import { oauthCallbackQuerySchema, oauthLoginQuerySchema } from '@trend-diary/domain/account'
 import { Hono } from 'hono'
 import type { Env } from '@/env'
 import { authenticator } from '@/middleware/authenticator'
 import rateLimiter from '@/middleware/rate-limiter'
-import zodValidator from '@/middleware/zod-validator'
 import oauthCallback from './handler/callback'
 import oauthLink from './handler/link'
 import oauthLogin from './handler/login'
 import oauthStatus from './handler/status'
 import oauthUnlink from './handler/unlink'
-import { oauthProviderParamSchema } from './schema'
+import {
+  oauthCallbackQueryValidator,
+  oauthLoginQueryValidator,
+  oauthProviderParamValidator,
+} from './schema'
 
 const app = new Hono<Env>()
   // OAuth(未認証で可)。認可はSupabase経由でプロバイダへ委譲し、callbackでセッションを確立する。
@@ -17,19 +19,19 @@ const app = new Hono<Env>()
   .get(
     '/:provider/login',
     rateLimiter,
-    zodValidator('param', oauthProviderParamSchema),
-    zodValidator('query', oauthLoginQuerySchema),
+    oauthProviderParamValidator,
+    oauthLoginQueryValidator,
     oauthLogin,
   )
   .get(
     '/:provider/callback',
     rateLimiter,
-    zodValidator('param', oauthProviderParamSchema),
-    zodValidator('query', oauthCallbackQuerySchema),
+    oauthProviderParamValidator,
+    oauthCallbackQueryValidator,
     oauthCallback,
   )
-  .get('/:provider/link', authenticator, zodValidator('param', oauthProviderParamSchema), oauthLink)
-  .get('/:provider', authenticator, zodValidator('param', oauthProviderParamSchema), oauthStatus)
-  .delete('/:provider', authenticator, zodValidator('param', oauthProviderParamSchema), oauthUnlink)
+  .get('/:provider/link', authenticator, oauthProviderParamValidator, oauthLink)
+  .get('/:provider', authenticator, oauthProviderParamValidator, oauthStatus)
+  .delete('/:provider', authenticator, oauthProviderParamValidator, oauthUnlink)
 
 export default app

--- a/application/apps/web/src/server/oauth/schema.ts
+++ b/application/apps/web/src/server/oauth/schema.ts
@@ -4,11 +4,9 @@ import { z } from 'zod'
 import zodValidator from '@/middleware/zod-validator'
 
 // :provider パスパラメータの検証。対応プロバイダは authentication の定義元に従い、未対応は422に落とす
-export const oauthProviderParamSchema = z.object({
+const oauthProviderParamSchema = z.object({
   provider: z.enum(OAUTH_PROVIDERS),
 })
-
-export type OAuthProviderParam = z.infer<typeof oauthProviderParamSchema>
 
 // param は全 OAuth ルートで共有するため単一の validator を使い回す
 export const oauthProviderParamValidator = zodValidator('param', oauthProviderParamSchema)

--- a/application/apps/web/src/server/oauth/schema.ts
+++ b/application/apps/web/src/server/oauth/schema.ts
@@ -1,5 +1,7 @@
 import { OAUTH_PROVIDERS } from '@trend-diary/authentication'
+import { oauthCallbackQuerySchema, oauthLoginQuerySchema } from '@trend-diary/domain/account'
 import { z } from 'zod'
+import zodValidator from '@/middleware/zod-validator'
 
 // :provider パスパラメータの検証。対応プロバイダは authentication の定義元に従い、未対応は422に落とす
 export const oauthProviderParamSchema = z.object({
@@ -7,3 +9,8 @@ export const oauthProviderParamSchema = z.object({
 })
 
 export type OAuthProviderParam = z.infer<typeof oauthProviderParamSchema>
+
+// param は全 OAuth ルートで共有するため単一の validator を使い回す
+export const oauthProviderParamValidator = zodValidator('param', oauthProviderParamSchema)
+export const oauthLoginQueryValidator = zodValidator('query', oauthLoginQuerySchema)
+export const oauthCallbackQueryValidator = zodValidator('query', oauthCallbackQuerySchema)


### PR DESCRIPTION
# 概要
## 課題
fix: #989

`apps/web/src/middleware/zod-validator.ts` の context 型が、バリデーション対象（`query` / `param` / `json`）の組み合わせごとに個別定義され、新しい組み合わせのたびに手書きの型が増えていた（PR #987 のレビュー起点）。

## 修正内容
`ZodValidatedContext` を「**適用済みの `zodValidator` チェーンから in/out を導出する型**」に変更し、ハンドラー側での schema 再記述をなくした。schema は validator 定義が唯一の源になり、変更が型へ自動的に伝播する。

```ts
// handler — 対象・型のマップを手書きせず、適用した validator の型から導出
export default async function readArticle(
  c: ZodValidatedContext<[typeof articleIdParamValidator, typeof createReadHistoryJsonValidator]>,
) { ... }

// route — 名前付き validator を結線
.post('/:article_id/read', authenticator, articleIdParamValidator, createReadHistoryJsonValidator, readArticle)
```

- validator を名前付きで定義し、route が結線・handler が `typeof` で型参照する。共有スキーマ分は集約（oauth は `oauth/schema.ts`、auth の signup/login は `auth/validators.ts`）、article は各ハンドラに co-locate。
- 旧 5 種（`ZodValidatedContext`(json) / `Query` / `Param` / `ParamQuery` / `ParamJson`）を単一の導出型に統合。`param` の `transform` で in/out が分かれるケースも validator の `in`(`z.input`)/`out`(`z.output`) から自動で分離される。
- **完成 app の型からエンドポイント指定で引く案は不可**: handler は app を構成する部品のため、その app 型から handler の `c` を引くと自己参照で循環する（`TS2456`/`TS2502`/`TS7022`）。handler の手前にある validator の型から取ることで循環を回避している。

### 副次的な是正
- diary の `page` は `z.coerce.number()` のため、RPC の**入力**型は本来クエリ文字列。旧型は in=out で出力型を入力に流用していたのを是正し、クライアントは `String(page)` を送るようにした（URL 上は元から文字列送信のためランタイム不変）。

## その他・参考情報
- API 層バリデーション規約の「`ZodValidatedContext` 系の型で型安全にアクセス」「`authenticator → param → json → handler` の順序」は維持（型名・route 上の適用順とも不変）。
- 検証: `tsc --noEmit` / `oxlint` / `oxfmt --check` / 型変換フックのテスト（`zod-validator.test.ts`）が green。統合テストは Supabase エミュレータ前提のため CI で実行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEGpSk53wCGknHMeWYTXwu