### PR TITLE
fix(web): 認証後の active_user 解決失敗を 404 から 500 へ倒し auth/passkey から account エラー写像を分離する

### DIFF
--- a/application/apps/web/src/server/passkey/error.test.ts
+++ b/application/apps/web/src/server/passkey/error.test.ts
@@ -22,11 +22,6 @@ describe('パスキー系ハンドラのエラーの HTTP 写像', () => {
         error: new PasskeyVerificationError('verify'),
         status: 401,
       },
-      {
-        name: 'ActiveUserNotFoundError',
-        error: new ActiveUserNotFoundError('user not found'),
-        status: 404,
-      },
     ])('$name を HTTPException($status) へ写像しメッセージを引き継ぐこと', ({ error, status }) => {
       const thrown = captureThrow(() => throwHttpError(error))
 
@@ -36,13 +31,24 @@ describe('パスキー系ハンドラのエラーの HTTP 写像', () => {
   })
 
   describe('異常系', () => {
-    it('写像先を持たないエラーは HTTPException(500) へ写像しメッセージを引き継ぐこと', () => {
-      const error = new UnexpectedAuthError('boom')
+    it.each([
+      {
+        // 認証後の active_user 解決失敗はサーバ側の不整合なので 404 ではなく 500 に倒す
+        name: 'ActiveUserNotFoundError',
+        error: new ActiveUserNotFoundError('user not found'),
+      },
+      {
+        name: 'UnexpectedAuthError',
+        error: new UnexpectedAuthError('boom'),
+      },
+    ])(
+      '$name は写像先を持たず HTTPException(500) へ写像しメッセージを引き継ぐこと',
+      ({ error }) => {
+        const thrown = captureThrow(() => throwHttpError(error))
 
-      const thrown = captureThrow(() => throwHttpError(error))
-
-      expect(thrown).toBeInstanceOf(HTTPException)
-      expect(thrown).toMatchObject({ status: 500, message: error.message })
-    })
+        expect(thrown).toBeInstanceOf(HTTPException)
+        expect(thrown).toMatchObject({ status: 500, message: error.message })
+      },
+    )
   })
 })

--- a/application/apps/web/src/server/passkey/error.test.ts
+++ b/application/apps/web/src/server/passkey/error.test.ts
@@ -3,7 +3,6 @@ import {
   PasskeyVerificationError,
   UnexpectedAuthError,
 } from '@trend-diary/authentication'
-import { ActiveUserNotFoundError } from '@trend-diary/domain/account'
 import { HTTPException } from 'hono/http-exception'
 import { describe, expect, it } from 'vitest'
 import { captureThrow } from '@/test/helper/capture-throw'
@@ -31,24 +30,14 @@ describe('パスキー系ハンドラのエラーの HTTP 写像', () => {
   })
 
   describe('異常系', () => {
-    it.each([
-      {
-        // 認証後の active_user 解決失敗はサーバ側の不整合なので 404 ではなく 500 に倒す
-        name: 'ActiveUserNotFoundError',
-        error: new ActiveUserNotFoundError('user not found'),
-      },
-      {
-        name: 'UnexpectedAuthError',
-        error: new UnexpectedAuthError('boom'),
-      },
-    ])(
-      '$name は写像先を持たず HTTPException(500) へ写像しメッセージを引き継ぐこと',
-      ({ error }) => {
-        const thrown = captureThrow(() => throwHttpError(error))
+    // 認証後の active_user 解決失敗（未写像の account エラー）を含め、写像先を持たないエラーは 500 に倒す
+    it('写像先を持たないエラーは HTTPException(500) へ写像しメッセージを引き継ぐこと', () => {
+      const error = new UnexpectedAuthError('boom')
 
-        expect(thrown).toBeInstanceOf(HTTPException)
-        expect(thrown).toMatchObject({ status: 500, message: error.message })
-      },
-    )
+      const thrown = captureThrow(() => throwHttpError(error))
+
+      expect(thrown).toBeInstanceOf(HTTPException)
+      expect(thrown).toMatchObject({ status: 500, message: error.message })
+    })
   })
 })

--- a/application/apps/web/src/server/passkey/error.ts
+++ b/application/apps/web/src/server/passkey/error.ts
@@ -1,11 +1,11 @@
 import { PasskeyRegistrationError, PasskeyVerificationError } from '@trend-diary/authentication'
-import { ActiveUserNotFoundError } from '@trend-diary/domain/account'
 import throwHttpErrorByTable, { type ErrorStatusTable } from '@/server/error/throw-http-error'
 
