### PR TITLE
refactor(web): passkeyモジュール内ファクトリーを導入しハンドラーの契約重複を解消

### DIFF
--- a/application/apps/web/src/server/passkey/handler/authentication-options.ts
+++ b/application/apps/web/src/server/passkey/handler/authentication-options.ts
@@ -1,16 +1,6 @@
-import { authClientConfig, PasskeyClient } from '@trend-diary/authentication'
-import type { Context } from 'hono'
-import type { Env } from '@/env'
-import CONTEXT_KEY from '@/middleware/context'
-import toAuthError from '@/server/error/auth-error'
-import { handleError } from '@/server/error/handle-error'
+import { createPasskeyActionHandler, respondChallengeOptions } from '../passkey-action'
 
-export default async function passkeyAuthenticationOptions(c: Context<Env>) {
-  const logger = c.get(CONTEXT_KEY.APP_LOG)
-
-  const passkeyClient = new PasskeyClient(authClientConfig(c))
-  const result = await passkeyClient.startAuthentication()
-  if (result.isErr()) handleError(toAuthError(result.error), logger)
-
-  return c.json({ challengeId: result.value.challenge_id, options: result.value.options }, 200)
-}
+export default createPasskeyActionHandler({
+  execute: (passkeyClient) => passkeyClient.startAuthentication(),
+  respond: (c, started) => respondChallengeOptions(c, started),
+})

--- a/application/apps/web/src/server/passkey/handler/disable.ts
+++ b/application/apps/web/src/server/passkey/handler/disable.ts
@@ -1,25 +1,18 @@
-import { authClientConfig, PasskeyClient } from '@trend-diary/authentication'
-import type { Context } from 'hono'
-import type { Env } from '@/env'
-import CONTEXT_KEY from '@/middleware/context'
-import toAuthError from '@/server/error/auth-error'
-import { handleError } from '@/server/error/handle-error'
+import { err, ok } from 'neverthrow'
+import { createPasskeyActionHandler } from '../passkey-action'
 
-// 暫定: 認証ハンドラの契約由来の構造一致（logout / passkeyAuthenticationOptions /
-// passkeyRegistrationOptions / passkeyStatus との類似）を共通化で解消するまで検出を抑制する。恒久対応は #1015
-// similarity-ignore
-export default async function passkeyDisable(c: Context<Env>) {
-  const logger = c.get(CONTEXT_KEY.APP_LOG)
-
-  const passkeyClient = new PasskeyClient(authClientConfig(c))
-  const listResult = await passkeyClient.list()
-  if (listResult.isErr()) handleError(toAuthError(listResult.error), logger)
-
+export default createPasskeyActionHandler({
   // トグルOFFは「パスキーを使わない」状態にすることなので、登録済みを全て削除する
-  for (const passkey of listResult.value) {
-    const deleteResult = await passkeyClient.delete({ passkeyId: passkey.id })
-    if (deleteResult.isErr()) handleError(toAuthError(deleteResult.error), logger)
-  }
+  execute: async (passkeyClient) => {
+    const listResult = await passkeyClient.list()
+    if (listResult.isErr()) return err(listResult.error)
 
-  return c.body(null, 204)
-}
+    for (const passkey of listResult.value) {
+      const deleteResult = await passkeyClient.delete({ passkeyId: passkey.id })
+      if (deleteResult.isErr()) return err(deleteResult.error)
+    }
+
+    return ok(null)
+  },
+  respond: (c) => c.body(null, 204),
+})

--- a/application/apps/web/src/server/passkey/handler/registration-options.ts
+++ b/application/apps/web/src/server/passkey/handler/registration-options.ts
@@ -1,16 +1,6 @@
-import { authClientConfig, PasskeyClient } from '@trend-diary/authentication'
-import type { Context } from 'hono'
-import type { Env } from '@/env'
-import CONTEXT_KEY from '@/middleware/context'
-import toAuthError from '@/server/error/auth-error'
-import { handleError } from '@/server/error/handle-error'
+import { createPasskeyActionHandler, respondChallengeOptions } from '../passkey-action'
 
