### PR TITLE
feat: Context 値の必須取得ヘルパー mustGet を追加する

### DIFF
--- a/application/apps/web/src/middleware/context.test.ts
+++ b/application/apps/web/src/middleware/context.test.ts
@@ -1,0 +1,37 @@
+import type { Context } from 'hono'
+import type { Env } from '@/env'
+import CONTEXT_KEY, { mustGet } from './context'
+
+// oxlint-disable-next-line typescript/no-restricted-types -- Hono の変数ストアへ任意値を投入するテスト用の入力のため
+function buildContext(entries: Record<string, unknown>): Context<Env> {
+  // oxlint-disable-next-line typescript/no-restricted-types -- Hono の変数ストアを模す、任意値を保持する Map のため
+  const store = new Map<string, unknown>(Object.entries(entries))
+  // oxlint-disable-next-line typescript/consistent-type-assertions -- テストに必要な最小限の Context を組み立てるため
+  return {
+    get: (key: string) => store.get(key),
+    // oxlint-disable-next-line typescript/no-restricted-types -- 最小限のモックを Hono の複雑な Context 型へ橋渡しする境界キャストのため
+  } as unknown as Context<Env>
+}
+
+describe('mustGet', () => {
+  describe('正常系', () => {
+    it('指定キーの値が設定されていればその値を返すこと', () => {
+      const sessionId = 'session-123'
+      const c = buildContext({ [CONTEXT_KEY.SESSION_ID]: sessionId })
+
+      expect(mustGet(c, CONTEXT_KEY.SESSION_ID)).toBe(sessionId)
+    })
+  })
+
+  describe('異常系', () => {
+    // 契約上必ず存在するはずの値が未設定なら握りつぶさず送出することを担保する
+    it.each([
+      ['未設定（undefined）', {}],
+      ['null', { [CONTEXT_KEY.SESSION_ID]: null }],
+    ])('%s の場合はどのキーか分かるエラーを送出すること', (_label, entries) => {
+      const c = buildContext(entries)
+
+      expect(() => mustGet(c, CONTEXT_KEY.SESSION_ID)).toThrow(CONTEXT_KEY.SESSION_ID)
+    })
+  })
+})

--- a/application/apps/web/src/middleware/context.ts
+++ b/application/apps/web/src/middleware/context.ts
@@ -1,7 +1,24 @@
+import type { Context } from 'hono'
+import type { Env } from '@/env'
+
 const CONTEXT_KEY = {
   APP_LOG: 'appLog',
   SESSION_USER: 'sessionUser',
   SESSION_ID: 'sessionId',
 } as const
+
+type ContextKey = (typeof CONTEXT_KEY)[keyof typeof CONTEXT_KEY]
+
+// 契約上必ず存在するはずの Context 値を取得する。未設定なら `!` で握らず明示的なエラーで契約違反を顕在化させるため
+export function mustGet<K extends ContextKey>(
+  c: Context<Env>,
+  key: K,
+): NonNullable<Env['Variables'][K]> {
+  const value = c.get(key)
+  if (value === null || value === undefined) {
+    throw new Error(`Context value for "${key}" is required but was not set`)
+  }
+  return value
+}
 
 export default CONTEXT_KEY

--- a/application/apps/web/src/middleware/error-handler.test.ts
+++ b/application/apps/web/src/middleware/error-handler.test.ts
@@ -84,7 +84,7 @@ describe('errorHandler', () => {
   describe('異常系', () => {
     // APP_LOG は request-logger が設定する契約。未設定での起動は契約違反として送出されることを担保する
     it('APP_LOG 未設定で呼び出された場合はエラーを送出すること', async () => {
-      await expect(errorHandler(new Error('boom'), buildContext())).rejects.toThrow('APP_LOG')
+      await expect(errorHandler(new Error('boom'), buildContext())).rejects.toThrow('appLog')
     })
   })
 })

--- a/application/apps/web/src/middleware/error-handler.ts
+++ b/application/apps/web/src/middleware/error-handler.ts
@@ -2,7 +2,7 @@ import { DiscordNotifier } from '@trend-diary/notification'
 import type { Context } from 'hono'
 import { HTTPException } from 'hono/http-exception'
 import type { Env } from '../env'
