### PR TITLE
refactor(account): 補償失敗通知の Notifier をハンドラ生成から集約へ

### DIFF
--- a/application/apps/web/src/middleware/authenticator/validate.ts
+++ b/application/apps/web/src/middleware/authenticator/validate.ts
@@ -1,8 +1,7 @@
 import { authClientConfig, SessionClient } from '@trend-diary/authentication'
-import getRdbClient from '@trend-diary/datastore/rdb'
-import { createAccountUseCase } from '@trend-diary/domain/account'
 import type { Context } from 'hono'
 import { err, ok, type Result } from 'neverthrow'
+import { createAccountUseCase } from '@/server/account/account-use-case'
 import type { Env, SessionUser } from '../../env'
 import CONTEXT_KEY from '../context'
 
@@ -26,8 +25,7 @@ export async function validateSession(
     return err(claims.error)
   }
 
-  const rdb = getRdbClient(c.env.DB)
-  const accountUseCase = createAccountUseCase(rdb)
+  const accountUseCase = createAccountUseCase(c)
   const result = await accountUseCase.resolveActiveUser(claims.value.authenticationId)
   if (result.isErr()) {
     logger.warn('Session validation failed', { error: result.error })

--- a/application/apps/web/src/server/account/account-use-case.test.ts
+++ b/application/apps/web/src/server/account/account-use-case.test.ts
@@ -1,0 +1,76 @@
+import type { LoggerType } from '@trend-diary/common/logger'
+import type { Context } from 'hono'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Env } from '@/env'
+import CONTEXT_KEY from '@/middleware/context'
+import { createAccountUseCase } from './account-use-case'
+
+const { discordCtor, discordSendMessage } = vi.hoisted(() => ({
+  discordCtor: vi.fn(),
+  discordSendMessage: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('@trend-diary/notification', () => ({
+  DiscordWebhookClient: class {
+    sendMessage = discordSendMessage
+
+    constructor(webhookUrl: string | undefined, logger: LoggerType) {
+      discordCtor(webhookUrl, logger)
+    }
+  },
+}))
+
+const { getRdbClientMock } = vi.hoisted(() => ({ getRdbClientMock: vi.fn(() => ({ rdb: true })) }))
+vi.mock('@trend-diary/datastore/rdb', () => ({ default: getRdbClientMock }))
+
+const { createDomainAccountUseCaseMock } = vi.hoisted(() => ({
+  createDomainAccountUseCaseMock: vi.fn((rdb, notifier) => ({ rdb, notifier })),
+}))
+vi.mock('@trend-diary/domain/account', () => ({
+  createAccountUseCase: createDomainAccountUseCaseMock,
+}))
+
+const WEBHOOK_URL = 'https://discord.test/webhook'
+const DB_BINDING = { db: true }
+const logger = { warn: vi.fn(), error: vi.fn() }
+
+function buildContext(): Context<Env> {
+  // oxlint-disable-next-line typescript/no-restricted-types -- Hono の変数ストアを模す、任意値を保持する Map のため
+  const store = new Map<string, unknown>([[CONTEXT_KEY.APP_LOG, logger]])
+  // oxlint-disable-next-line typescript/consistent-type-assertions -- テストに必要な最小限の Context を組み立てるため
+  return {
+    get: (key: string) => store.get(key),
+    env: { DB: DB_BINDING, DISCORD_WEBHOOK_URL: WEBHOOK_URL },
+    // oxlint-disable-next-line typescript/no-restricted-types -- 最小限のモックを Hono の複雑な Context 型へ橋渡しする境界キャストのため
+  } as unknown as Context<Env>
+}
+
+describe('createAccountUseCase', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('正常系', () => {
+    it('Context の DB と Notifier からドメインの AccountUseCase を生成する', () => {
+      const useCase = createAccountUseCase(buildContext())
+
+      expect(getRdbClientMock).toHaveBeenCalledWith(DB_BINDING)
+      const [rdb, notifier] = createDomainAccountUseCaseMock.mock.calls[0] ?? []
+      expect(rdb).toEqual({ rdb: true })
+      expect(notifier).toMatchObject({ sendMessage: expect.any(Function) })
+      expect(useCase).toBe(createDomainAccountUseCaseMock.mock.results[0]?.value)
+    })
+
+    it('Notifier は sendMessage 実行時にのみ DiscordWebhookClient を生成して委譲する', async () => {
+      createAccountUseCase(buildContext())
+      const notifier = createDomainAccountUseCaseMock.mock.calls[0]?.[1]
+
+      // 生成時点ではクライアントを作らない（クエリ経路での毎リクエスト生成を避けるため）
+      expect(discordCtor).not.toHaveBeenCalled()
+
+      await notifier.sendMessage('整合性エラー')
+
+      expect(discordCtor).toHaveBeenCalledWith(WEBHOOK_URL, logger)
+      expect(discordSendMessage).toHaveBeenCalledWith('整合性エラー')
+    })
+  })
+})

--- a/application/apps/web/src/server/account/account-use-case.ts
+++ b/application/apps/web/src/server/account/account-use-case.ts
@@ -2,6 +2,7 @@ import getRdbClient from '@trend-diary/datastore/rdb'
 import {
   type AccountUseCase,
   createAccountUseCase as createDomainAccountUseCase,
+  type Notifier,
 } from '@trend-diary/domain/account'
 import { DiscordWebhookClient } from '@trend-diary/notification'
 import type { Context } from 'hono'
@@ -13,6 +14,11 @@ import CONTEXT_KEY from '@/middleware/context'
 export function createAccountUseCase(c: Context<Env>): AccountUseCase {
   const rdb = getRdbClient(c.env.DB)
   const logger = c.get(CONTEXT_KEY.APP_LOG)
-  const notifier = new DiscordWebhookClient(c.env.DISCORD_WEBHOOK_URL, logger)
+  // 通知が要るのは補償失敗時だけなので、送信時にのみクライアントを生成する。これによりセッション検証等の
+  // クエリ経路（通知不要）では毎リクエストの生成を避けられる。未設定URLや送信失敗は同クライアントが握りつぶす
+  const notifier: Notifier = {
+    sendMessage: (content) =>
+      new DiscordWebhookClient(c.env.DISCORD_WEBHOOK_URL, logger).sendMessage(content),
+  }
   return createDomainAccountUseCase(rdb, notifier)
 }

--- a/application/apps/web/src/server/account/account-use-case.ts
+++ b/application/apps/web/src/server/account/account-use-case.ts
@@ -1,0 +1,18 @@
+import getRdbClient from '@trend-diary/datastore/rdb'
+import {
+  type AccountUseCase,
+  createAccountUseCase as createDomainAccountUseCase,
+} from '@trend-diary/domain/account'
+import { DiscordWebhookClient } from '@trend-diary/notification'
+import type { Context } from 'hono'
+import type { Env } from '@/env'
+import CONTEXT_KEY from '@/middleware/context'
+
+// 補償トランザクション失敗（孤児 users レコード）の運用通知に使う Notifier を、ハンドラ個別ではなく
+// ここで一元的に組み立てて注入する（error-handler ミドルウェアが Discord クライアントを内部生成するのに倣う）
+export function createAccountUseCase(c: Context<Env>): AccountUseCase {
+  const rdb = getRdbClient(c.env.DB)
+  const logger = c.get(CONTEXT_KEY.APP_LOG)
+  const notifier = new DiscordWebhookClient(c.env.DISCORD_WEBHOOK_URL, logger)
+  return createDomainAccountUseCase(rdb, notifier)
+}

--- a/application/apps/web/src/server/auth/handler/login.ts
+++ b/application/apps/web/src/server/auth/handler/login.ts
@@ -1,8 +1,8 @@
 import { authClientConfig, PasswordAuthClient } from '@trend-diary/authentication'
-import getRdbClient from '@trend-diary/datastore/rdb'
-import { type AuthInput, createAccountUseCase } from '@trend-diary/domain/account'
+import type { AuthInput } from '@trend-diary/domain/account'
 import CONTEXT_KEY from '@/middleware/context'
 import type { ZodValidatedContext } from '@/middleware/zod-validator'
+import { createAccountUseCase } from '@/server/account/account-use-case'
 import toAuthError from '@/server/error/auth-error'
 import { handleError } from '@/server/error/handle-error'
 import { verifyTurnstile } from '../captcha'
@@ -24,8 +24,7 @@ export default async function login(c: ZodValidatedContext<AuthInput>) {
 
   const user = loginResult.value
 
-  const rdb = getRdbClient(c.env.DB)
-  const accountUseCase = createAccountUseCase(rdb)
+  const accountUseCase = createAccountUseCase(c)
   const result = await accountUseCase.resolveActiveUser(user.id)
   if (result.isErr()) throw handleError(result.error, logger)
 

--- a/application/apps/web/src/server/auth/handler/passkey-login-verify.ts
+++ b/application/apps/web/src/server/auth/handler/passkey-login-verify.ts
@@ -1,10 +1,9 @@
 import type { AuthenticationResponseJSON } from '@simplewebauthn/browser'
 import { authClientConfig, PasskeyClient } from '@trend-diary/authentication'
-import getRdbClient from '@trend-diary/datastore/rdb'
-import { createAccountUseCase } from '@trend-diary/domain/account'
 import { z } from 'zod'
 import CONTEXT_KEY from '@/middleware/context'
 import type { ZodValidatedContext } from '@/middleware/zod-validator'
+import { createAccountUseCase } from '@/server/account/account-use-case'
 import toAuthError from '@/server/error/auth-error'
 import { handleError } from '@/server/error/handle-error'
 
@@ -29,8 +28,7 @@ export default async function passkeyLoginVerify(c: ZodValidatedContext<PasskeyL
   })
   if (userResult.isErr()) throw handleError(toAuthError(userResult.error), logger)
 
-  const rdb = getRdbClient(c.env.DB)
-  const accountUseCase = createAccountUseCase(rdb)
+  const accountUseCase = createAccountUseCase(c)
   const activeUserResult = await accountUseCase.resolveActiveUser(userResult.value.id)
   if (activeUserResult.isErr()) throw handleError(activeUserResult.error, logger)
 

--- a/application/apps/web/src/server/auth/handler/signup.ts
+++ b/application/apps/web/src/server/auth/handler/signup.ts
@@ -1,9 +1,8 @@
 import { authClientConfig, PasswordAuthClient } from '@trend-diary/authentication'
-import getRdbClient from '@trend-diary/datastore/rdb'
-import { type AuthInput, createAccountUseCase } from '@trend-diary/domain/account'
-import { DiscordWebhookClient } from '@trend-diary/notification'
+import type { AuthInput } from '@trend-diary/domain/account'
 import CONTEXT_KEY from '@/middleware/context'
 import type { ZodValidatedContext } from '@/middleware/zod-validator'
+import { createAccountUseCase } from '@/server/account/account-use-case'
 import toAuthError from '@/server/error/auth-error'
 import { handleError } from '@/server/error/handle-error'
 import { verifyTurnstile } from '../captcha'
@@ -30,14 +29,8 @@ export default async function signup(c: ZodValidatedContext<AuthInput>) {
   // 管理者権限(service_role)を要するが、サインアップ経路(anonクライアント)にadmin権限を持たせる
   // べきではないため行わない。対応候補は service_role を持つ別cronで未紐付けの認証ユーザーを定期
   // クリーンアップするなど。別イシューで再設計する。
-  const rdb = getRdbClient(c.env.DB)
-  const accountUseCase = createAccountUseCase(rdb)
-  const notifier = new DiscordWebhookClient(c.env.DISCORD_WEBHOOK_URL, logger)
-  const result = await accountUseCase.registerActiveUser(
-    user.email ?? valid.email,
-    user.id,
-    notifier,
-  )
+  const accountUseCase = createAccountUseCase(c)
+  const result = await accountUseCase.registerActiveUser(user.email ?? valid.email, user.id)
   if (result.isErr()) throw handleError(result.error, logger)
 
   logger.info('signup success', { activeUserId: result.value.activeUserId })

--- a/application/apps/web/src/server/oauth/handler/callback.ts
+++ b/application/apps/web/src/server/oauth/handler/callback.ts
@@ -1,12 +1,11 @@
 import { authClientConfig, OAuthClient } from '@trend-diary/authentication'
 import { ClientError } from '@trend-diary/common/errors'
 import { resolveLoginRedirectTarget } from '@trend-diary/common/sanitization'
-import getRdbClient from '@trend-diary/datastore/rdb'
-import { createAccountUseCase, type OAuthCallbackQuery } from '@trend-diary/domain/account'
-import { DiscordWebhookClient } from '@trend-diary/notification'
+import type { OAuthCallbackQuery } from '@trend-diary/domain/account'
 import { deleteCookie, getCookie } from 'hono/cookie'
 import CONTEXT_KEY from '@/middleware/context'
 import type { ZodValidatedParamQueryContext } from '@/middleware/zod-validator'
+import { createAccountUseCase } from '@/server/account/account-use-case'
 import { handleError } from '@/server/error/handle-error'
 import {
   OAUTH_COOKIE_OPTIONS,
@@ -57,8 +56,7 @@ export default async function oauthCallback(
 
   const { id: authenticationId, email } = exchangeResult.value
 
-  const rdb = getRdbClient(c.env.DB)
-  const accountUseCase = createAccountUseCase(rdb)
+  const accountUseCase = createAccountUseCase(c)
 
   // 既存ユーザーは認証IDだけで特定できるため、メール未取得でもログインを許可する
   const resolved = await accountUseCase.resolveActiveUser(authenticationId)
@@ -76,8 +74,7 @@ export default async function oauthCallback(
     return c.redirect(errorRedirect, 302)
   }
 
-  const notifier = new DiscordWebhookClient(c.env.DISCORD_WEBHOOK_URL, logger)
-  const registered = await accountUseCase.registerActiveUser(email, authenticationId, notifier)
+  const registered = await accountUseCase.registerActiveUser(email, authenticationId)
   if (registered.isErr()) {
     throw handleError(registered.error, logger)
   }

--- a/application/packages/domain/src/account/factory.test.ts
+++ b/application/packages/domain/src/account/factory.test.ts
@@ -2,13 +2,15 @@ import type { RdbClient } from '@trend-diary/datastore/rdb'
 import { describe, expect, it } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
 import { createAccountUseCase } from './factory'
+import type { Notifier } from './repository'
 import { AccountUseCase } from './use-case'
 
 describe('createAccountUseCase', () => {
-  it('RdbClientから AccountUseCase インスタンスを生成すること', () => {
+  it('RdbClientとNotifierから AccountUseCase インスタンスを生成すること', () => {
     const rdbClient = mockDeep<RdbClient>()
+    const notifier = mockDeep<Notifier>()
 
-    const useCase = createAccountUseCase(rdbClient)
+    const useCase = createAccountUseCase(rdbClient, notifier)
 
     expect(useCase).toBeInstanceOf(AccountUseCase)
   })

--- a/application/packages/domain/src/account/factory.ts
+++ b/application/packages/domain/src/account/factory.ts
@@ -1,10 +1,11 @@
 import type { RdbClient } from '@trend-diary/datastore/rdb'
 import CommandImpl from './infrastructure/command-impl'
 import QueryImpl from './infrastructure/query-impl'
+import type { Notifier } from './repository'
 import { AccountUseCase } from './use-case'
 
-export function createAccountUseCase(db: RdbClient): AccountUseCase {
-  const userCommand = new CommandImpl(db)
+export function createAccountUseCase(db: RdbClient, notifier: Notifier): AccountUseCase {
+  const userCommand = new CommandImpl(db, notifier)
   const userQuery = new QueryImpl(db)
   return new AccountUseCase(userCommand, userQuery)
 }

--- a/application/packages/domain/src/account/index.ts
+++ b/application/packages/domain/src/account/index.ts
@@ -1,4 +1,5 @@
 import { createAccountUseCase } from './factory'
+import type { Notifier } from './repository'
 import type { ActiveUser, ActiveUserInput, CurrentUser } from './schema/active-user-schema'
 import { activeUserInputSchema, activeUserSchema } from './schema/active-user-schema'
 import type { AuthInput, OAuthCallbackQuery, OAuthLoginQuery } from './schema/auth-schema'
@@ -7,13 +8,16 @@ import {
   oauthCallbackQuerySchema,
   oauthLoginQuerySchema,
 } from './schema/auth-schema'
+import type { AccountUseCase } from './use-case'
 
 // 型
 export type {
+  AccountUseCase,
   ActiveUser,
   ActiveUserInput,
   AuthInput,
   CurrentUser,
+  Notifier,
   OAuthCallbackQuery,
   OAuthLoginQuery,
 }

--- a/application/packages/domain/src/account/infrastructure/command-impl.test.ts
+++ b/application/packages/domain/src/account/infrastructure/command-impl.test.ts
@@ -36,7 +36,7 @@ describe('CommandImpl', () => {
   beforeEach(() => {
     logger = new Logger('silent')
     notifier = { sendMessage: vi.fn().mockResolvedValue(undefined) }
-    useCase = new CommandImpl(getRdbClient(), logger)
+    useCase = new CommandImpl(getRdbClient(), notifier, logger)
   })
 
   describe('createActiveWithAuthenticationId', () => {
@@ -58,7 +58,6 @@ describe('CommandImpl', () => {
       const result = await useCase.createActiveWithAuthenticationId(
         'test@example.com',
         'auth-id-123',
-        notifier,
         '表示名',
       )
 
@@ -113,7 +112,6 @@ describe('CommandImpl', () => {
       const result = await useCase.createActiveWithAuthenticationId(
         'test@example.com',
         'auth-id-123',
-        notifier,
       )
 
       // Assert
@@ -133,7 +131,6 @@ describe('CommandImpl', () => {
       const result = await useCase.createActiveWithAuthenticationId(
         'test@example.com',
         'auth-id-123',
-        notifier,
       )
 
       // Assert: ServerErrorを返す
@@ -165,7 +162,6 @@ describe('CommandImpl', () => {
       const result = await useCase.createActiveWithAuthenticationId(
         'test@example.com',
         'auth-id-123',
-        notifier,
       )
 
       // Assert: ServerErrorを返す
@@ -195,7 +191,6 @@ describe('CommandImpl', () => {
       const result = await useCase.createActiveWithAuthenticationId(
         'test@example.com',
         'auth-id-123',
-        notifier,
       )
 
       // Assert: 補償が失敗しても元のServerErrorを返す
@@ -222,7 +217,7 @@ describe('CommandImpl', () => {
         .mockRejectedValueOnce(compensationError)
 
       // Act
-      await useCase.createActiveWithAuthenticationId('test@example.com', 'auth-id-123', notifier)
+      await useCase.createActiveWithAuthenticationId('test@example.com', 'auth-id-123')
 
       // Assert: 手動対応に必要なuserId(=2)と補償エラーをerrorログに残すこと
       expect(errorSpy).toHaveBeenCalledWith(
@@ -243,7 +238,7 @@ describe('CommandImpl', () => {
         .mockRejectedValueOnce(compensationError)
 
       // Act
-      await useCase.createActiveWithAuthenticationId('test@example.com', 'auth-id-123', notifier)
+      await useCase.createActiveWithAuthenticationId('test@example.com', 'auth-id-123')
 
       // Assert: userId(=2)と補償エラーを含むメッセージを通知すること
       expect(notifier.sendMessage).toHaveBeenCalledWith(expect.stringContaining('userId: 2'))
@@ -261,7 +256,7 @@ describe('CommandImpl', () => {
         .mockResolvedValueOnce({ rows: [] })
 
       // Act
-      await useCase.createActiveWithAuthenticationId('test@example.com', 'auth-id-123', notifier)
+      await useCase.createActiveWithAuthenticationId('test@example.com', 'auth-id-123')
 
       // Assert: 補償が成功した場合はログも通知も出さないこと
       expect(errorSpy).not.toHaveBeenCalled()

--- a/application/packages/domain/src/account/infrastructure/command-impl.ts
+++ b/application/packages/domain/src/account/infrastructure/command-impl.ts
@@ -16,13 +16,13 @@ const defaultLogger = new Logger('error', { component: 'user-command' })
 export default class CommandImpl implements Command {
   constructor(
     private readonly db: RdbClient,
+    private readonly notifier: Notifier,
     private readonly logger: Logger = defaultLogger,
   ) {}
 
   async createActiveWithAuthenticationId(
     email: string,
     authenticationId: string,
-    notifier: Notifier,
     displayName?: string | null,
   ): Promise<Result<CurrentUser, ServerError>> {
     // INFO: D1はインタラクティブトランザクション非対応のため、users→active_usersを逐次insertし、
@@ -51,7 +51,7 @@ export default class CommandImpl implements Command {
           compensateResult.error,
         )
         // 通知失敗は補償処理の結果に影響させない（通知基盤側で握りつぶす）
-        await notifier.sendMessage(
+        await this.notifier.sendMessage(
           `🚨 整合性エラー: active_usersを持たないusersレコードが孤立（サインアップ補償トランザクション失敗）\nuserId: ${userId}\nerror: ${compensateResult.error.message}`,
         )
       }

--- a/application/packages/domain/src/account/repository.ts
+++ b/application/packages/domain/src/account/repository.ts
@@ -22,7 +22,6 @@ export interface Command {
   createActiveWithAuthenticationId(
     email: string,
     authenticationId: string,
-    notifier: Notifier,
     displayName?: string | null,
   ): Promise<Result<CurrentUser, ServerError>>
 }

--- a/application/packages/domain/src/account/use-case.test.ts
+++ b/application/packages/domain/src/account/use-case.test.ts
@@ -2,13 +2,12 @@ import { ClientError, ServerError } from '@trend-diary/common/errors'
 import { err, ok } from 'neverthrow'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { mockDeep } from 'vitest-mock-extended'
-import type { Command, Notifier, Query } from './repository'
+import type { Command, Query } from './repository'
 import type { CurrentUser } from './schema/active-user-schema'
 import { AccountUseCase } from './use-case'
 
 const commandMock = mockDeep<Command>()
 const queryMock = mockDeep<Query>()
-const notifierMock = mockDeep<Notifier>()
 
 const mockActiveUser: CurrentUser = {
   activeUserId: 1n,
@@ -32,17 +31,12 @@ describe('AccountUseCase', () => {
       it('認証IDに紐づくアクティブユーザーを作成して返す', async () => {
         commandMock.createActiveWithAuthenticationId.mockResolvedValue(ok(mockActiveUser))
 
-        const result = await useCase.registerActiveUser(
-          'test@example.com',
-          'auth-user-id-123',
-          notifierMock,
-        )
+        const result = await useCase.registerActiveUser('test@example.com', 'auth-user-id-123')
 
         expect(result._unsafeUnwrap()).toEqual(mockActiveUser)
         expect(commandMock.createActiveWithAuthenticationId).toHaveBeenCalledWith(
           'test@example.com',
           'auth-user-id-123',
-          notifierMock,
           undefined,
         )
       })
@@ -54,11 +48,7 @@ describe('AccountUseCase', () => {
           err(new ServerError('create failed')),
         )
 
-        const result = await useCase.registerActiveUser(
-          'test@example.com',
-          'auth-user-id-123',
-          notifierMock,
-        )
+        const result = await useCase.registerActiveUser('test@example.com', 'auth-user-id-123')
 
         expect(result._unsafeUnwrapErr()).toBeInstanceOf(ServerError)
       })

--- a/application/packages/domain/src/account/use-case.ts
+++ b/application/packages/domain/src/account/use-case.ts
@@ -1,6 +1,6 @@
 import { ClientError, ServerError } from '@trend-diary/common/errors'
 import { err, ok, type Result } from 'neverthrow'
-import type { Command, Notifier, Query } from './repository'
+import type { Command, Query } from './repository'
 import type { CurrentUser } from './schema/active-user-schema'
 
 export class AccountUseCase {
@@ -12,15 +12,9 @@ export class AccountUseCase {
   async registerActiveUser(
     email: string,
     authenticationId: string,
-    notifier: Notifier,
     displayName?: string | null,
   ): Promise<Result<CurrentUser, ServerError>> {
-    return this.userCommand.createActiveWithAuthenticationId(
-      email,
-      authenticationId,
-      notifier,
-      displayName,
-    )
+    return this.userCommand.createActiveWithAuthenticationId(email, authenticationId, displayName)
   }
 
   async resolveActiveUser(


### PR DESCRIPTION
## 背景

close #992

PR #986 のレビューで、`github-callback`（現 `oauth/handler/callback.ts`）ハンドラが `DiscordWebhookClient`（`Notifier`）を生成してドメインへ渡している点について「このレイヤーで Discord 通知を生成せず、error-handler ミドルウェアのようなパターンに倣うべき」との指摘がありました。

補償トランザクション失敗（`active_users` 作成失敗 → `users` 行の削除も失敗し孤児レコードが残るケース）を運用者へ知らせる `Notifier` を、ドメインの `createActiveWithAuthenticationId`（`registerActiveUser` 経由）が必須引数として要求していたため、呼び出し側のハンドラ（`signup.ts` / `callback.ts` 双方）で `DiscordWebhookClient` を都度生成して引き回す形になっていました。

## やったこと

`Notifier` の引き回しを注入方式へ改め、ハンドラ層で Discord クライアントを都度生成しない形にしました。

- **ドメイン**: `Notifier` を `CommandImpl` のコンストラクタ依存へ移動し、`createActiveWithAuthenticationId` / `registerActiveUser` のメソッド引数から除去（`Command` インターフェース・`AccountUseCase` も追従）
- **ドメイン factory**: `createAccountUseCase(db, notifier)` で `Notifier` を受け取る形に変更。併せて `AccountUseCase` / `Notifier` 型を index から公開
- **web**: `Notifier`（`DiscordWebhookClient`）と `RdbClient` を Hono `Context` から一元的に組み立てる `createAccountUseCase(c)` を `server/account/account-use-case.ts` に新設。error-handler ミドルウェアが Discord クライアントを内部生成するのに倣い、生成箇所を集約
- 5 箇所の呼び出し（`callback.ts` / `signup.ts` / `login.ts` / `passkey-login-verify.ts` / `middleware/authenticator/validate.ts`）を新ファクトリへ差し替え

補償失敗通知のメッセージ内容・タイミングは従来どおりで、挙動は変えていません。

## スコープ外

- PR #986 の GitHub ログイン/新規登録機能そのもの（マージ済み）

## テスト

- `pnpm --filter @trend-diary/domain typecheck` / `pnpm --filter @trend-diary/web typecheck`: パス
- `pnpm --filter @trend-diary/domain test`: 267 passed（カバレッジ閾値 OK）
- `pnpm check`（oxlint / oxfmt）: 新規のエラー・警告なし
- web・E2E を含むフルテストは CI で実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdbkmqX3YY2zxWkpqJAjzG)_