-export default async function passkeyRegistrationOptions(c: Context<Env>) {
-  const logger = c.get(CONTEXT_KEY.APP_LOG)
-
-  const passkeyClient = new PasskeyClient(authClientConfig(c))
-  const result = await passkeyClient.startRegistration()
-  if (result.isErr()) handleError(toAuthError(result.error), logger)
-
-  return c.json({ challengeId: result.value.challenge_id, options: result.value.options }, 200)
-}
+export default createPasskeyActionHandler({
+  execute: (passkeyClient) => passkeyClient.startRegistration(),
+  respond: (c, started) => respondChallengeOptions(c, started),
+})

--- a/application/apps/web/src/server/passkey/handler/status.ts
+++ b/application/apps/web/src/server/passkey/handler/status.ts
@@ -1,16 +1,6 @@
-import { authClientConfig, PasskeyClient } from '@trend-diary/authentication'
-import type { Context } from 'hono'
-import type { Env } from '@/env'
-import CONTEXT_KEY from '@/middleware/context'
-import toAuthError from '@/server/error/auth-error'
-import { handleError } from '@/server/error/handle-error'
+import { createPasskeyActionHandler } from '../passkey-action'
 
-export default async function passkeyStatus(c: Context<Env>) {
-  const logger = c.get(CONTEXT_KEY.APP_LOG)
-
-  const passkeyClient = new PasskeyClient(authClientConfig(c))
-  const result = await passkeyClient.list()
-  if (result.isErr()) handleError(toAuthError(result.error), logger)
-
-  return c.json({ hasPasskey: result.value.length > 0 }, 200)
-}
+export default createPasskeyActionHandler({
+  execute: (passkeyClient) => passkeyClient.list(),
+  respond: (c, passkeys) => c.json({ hasPasskey: passkeys.length > 0 }, 200),
+})