-import CONTEXT_KEY from './context'
+import CONTEXT_KEY, { mustGet } from './context'
 
 interface RequestInfo {
   url: string
@@ -11,11 +11,7 @@ interface RequestInfo {
 }
 
 const errorHandler = async (err: Error, c: Context<Env>): Promise<Response> => {
-  const logger = c.get(CONTEXT_KEY.APP_LOG)
-
-  if (!logger) {
-    throw new Error('APP_LOG must be set by request-logger before errorHandler runs')
-  }
+  const logger = mustGet(c, CONTEXT_KEY.APP_LOG)
 
   const requestInfo: RequestInfo = {
     url: c.req.url,

--- a/application/apps/web/src/server/article/handler/get-diary.ts
+++ b/application/apps/web/src/server/article/handler/get-diary.ts
@@ -10,7 +10,7 @@ import type {
 import { HTTPException } from 'hono/http-exception'
 import { z } from 'zod'
 import { toTodayJstDateString } from '@/common/locale/date'
-import CONTEXT_KEY from '@/middleware/context'
+import CONTEXT_KEY, { mustGet } from '@/middleware/context'
 import zodValidator, { type ZodValidatedContext } from '@/middleware/zod-validator'
 import { handleError } from '@/server/error/handle-error'
 
@@ -77,7 +77,7 @@ interface DiaryRangeResponse {
 
 export default async function getDiary(c: ZodValidatedContext<[typeof diaryQueryValidator]>) {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
-  const sessionUser = c.get(CONTEXT_KEY.SESSION_USER)!
+  const sessionUser = mustGet(c, CONTEXT_KEY.SESSION_USER)
   const query = c.req.valid('query')
   const todayJst = resolveTodayJst()
   const fromDate = query.from

--- a/application/apps/web/src/server/article/handler/unread-digestion-articles.ts
+++ b/application/apps/web/src/server/article/handler/unread-digestion-articles.ts
@@ -2,7 +2,7 @@ import getRdbClient from '@trend-diary/datastore/rdb'
 import { createArticleUseCase } from '@trend-diary/domain/article'
 import { mediaListSchema } from '@trend-diary/domain/article/schema/query-schema'
 import { z } from 'zod'
-import CONTEXT_KEY from '@/middleware/context'
+import CONTEXT_KEY, { mustGet } from '@/middleware/context'
 import zodValidator, { type ZodValidatedContext } from '@/middleware/zod-validator'
 import { handleError } from '@/server/error/handle-error'
 import { type ArticleResponse, toArticleResponse } from '../article-response'
@@ -22,7 +22,7 @@ export default async function unreadDigestionArticles(
   c: ZodValidatedContext<[typeof unreadDigestionQueryValidator]>,
 ): Promise<Response> {
   const logger = c.get(CONTEXT_KEY.APP_LOG)
-  const sessionUser = c.get(CONTEXT_KEY.SESSION_USER)!
+  const sessionUser = mustGet(c, CONTEXT_KEY.SESSION_USER)
   const query = c.req.valid('query')
 
   const rdb = getRdbClient(c.env.DB)


### PR DESCRIPTION
## 概要

Closes #999

Hono の Context から必須の値（`APP_LOG` / `SESSION_USER` 等）を取得する `mustGet` ヘルパーを追加しました。契約上必ず存在するはずの値が未設定（nullish）だった場合に、握りつぶしたり `!`（非 null アサーション）で誤魔化したりせず、明示的なエラーで契約違反を顕在化させます。

## 変更内容

- `middleware/context.ts` に `mustGet(c, key)` を追加
  - 未設定時は `Context value for "<key>" is required but was not set`（英語・キー名入り）を送出
  - 戻り値の型は `NonNullable<Env['Variables'][K]>` でキーごとに型安全
  - 配置方針（`utils/` を作らない）に従い、Context キー定義と同じ `middleware/context.ts` に配置
- 呼び出し側を統一
  - `middleware/error-handler.ts`: `if (!logger) throw ...` を `mustGet` へ置き換え
  - `server/article/handler/get-diary.ts` / `unread-digestion-articles.ts`: `c.get(CONTEXT_KEY.SESSION_USER)!` の非 null アサーションを `mustGet` へ置き換え
- テスト
  - `middleware/context.test.ts`: 正常取得 / 未設定（undefined・null）時の送出を追加
  - `middleware/error-handler.test.ts`: エラーメッセージ変更に合わせて期待値を更新

## 完成の定義（受け入れ基準）

- [x] Context から指定キーの値を取得し、未設定なら明示的なエラーを送出するヘルパーを追加
- [x] エラーメッセージは英語で、どのキーが未設定かが分かる
- [x] `error-handler.ts` の `if (!logger) throw` を当該ヘルパーへ置き換え
- [x] `c.get(...)!` で握っている箇所を当該ヘルパーへ置き換え
- [x] ヘルパーの単体テスト（正常取得 / 未設定時の送出）を追加

## 確認

- `oxlint` / `oxfmt --check` / `tsc --noEmit` 通過
- 対象テスト（context / error-handler）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqKqdySwk62JWyD9ntYr6P)_