+// 認証後の active_user 解決失敗（ActiveUserNotFoundError 等）はサーバ側の不整合なので、
+// ここでは写像せず default の 500 へ倒す。account のエラー写像は passkey ハンドラから分離する
 const ERROR_STATUS_TABLE: ErrorStatusTable = [
   [PasskeyRegistrationError, 400],
   [PasskeyVerificationError, 401],
-  [ActiveUserNotFoundError, 404],
 ]
 
 export default function throwHttpError(error: Error): never {

--- a/application/apps/web/src/server/passkey/handler/authentication-verify.ts
+++ b/application/apps/web/src/server/passkey/handler/authentication-verify.ts
@@ -35,6 +35,7 @@ export default async function passkeyAuthenticationVerify(
 
   const rdb = getRdbClient(c.env.DB)
   const accountUseCase = createAccountUseCase(rdb)
+  // 認証成功後に active_user が無いのは孤児 auth ユーザー等のサーバ不整合なので、404 ではなく 500 に倒す
   const activeUserResult = await accountUseCase.resolveActiveUser(userResult.value.id)
   if (activeUserResult.isErr()) throwHttpError(activeUserResult.error)
 

--- a/application/apps/web/src/server/sessions/error.test.ts
+++ b/application/apps/web/src/server/sessions/error.test.ts
@@ -1,5 +1,4 @@
 import { InvalidCredentialsError, UnexpectedAuthError } from '@trend-diary/authentication'
-import { ActiveUserNotFoundError } from '@trend-diary/domain/account'
 import { HTTPException } from 'hono/http-exception'
 import { describe, expect, it } from 'vitest'
 import { captureThrow } from '@/test/helper/capture-throw'
@@ -18,24 +17,14 @@ describe('ログイン系ハンドラのエラーの HTTP 写像', () => {
   })
 
   describe('異常系', () => {
-    it.each([
-      {
-        // 認証後の active_user 解決失敗はサーバ側の不整合なので 404 ではなく 500 に倒す
-        name: 'ActiveUserNotFoundError',
-        error: new ActiveUserNotFoundError('user not found'),
-      },
-      {
-        name: 'UnexpectedAuthError',
-        error: new UnexpectedAuthError('boom'),
-      },
-    ])(
-      '$name は写像先を持たず HTTPException(500) へ写像しメッセージを引き継ぐこと',
-      ({ error }) => {
-        const thrown = captureThrow(() => throwHttpError(error))
+    // 認証後の active_user 解決失敗（未写像の account エラー）を含め、写像先を持たないエラーは 500 に倒す
+    it('写像先を持たないエラーは HTTPException(500) へ写像しメッセージを引き継ぐこと', () => {
+      const error = new UnexpectedAuthError('boom')
 
-        expect(thrown).toBeInstanceOf(HTTPException)
-        expect(thrown).toMatchObject({ status: 500, message: error.message })
-      },
-    )
+      const thrown = captureThrow(() => throwHttpError(error))
+
+      expect(thrown).toBeInstanceOf(HTTPException)
+      expect(thrown).toMatchObject({ status: 500, message: error.message })
+    })
   })
 })