--- a/application/apps/web/src/server/passkey/passkey-action.test.ts
+++ b/application/apps/web/src/server/passkey/passkey-action.test.ts
@@ -1,0 +1,143 @@
+import {
+  NoSessionError,
+  PasskeyClient,
+  PasskeyRegistrationError,
+  PasskeyVerificationError,
+  UnexpectedAuthError,
+} from '@trend-diary/authentication'
+import { HTTPException } from 'hono/http-exception'
+import { err, ok } from 'neverthrow'
+import CONTEXT_KEY from '@/middleware/context'
+import {
+  createPasskeyActionHandler,
+  type PasskeyActionContext,
+  respondChallengeOptions,
+} from './passkey-action'
+
+interface FakeLogger {
+  info: ReturnType<typeof vi.fn>
+  warn: ReturnType<typeof vi.fn>
+  error: ReturnType<typeof vi.fn>
+}
+
+interface BuildContextOptions {
+  hasAppLog?: boolean
+}
+
+function buildContext({ hasAppLog = true }: BuildContextOptions = {}): {
+  c: PasskeyActionContext
+  logger: FakeLogger
+} {
+  const logger: FakeLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+  // oxlint-disable-next-line typescript/consistent-type-assertions -- 最小限のモックを Hono の複雑な Context 型へ橋渡しする境界キャストで、構造的に代入できず二重アサーションが避けられないため
+  const c = {
+    get: (key: string) => (hasAppLog && key === CONTEXT_KEY.APP_LOG ? logger : undefined),
+    // PasskeyClient の生成（authClientConfig）が参照する最小限の環境値
+    env: { SUPABASE_URL: 'http://supabase.local', SUPABASE_ANON_KEY: 'anon-key' },
+    req: { header: () => undefined },
+    header: vi.fn(),
+    // oxlint-disable-next-line typescript/no-restricted-types -- Hono の c.json を模すモックで、任意の JSON 値を受けるため
+    json: (data: unknown, status: number) =>
+      new Response(JSON.stringify(data), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    // oxlint-disable-next-line typescript/no-restricted-types -- 最小限のモックを Hono の複雑な Context 型へ橋渡しする境界キャストのため
+  } as unknown as PasskeyActionContext
+  return { c, logger }
+}
+
+describe('createPasskeyActionHandler', () => {
+  describe('正常系', () => {
+    it('execute の成功値を respond に渡し、respond の戻り値を返すこと', async () => {
+      const respond = vi.fn((_c: PasskeyActionContext, output: string) => `responded:${output}`)
+      const handler = createPasskeyActionHandler({
+        execute: () => Promise.resolve(ok('output-value')),
+        respond,
+      })
+
+      const { c } = buildContext()
+      const res = await handler(c)
+
+      expect(res).toBe('responded:output-value')
+      expect(respond).toHaveBeenCalledWith(c, 'output-value')
+    })
+
+    it('生成した PasskeyClient を execute に渡すこと', async () => {
+      const execute = vi.fn((_passkeyClient: PasskeyClient) => Promise.resolve(ok(null)))
+      const handler = createPasskeyActionHandler({ execute, respond: () => null })
+
+      const { c } = buildContext()
+      await handler(c)
+
+      expect(execute.mock.calls[0]?.[0]).toBeInstanceOf(PasskeyClient)
+    })
+  })
+
+  describe('準正常系', () => {
+    it.each([
+      {
+        name: 'PasskeyRegistrationError',
+        error: new PasskeyRegistrationError('registration failed'),
+        status: 400,
+      },
+      {
+        name: 'PasskeyVerificationError',
+        error: new PasskeyVerificationError('verification failed'),
+        status: 401,
+      },
+      { name: 'NoSessionError', error: new NoSessionError('no session'), status: 401 },
+      { name: 'UnexpectedAuthError', error: new UnexpectedAuthError('unexpected'), status: 500 },
+    ])(
+      'execute が $name を返すと toAuthError で変換した HTTPException を投げ respond を呼ばないこと',
+      async ({ error, status }) => {
+        const respond = vi.fn()
+        const handler = createPasskeyActionHandler({
+          execute: () => Promise.resolve(err(error)),
+          respond,
+        })
+
+        const { c } = buildContext()
+        // oxlint-disable-next-line typescript/no-restricted-types -- catch は任意の値を受けるため unknown 以外に書けないため
+        const thrown = await handler(c).catch((e: unknown) => e)
+
+        expect(thrown).toBeInstanceOf(HTTPException)
+        expect(thrown).toMatchObject({ status })
+        expect(respond).not.toHaveBeenCalled()
+      },
+    )
+  })
+
+  describe('異常系', () => {
+    // ロガーはミドルウェアが必ず設定する契約のため、未設定は握りつぶさず契約違反として送出する
+    it('APP_LOG が未設定なら契約違反エラーを投げること', async () => {
+      const handler = createPasskeyActionHandler({
+        execute: () => Promise.resolve(ok(null)),
+        respond: () => null,
+      })
+
+      const { c } = buildContext({ hasAppLog: false })
+
+      await expect(handler(c)).rejects.toThrow(CONTEXT_KEY.APP_LOG)
+    })
+  })
+})
+
+describe('respondChallengeOptions', () => {
+  describe('正常系', () => {
+    it('challenge_id と options を challengeId・options として 200 で返すこと', async () => {
+      const { c } = buildContext()
+
+      const res = respondChallengeOptions(c, {
+        challenge_id: 'challenge-1',
+        options: { rpId: 'example.com' },
+      })
+
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({
+        challengeId: 'challenge-1',
+        options: { rpId: 'example.com' },
+      })
+    })
+  })
+})

--- a/application/apps/web/src/server/passkey/passkey-action.ts
+++ b/application/apps/web/src/server/passkey/passkey-action.ts
@@ -8,8 +8,6 @@ import { handleError } from '@/server/error/handle-error'
 
 export type PasskeyActionContext = Context<Env>
 
-// ハンドラ契約由来の共通部分（ロガー取得→PasskeyClient生成→実行→AuthError変換）だけを集約する。
-// レスポンス整形はハンドラごとに異なるため respond として各ハンドラに残し、過剰抽象を避ける
 export function createPasskeyActionHandler<TOutput, TResponse>(config: {
   execute: (passkeyClient: PasskeyClient) => Promise<Result<TOutput, AuthError>>
   respond: (c: PasskeyActionContext, output: TOutput) => TResponse
@@ -25,8 +23,6 @@ export function createPasskeyActionHandler<TOutput, TResponse>(config: {
   }
 }
 
-// 登録・認証の options エンドポイントは WebAuthn ceremony 開始という同じ公開契約
-// （challengeId と options を返す）を持つため、レスポンス整形を共通化する
 export function respondChallengeOptions<TOptions>(
   c: PasskeyActionContext,
   started: { challenge_id: string; options: TOptions },

--- a/application/apps/web/src/server/passkey/passkey-action.ts
+++ b/application/apps/web/src/server/passkey/passkey-action.ts
@@ -1,0 +1,35 @@
+import { type AuthError, authClientConfig, PasskeyClient } from '@trend-diary/authentication'
+import type { Context } from 'hono'
+import type { Result } from 'neverthrow'
+import type { Env } from '@/env'
+import CONTEXT_KEY, { mustGet } from '@/middleware/context'
+import toAuthError from '@/server/error/auth-error'
+import { handleError } from '@/server/error/handle-error'
+
+export type PasskeyActionContext = Context<Env>
+
+// ハンドラ契約由来の共通部分（ロガー取得→PasskeyClient生成→実行→AuthError変換）だけを集約する。
+// レスポンス整形はハンドラごとに異なるため respond として各ハンドラに残し、過剰抽象を避ける
+export function createPasskeyActionHandler<TOutput, TResponse>(config: {
+  execute: (passkeyClient: PasskeyClient) => Promise<Result<TOutput, AuthError>>
+  respond: (c: PasskeyActionContext, output: TOutput) => TResponse
+}) {
+  return async (c: PasskeyActionContext) => {
+    const logger = mustGet(c, CONTEXT_KEY.APP_LOG)
+
+    const passkeyClient = new PasskeyClient(authClientConfig(c))
+    const result = await config.execute(passkeyClient)
+    if (result.isErr()) handleError(toAuthError(result.error), logger)
+
+    return config.respond(c, result.value)
+  }
+}
+
+// 登録・認証の options エンドポイントは WebAuthn ceremony 開始という同じ公開契約
+// （challengeId と options を返す）を持つため、レスポンス整形を共通化する
+export function respondChallengeOptions<TOptions>(
+  c: PasskeyActionContext,
+  started: { challenge_id: string; options: TOptions },
+) {
+  return c.json({ challengeId: started.challenge_id, options: started.options }, 200)
+}


### PR DESCRIPTION
# 概要
## 課題
passkey ハンドラー群に「ロガー取得 → PasskeyClient 生成 → 1 処理 → AuthError 変換 → レスポンス」というハンドラ契約由来の構造一致が similarity-ts に検出され、`disable.ts` への `similarity-ignore` で暫定抑制していました（#1015）。

## 修正内容
- fix: なし（#1015 のうち passkey モジュール側のみの対応で、auth モジュール側の共通化（login / signup）が残るため close しません）
- article の先例（`createArticleActionHandler`）に倣い、契約の共通部分だけを集約する `createPasskeyActionHandler` を passkey モジュール内に導入しました
  - 適用対象は authentication-options / registration-options / status / disable の 4 ハンドラーで、`disable.ts` の `similarity-ignore` を外しました
  - レスポンス整形はハンドラーごとに異なるため `respond` として各ハンドラーに残し、同一の公開契約（challengeId + options）を持つ options 系のみ `respondChallengeOptions` へ共通化しました
- verify 系 2 ハンドラーは対象外としました
  - 検証入力やドメインユースケースを併用しエラー変換の経路（`toAuthError` を通さないエラー）が異なるため、束ねると過剰抽象になると判断しました
- 各ハンドラーの挙動（ステータス・レスポンス・エラー変換）の不変は既存の `route.test.ts`（実結合）で担保し、ファクトリー自体の契約は新設の `passkey-action.test.ts` で担保しています

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015xdG8MkZKPKVyFKEwYDHn2

---
_Generated by [Claude Code](https://claude.ai/code/session_015xdG8MkZKPKVyFKEwYDHn2)_