--- a/application/apps/web/src/server/sessions/error.test.ts
+++ b/application/apps/web/src/server/sessions/error.test.ts
@@ -7,33 +7,35 @@ import throwHttpError from './error'
 
 describe('ログイン系ハンドラのエラーの HTTP 写像', () => {
   describe('準正常系', () => {
-    it.each([
-      {
-        name: 'InvalidCredentialsError',
-        error: new InvalidCredentialsError('invalid'),
-        status: 401,
-      },
-      {
-        name: 'ActiveUserNotFoundError',
-        error: new ActiveUserNotFoundError('user not found'),
-        status: 404,
-      },
-    ])('$name を HTTPException($status) へ写像しメッセージを引き継ぐこと', ({ error, status }) => {
+    it('InvalidCredentialsError を HTTPException(401) へ写像しメッセージを引き継ぐこと', () => {
+      const error = new InvalidCredentialsError('invalid')
+
       const thrown = captureThrow(() => throwHttpError(error))
 
       expect(thrown).toBeInstanceOf(HTTPException)
-      expect(thrown).toMatchObject({ status, message: error.message })
+      expect(thrown).toMatchObject({ status: 401, message: error.message })
     })
   })
 
   describe('異常系', () => {
-    it('写像先を持たないエラーは HTTPException(500) へ写像しメッセージを引き継ぐこと', () => {
-      const error = new UnexpectedAuthError('boom')
+    it.each([
+      {
+        // 認証後の active_user 解決失敗はサーバ側の不整合なので 404 ではなく 500 に倒す
+        name: 'ActiveUserNotFoundError',
+        error: new ActiveUserNotFoundError('user not found'),
+      },
+      {
+        name: 'UnexpectedAuthError',
+        error: new UnexpectedAuthError('boom'),
+      },
+    ])(
+      '$name は写像先を持たず HTTPException(500) へ写像しメッセージを引き継ぐこと',
+      ({ error }) => {
+        const thrown = captureThrow(() => throwHttpError(error))
 
-      const thrown = captureThrow(() => throwHttpError(error))
-
-      expect(thrown).toBeInstanceOf(HTTPException)
-      expect(thrown).toMatchObject({ status: 500, message: error.message })
-    })
+        expect(thrown).toBeInstanceOf(HTTPException)
+        expect(thrown).toMatchObject({ status: 500, message: error.message })
+      },
+    )
   })
 })

--- a/application/apps/web/src/server/sessions/error.ts
+++ b/application/apps/web/src/server/sessions/error.ts
@@ -1,11 +1,9 @@
 import { InvalidCredentialsError } from '@trend-diary/authentication'
-import { ActiveUserNotFoundError } from '@trend-diary/domain/account'
 import throwHttpErrorByTable, { type ErrorStatusTable } from '@/server/error/throw-http-error'
 
-const ERROR_STATUS_TABLE: ErrorStatusTable = [
-  [InvalidCredentialsError, 401],
-  [ActiveUserNotFoundError, 404],
-]
+// 認証後の active_user 解決失敗（ActiveUserNotFoundError 等）はサーバ側の不整合なので、
+// ここでは写像せず default の 500 へ倒す。account のエラー写像は auth ハンドラから分離する
+const ERROR_STATUS_TABLE: ErrorStatusTable = [[InvalidCredentialsError, 401]]
 
 export default function throwHttpError(error: Error): never {
   return throwHttpErrorByTable(error, ERROR_STATUS_TABLE)

--- a/application/apps/web/src/server/sessions/handler/create.ts
+++ b/application/apps/web/src/server/sessions/handler/create.ts
@@ -25,6 +25,7 @@ export default async function createSession(c: ZodValidatedContext<[typeof authI
 
   const rdb = getRdbClient(c.env.DB)
   const accountUseCase = createAccountUseCase(rdb)
+  // 認証成功後に active_user が無いのは孤児 auth ユーザー等のサーバ不整合なので、404 ではなく 500 に倒す
   const result = await accountUseCase.resolveActiveUser(user.id)
   if (result.isErr()) throwHttpError(result.error)
 


### PR DESCRIPTION
# 概要
## 課題
認証系ハンドラ（`sessions/create` / `passkey/authentication-verify`）が、認証結果のエラー写像に加えて account 解決（`resolveActiveUser`）のエラー写像まで担っており、各リソースの `error.ts` が `ActiveUserNotFoundError → 404` を抱えていた（#1029）。

- 認証成功後に active_user が無いのは孤児 auth ユーザー等のサーバ側の不整合であり、これを 404 に写像するのは `.claude/rules/contract.md` の「契約違反（サーバ側の配線ミス）をクライアントエラー（404 等）に偽装しない」に反する
- account のエラー写像が auth/passkey ハンドラに混ざり、責務の境界が曖昧になっていた

## 修正内容
- fix: #1029
- `resolveActiveUser` の失敗を 404 ではなく errorHandler の 500（＋通知）へ倒すようにした
  - `sessions/error.ts` / `passkey/error.ts` の写像表から `ActiveUserNotFoundError → 404` を外し、未写像として default の 500 に落とした
  - あわせて両 `error.ts` から account のエラー写像 import（`ActiveUserNotFoundError`）を除去し、auth/passkey ハンドラを account のエラー写像から分離した
- `oauth/callback` は新規登録フローのため対象外とした
  - 未連携（`ActiveUserNotFoundError`）は初回ログイン→新規登録として扱う分岐で `ActiveUserNotFoundError` を参照するのみで、account のエラー写像 thrower は import していない
  - 認証後の account 解決失敗・`registerActiveUser` 失敗はいずれも既にサーバ不整合として 500 に写像済みで、本 PR の方針と整合している
- `registrations/create` は `registerActiveUser` 失敗を元々 default の 500 に落としており、account のエラー写像 import も無いため変更なし

## 影響
- 認証成功後に active_user を解決できないケースの応答が 404 → 500 に変わる（監視・通知の対象になる）


---
_Generated by [Claude Code](https://claude.ai/code/session_012U5Car6Pm97d5GoAS81ndb)_