### PR TITLE
refactor: authentication / article の Result エラー型を実際に返す型へ絞る

### DIFF
--- a/application/apps/web/src/server/oauth/oauth-start.test.ts
+++ b/application/apps/web/src/server/oauth/oauth-start.test.ts
@@ -55,7 +55,6 @@ function findSetCookie(setCookies: string[], prefix: string): string {
   return setCookies.find((cookie) => cookie.startsWith(prefix)) ?? ''
 }
 
-// start が返しうるエラーは OAuthClient の実エラー(UnexpectedAuthError)に限られるため、Error でぼかさない
 function baseConfig(result: Result<{ url: string }, UnexpectedAuthError>) {
   return {
     start: () => Promise.resolve(result),

--- a/application/apps/web/src/server/oauth/oauth-start.test.ts
+++ b/application/apps/web/src/server/oauth/oauth-start.test.ts
@@ -1,5 +1,5 @@
 import type * as AuthModule from '@trend-diary/authentication'
-import { type AuthError, NoSessionError, UnexpectedAuthError } from '@trend-diary/authentication'
+import { NoSessionError, UnexpectedAuthError } from '@trend-diary/authentication'
 import { HTTPException } from 'hono/http-exception'
 import { err, ok, type Result } from 'neverthrow'
 import CONTEXT_KEY from '@/middleware/context'
@@ -55,7 +55,7 @@ function findSetCookie(setCookies: string[], prefix: string): string {
   return setCookies.find((cookie) => cookie.startsWith(prefix)) ?? ''
 }
 
-function baseConfig(result: Result<{ url: string }, AuthError>) {
+function baseConfig(result: Result<{ url: string }, Error>) {
   return {
     start: () => Promise.resolve(result),
     flow: OAUTH_FLOW.login,

--- a/application/apps/web/src/server/oauth/oauth-start.test.ts
+++ b/application/apps/web/src/server/oauth/oauth-start.test.ts
@@ -1,5 +1,5 @@
 import type * as AuthModule from '@trend-diary/authentication'
-import { NoSessionError, UnexpectedAuthError } from '@trend-diary/authentication'
+import { UnexpectedAuthError } from '@trend-diary/authentication'
 import { HTTPException } from 'hono/http-exception'
 import { err, ok, type Result } from 'neverthrow'
 import CONTEXT_KEY from '@/middleware/context'
@@ -55,7 +55,8 @@ function findSetCookie(setCookies: string[], prefix: string): string {
   return setCookies.find((cookie) => cookie.startsWith(prefix)) ?? ''
 }
 
-function baseConfig(result: Result<{ url: string }, Error>) {
+// start が返しうるエラーは OAuthClient の実エラー(UnexpectedAuthError)に限られるため、Error でぼかさない
+function baseConfig(result: Result<{ url: string }, UnexpectedAuthError>) {
   return {
     start: () => Promise.resolve(result),
     flow: OAUTH_FLOW.login,
@@ -120,10 +121,10 @@ describe('createOAuthStartHandler', () => {
   })
 
   describe('準正常系', () => {
-    it.each([
-      { name: 'NoSessionError', error: new NoSessionError('no session'), status: 401 },
-      { name: 'UnexpectedAuthError', error: new UnexpectedAuthError('unexpected'), status: 500 },
-    ])('startが$nameを返すとHTTPException($status)を投げること', async ({ error, status }) => {
+    // エラー種別ごとの写像(NoSessionError→401 等)は error.test.ts が担保する。
+    // ここは start のエラーを throwHttpError へ委譲し HTTPException として送出することだけを検証する
+    it('startがエラーを返すとthrowHttpError経由でHTTPExceptionを投げること', async () => {
+      const error = new UnexpectedAuthError('unexpected')
       const handler = createOAuthStartHandler(baseConfig(err(error)))
 
       const { c } = buildContext()
@@ -131,7 +132,7 @@ describe('createOAuthStartHandler', () => {
       const thrown = await handler(c).catch((e: unknown) => e)
 
       expect(thrown).toBeInstanceOf(HTTPException)
-      expect(thrown).toMatchObject({ status, message: error.message })
+      expect(thrown).toMatchObject({ status: 500, message: error.message })
     })
   })
 })

--- a/application/apps/web/src/server/oauth/oauth-start.ts
+++ b/application/apps/web/src/server/oauth/oauth-start.ts
@@ -1,9 +1,4 @@
-import {
-  type AuthError,
-  authClientConfig,
-  OAuthClient,
-  type OAuthProvider,
-} from '@trend-diary/authentication'
+import { authClientConfig, OAuthClient, type OAuthProvider } from '@trend-diary/authentication'
 import { setCookie } from 'hono/cookie'
 import type { Result } from 'neverthrow'
 import type { ZodValidatedContext } from '@/middleware/zod-validator'
@@ -20,14 +15,16 @@ type OAuthFlow = (typeof OAUTH_FLOW)[keyof typeof OAUTH_FLOW]
 
 export type OAuthStartContext = ZodValidatedContext<[typeof oauthProviderParamValidator]>
 
+// エラー型は start が実際に返す具象型を TError で受け、HTTP 写像(throwHttpError)へそのまま渡す
 export function createOAuthStartHandler<
   TContext extends OAuthStartContext = OAuthStartContext,
+  TError extends Error = Error,
 >(config: {
   start: (
     oauthClient: OAuthClient,
     provider: OAuthProvider,
     callbackUrl: string,
-  ) => Promise<Result<{ url: string }, AuthError>>
+  ) => Promise<Result<{ url: string }, TError>>
   flow: OAuthFlow
   // 戻り先Cookieは保存/クリアの判断がフローごとに異なるため、ファクトリーに分岐を持ち込まず設定側で制御する
   setRedirectCookie: (c: TContext) => void

--- a/application/apps/web/src/server/oauth/oauth-start.ts
+++ b/application/apps/web/src/server/oauth/oauth-start.ts
@@ -1,6 +1,6 @@
 import { authClientConfig, OAuthClient, type OAuthProvider } from '@trend-diary/authentication'
 import { setCookie } from 'hono/cookie'
-import type { Result } from 'neverthrow'
+import type { Err, Result } from 'neverthrow'
 import type { ZodValidatedContext } from '@/middleware/zod-validator'
 import throwHttpError from '@/server/oauth/error'
 import {
@@ -15,9 +15,13 @@ type OAuthFlow = (typeof OAUTH_FLOW)[keyof typeof OAUTH_FLOW]
 
 export type OAuthStartContext = ZodValidatedContext<[typeof oauthProviderParamValidator]>
 
+type ResultErr<TResult> = TResult extends Err<infer _TValue, infer TError> ? TError : never
+// 境界の TError を手書きの基底型で緩めず、OAuthClient が実際に返すエラー集合を上限にする
+type OAuthClientError = ResultErr<Awaited<ReturnType<OAuthClient[keyof OAuthClient]>>>
+
 export function createOAuthStartHandler<
   TContext extends OAuthStartContext = OAuthStartContext,
-  TError extends Error = Error,
+  TError extends OAuthClientError = OAuthClientError,
 >(config: {
   start: (
     oauthClient: OAuthClient,

--- a/application/apps/web/src/server/oauth/oauth-start.ts
+++ b/application/apps/web/src/server/oauth/oauth-start.ts
@@ -15,7 +15,6 @@ type OAuthFlow = (typeof OAUTH_FLOW)[keyof typeof OAUTH_FLOW]
 
 export type OAuthStartContext = ZodValidatedContext<[typeof oauthProviderParamValidator]>
 
-// エラー型は start が実際に返す具象型を TError で受け、HTTP 写像(throwHttpError)へそのまま渡す
 export function createOAuthStartHandler<
   TContext extends OAuthStartContext = OAuthStartContext,
   TError extends Error = Error,

--- a/application/apps/web/src/server/passkey/passkey-action.ts
+++ b/application/apps/web/src/server/passkey/passkey-action.ts
@@ -6,7 +6,6 @@ import throwHttpError from '@/server/passkey/error'
 
 export type PasskeyActionContext = Context<Env>
 
-// エラー型は execute が実際に返す具象型を TError で受け、HTTP 写像(throwHttpError)へそのまま渡す
 export function createPasskeyActionHandler<TOutput, TResponse, TError extends Error>(config: {
   execute: (passkeyClient: PasskeyClient) => Promise<Result<TOutput, TError>>
   respond: (c: PasskeyActionContext, output: TOutput) => TResponse

--- a/application/apps/web/src/server/passkey/passkey-action.ts
+++ b/application/apps/web/src/server/passkey/passkey-action.ts
@@ -1,4 +1,4 @@
-import { type AuthError, authClientConfig, PasskeyClient } from '@trend-diary/authentication'
+import { authClientConfig, PasskeyClient } from '@trend-diary/authentication'
 import type { Context } from 'hono'
 import type { Result } from 'neverthrow'
 import type { Env } from '@/env'
@@ -6,8 +6,9 @@ import throwHttpError from '@/server/passkey/error'
 
 export type PasskeyActionContext = Context<Env>
 
-export function createPasskeyActionHandler<TOutput, TResponse>(config: {
-  execute: (passkeyClient: PasskeyClient) => Promise<Result<TOutput, AuthError>>
+// エラー型は execute が実際に返す具象型を TError で受け、HTTP 写像(throwHttpError)へそのまま渡す
+export function createPasskeyActionHandler<TOutput, TResponse, TError extends Error>(config: {
+  execute: (passkeyClient: PasskeyClient) => Promise<Result<TOutput, TError>>
   respond: (c: PasskeyActionContext, output: TOutput) => TResponse
 }) {
   return async (c: PasskeyActionContext) => {

--- a/application/apps/web/src/server/passkey/passkey-action.ts
+++ b/application/apps/web/src/server/passkey/passkey-action.ts
@@ -1,12 +1,20 @@
 import { authClientConfig, PasskeyClient } from '@trend-diary/authentication'
 import type { Context } from 'hono'
-import type { Result } from 'neverthrow'
+import type { Err, Result } from 'neverthrow'
 import type { Env } from '@/env'
 import throwHttpError from '@/server/passkey/error'
 
 export type PasskeyActionContext = Context<Env>
 
-export function createPasskeyActionHandler<TOutput, TResponse, TError extends Error>(config: {
+type ResultErr<TResult> = TResult extends Err<infer _TValue, infer TError> ? TError : never
+// 境界の TError を手書きの基底型で緩めず、PasskeyClient が実際に返すエラー集合を上限にする
+type PasskeyClientError = ResultErr<Awaited<ReturnType<PasskeyClient[keyof PasskeyClient]>>>
+
+export function createPasskeyActionHandler<
+  TOutput,
+  TResponse,
+  TError extends PasskeyClientError,
+>(config: {
   execute: (passkeyClient: PasskeyClient) => Promise<Result<TOutput, TError>>
   respond: (c: PasskeyActionContext, output: TOutput) => TResponse
 }) {

--- a/application/packages/authentication/src/errors.ts
+++ b/application/packages/authentication/src/errors.ts
@@ -1,5 +1,6 @@
 // 認証パッケージが返すカスタムエラー。HTTP ステータス等の責務は持たず、失敗の種別を型で表す。
 // HTTP への写像は HTTP 境界(web の errorHandler)の責務とする。
+// 各メソッドの Result は実際に返す具象型で表すため、基底型はパッケージ内の共通土台に留め index.ts からは公開しない。
 export abstract class AuthError extends Error {}
 
 export class InvalidCredentialsError extends AuthError {

--- a/application/packages/authentication/src/index.ts
+++ b/application/packages/authentication/src/index.ts
@@ -1,6 +1,5 @@
 export { AuthAdminClient, type AuthAdminConfig, type AuthUserSummary } from './admin/client'
 export {
-  AuthError,
   InvalidCredentialsError,
   NoSessionError,
   PasskeyRegistrationError,

--- a/application/packages/authentication/src/infrastructure/supabase-result.ts
+++ b/application/packages/authentication/src/infrastructure/supabase-result.ts
@@ -4,17 +4,32 @@ import { type AuthError, UnexpectedAuthError } from '../errors'
 
 type SupabaseData<TResponse> = TResponse extends { error: null; data: infer TData } ? TData : never
 
+interface SupabaseCallResponse {
+  // oxlint-disable-next-line typescript/no-restricted-types -- SDKごとにdata形状が異なる制約用で、具体型は呼び出し時のTResponseが確定するため
+  data: unknown
+  error: Error | null
+}
+
 // Supabase SDK は失敗を例外(通信断など基盤の失敗)と戻り値 { error }(業務エラー)の2経路で返す。
 // 例外は原因を特定できないため一律 UnexpectedAuthError とし、区別できる業務エラーのみ mapError に委ねる。
-// 戻り型は例外由来の UnexpectedAuthError と mapError の戻り型 TError の和で表し、呼び出し側で実際のエラー集合へ絞れるようにする。
+// オーバーロードで mapError の有無と戻りエラー型を対応づけ、省略時は UnexpectedAuthError に固定、
+// 指定時のみ例外由来の UnexpectedAuthError と mapError の戻り型 TError の和を返す。
+// これにより「TError を指定しつつ mapError を渡し忘れる」不整合をコンパイル時に防ぐ。
+export async function callSupabase<TResponse extends SupabaseCallResponse>(
+  call: () => Promise<TResponse>,
+): Promise<Result<SupabaseData<TResponse>, UnexpectedAuthError>>
 export async function callSupabase<
-  // oxlint-disable-next-line typescript/no-restricted-types -- SDKごとにdata形状が異なる制約用で、具体型は呼び出し時のTResponseが確定するため
-  TResponse extends { data: unknown; error: Error | null },
+  TResponse extends SupabaseCallResponse,
+  TError extends AuthError,
+>(
+  call: () => Promise<TResponse>,
+  mapError: (error: Error) => TError,
+): Promise<Result<SupabaseData<TResponse>, UnexpectedAuthError | TError>>
+export async function callSupabase<
+  TResponse extends SupabaseCallResponse,
   TError extends AuthError = UnexpectedAuthError,
 >(
   call: () => Promise<TResponse>,
-  // 既定は業務エラーを区別せず UnexpectedAuthError に畳む。ジェネリックな TError を戻す既定値は
-  // 型として表現できないため、既定関数ではなく未指定時の分岐で UnexpectedAuthError を返す
   mapError?: (error: Error) => TError,
 ): Promise<Result<SupabaseData<TResponse>, UnexpectedAuthError | TError>> {
   const called = await wrapAsyncCall(call)

--- a/application/packages/authentication/src/infrastructure/supabase-result.ts
+++ b/application/packages/authentication/src/infrastructure/supabase-result.ts
@@ -6,18 +6,26 @@ type SupabaseData<TResponse> = TResponse extends { error: null; data: infer TDat
 
 // Supabase SDK は失敗を例外(通信断など基盤の失敗)と戻り値 { error }(業務エラー)の2経路で返す。
 // 例外は原因を特定できないため一律 UnexpectedAuthError とし、区別できる業務エラーのみ mapError に委ねる。
+// 戻り型は例外由来の UnexpectedAuthError と mapError の戻り型 TError の和で表し、呼び出し側で実際のエラー集合へ絞れるようにする。
 export async function callSupabase<
   // oxlint-disable-next-line typescript/no-restricted-types -- SDKごとにdata形状が異なる制約用で、具体型は呼び出し時のTResponseが確定するため
   TResponse extends { data: unknown; error: Error | null },
+  TError extends AuthError = UnexpectedAuthError,
 >(
   call: () => Promise<TResponse>,
-  mapError: (error: Error) => AuthError = (error) => new UnexpectedAuthError(error.message),
-): Promise<Result<SupabaseData<TResponse>, AuthError>> {
+  // 既定は業務エラーを区別せず UnexpectedAuthError に畳む。ジェネリックな TError を戻す既定値は
+  // 型として表現できないため、既定関数ではなく未指定時の分岐で UnexpectedAuthError を返す
+  mapError?: (error: Error) => TError,
+): Promise<Result<SupabaseData<TResponse>, UnexpectedAuthError | TError>> {
   const called = await wrapAsyncCall(call)
   if (called.isErr()) return err(new UnexpectedAuthError(called.error.message))
 
   const response = called.value
-  if (response.error) return err(mapError(response.error))
+  if (response.error) {
+    return err(
+      mapError ? mapError(response.error) : new UnexpectedAuthError(response.error.message),
+    )
+  }
 
   // oxlint-disable-next-line typescript/consistent-type-assertions -- ジェネリックなユニオンは error=null 判定後も戻り値型へ絞り込めないため
   return ok(response.data as SupabaseData<TResponse>)

--- a/application/packages/authentication/src/oauth/client.ts
+++ b/application/packages/authentication/src/oauth/client.ts
@@ -1,6 +1,6 @@
 import type { OAuthResponse, User, UserIdentity } from '@supabase/supabase-js'
 import { err, ok, type Result } from 'neverthrow'
-import { type AuthError, UnexpectedAuthError } from '../errors'
+import { UnexpectedAuthError } from '../errors'
 import {
   type AuthClientConfig,
   createBackendClient,
@@ -21,7 +21,7 @@ export class OAuthClient {
   private async startFlow(
     request: () => Promise<OAuthResponse>,
     failureLabel: string,
-  ): Promise<Result<{ url: string }, AuthError>> {
+  ): Promise<Result<{ url: string }, UnexpectedAuthError>> {
     return (await callSupabase(request)).andThen(({ url }) =>
       url ? ok({ url }) : err(new UnexpectedAuthError(failureLabel)),
     )
@@ -30,7 +30,7 @@ export class OAuthClient {
   async startAuthorization(
     provider: OAuthProvider,
     redirectTo: string,
-  ): Promise<Result<{ url: string }, AuthError>> {
+  ): Promise<Result<{ url: string }, UnexpectedAuthError>> {
     return this.startFlow(
       () =>
         this.client.auth.signInWithOAuth({
@@ -44,7 +44,7 @@ export class OAuthClient {
   async startLink(
     provider: OAuthProvider,
     redirectTo: string,
-  ): Promise<Result<{ url: string }, AuthError>> {
+  ): Promise<Result<{ url: string }, UnexpectedAuthError>> {
     return this.startFlow(
       () =>
         this.client.auth.linkIdentity({
@@ -56,20 +56,20 @@ export class OAuthClient {
   }
 
   // 成功でも user/session が空なら失敗として err に畳み、呼び出し側でのResult外エラー処理を無くす
-  async exchangeCode(code: string): Promise<Result<User, AuthError>> {
+  async exchangeCode(code: string): Promise<Result<User, UnexpectedAuthError>> {
     return (await callSupabase(() => this.client.auth.exchangeCodeForSession(code))).andThen(
       ({ user, session }) =>
         user && session ? ok(user) : err(new UnexpectedAuthError('OAuth code exchange failed')),
     )
   }
 
-  async listIdentities(): Promise<Result<UserIdentity[], AuthError>> {
+  async listIdentities(): Promise<Result<UserIdentity[], UnexpectedAuthError>> {
     return (await callSupabase(() => this.client.auth.getUserIdentities())).map(
       ({ identities }) => identities,
     )
   }
 
-  async unlinkIdentity(identity: UserIdentity): Promise<Result<null, AuthError>> {
+  async unlinkIdentity(identity: UserIdentity): Promise<Result<null, UnexpectedAuthError>> {
     return callSupabase(async () => ({
       ...(await this.client.auth.unlinkIdentity(identity)),
       data: null,

--- a/application/packages/authentication/src/passkey/client.ts
+++ b/application/packages/authentication/src/passkey/client.ts
@@ -1,11 +1,6 @@
 import type { User } from '@supabase/supabase-js'
 import { err, ok, type Result } from 'neverthrow'
-import {
-  type AuthError,
-  PasskeyRegistrationError,
-  PasskeyVerificationError,
-  UnexpectedAuthError,
-} from '../errors'
+import { PasskeyRegistrationError, PasskeyVerificationError, UnexpectedAuthError } from '../errors'
 import {
   type AuthClientConfig,
   createBackendClient,
@@ -41,7 +36,9 @@ export class PasskeyClient {
   }
 
   // 成功でも user/session が空なら認証失敗として err に畳み、呼び出し側でのResult外エラー処理を無くす
-  async verifyAuthentication(params: VerifyAuthenticationParams): Promise<Result<User, AuthError>> {
+  async verifyAuthentication(
+    params: VerifyAuthenticationParams,
+  ): Promise<Result<User, PasskeyVerificationError | UnexpectedAuthError>> {
     return (
       await callSupabase(
         () => this.client.auth.passkey.verifyAuthentication(params),

--- a/application/packages/authentication/src/password/client.ts
+++ b/application/packages/authentication/src/password/client.ts
@@ -1,11 +1,6 @@
 import { AuthError, type User } from '@supabase/supabase-js'
 import { err, ok, type Result } from 'neverthrow'
-import {
-  type AuthError as AuthClientError,
-  InvalidCredentialsError,
-  UnexpectedAuthError,
-  UserAlreadyExistsError,
-} from '../errors'
+import { InvalidCredentialsError, UnexpectedAuthError, UserAlreadyExistsError } from '../errors'
 import {
   type AuthClientConfig,
   createBackendClient,
@@ -26,7 +21,9 @@ export class PasswordAuthClient {
   }
 
   // 成功でも user/session が空なら失敗として err に畳み、呼び出し側でのResult外エラー処理を無くす
-  async signIn(credentials: PasswordCredentials): Promise<Result<User, AuthClientError>> {
+  async signIn(
+    credentials: PasswordCredentials,
+  ): Promise<Result<User, InvalidCredentialsError | UnexpectedAuthError>> {
     return (
       await callSupabase(() => this.client.auth.signInWithPassword(credentials), toSignInError)
     ).andThen(({ user, session }) =>
@@ -35,19 +32,21 @@ export class PasswordAuthClient {
   }
 
   // 成功でも user が空なら登録失敗として err に畳み、呼び出し側でのResult外エラー処理を無くす
-  async signUp(credentials: PasswordCredentials): Promise<Result<User, AuthClientError>> {
+  async signUp(
+    credentials: PasswordCredentials,
+  ): Promise<Result<User, UserAlreadyExistsError | UnexpectedAuthError>> {
     return (await callSupabase(() => this.client.auth.signUp(credentials), toSignUpError)).andThen(
       ({ user }) => (user ? ok(user) : err(new UnexpectedAuthError('User registration failed'))),
     )
   }
 
   // 既にログアウト済みでもSupabaseはエラーを返さないため、error は通信・サーバ障害のみを表す
-  async signOut(): Promise<Result<null, AuthClientError>> {
+  async signOut(): Promise<Result<null, UnexpectedAuthError>> {
     return callSupabase(async () => ({ ...(await this.client.auth.signOut()), data: null }))
   }
 }
 
-function toSignInError(error: Error): AuthClientError {
+function toSignInError(error: Error): InvalidCredentialsError | UnexpectedAuthError {
   const isInvalidCredentials = error instanceof AuthError && error.code === 'invalid_credentials'
   return isInvalidCredentials
     ? new InvalidCredentialsError(error.message)
@@ -55,7 +54,7 @@ function toSignInError(error: Error): AuthClientError {
 }
 
 // NOTE: Supabaseは専用エラー型を提供しないためメッセージ文字列で既存ユーザーを判定している
-function toSignUpError(error: Error): AuthClientError {
+function toSignUpError(error: Error): UserAlreadyExistsError | UnexpectedAuthError {
   return error.message.includes('already registered')
     ? new UserAlreadyExistsError(error.message)
     : new UnexpectedAuthError(error.message)

--- a/application/packages/authentication/src/session/client.ts
+++ b/application/packages/authentication/src/session/client.ts
@@ -1,5 +1,5 @@
 import { err, ok, type Result } from 'neverthrow'
-import { type AuthError, NoSessionError } from '../errors'
+import { NoSessionError, type UnexpectedAuthError } from '../errors'
 import {
   type AuthClientConfig,
   createBackendClient,
@@ -15,7 +15,9 @@ export class SessionClient {
   }
 
   // セッション無し・失効はエラーではなく未認証として扱うため、業務エラーも空データも一律 NoSessionError に畳む
-  async getClaims(): Promise<Result<{ authenticationId: string }, AuthError>> {
+  async getClaims(): Promise<
+    Result<{ authenticationId: string }, NoSessionError | UnexpectedAuthError>
+  > {
     return (
       await callSupabase(
         () => this.client.auth.getClaims(),

--- a/application/packages/domain/src/article/error.ts
+++ b/application/packages/domain/src/article/error.ts
@@ -1,6 +1,7 @@
 // 記事集約のドメインエラー。HTTP ステータス等の責務は持たず、失敗の種別を型で表す。
 // HTTP への写像は HTTP 境界(ハンドラ)の責務とする。
-export abstract class ArticleError extends Error {}
+// 各メソッドの Result は実際に返す具象型で表すため、基底型は集約内の共通土台に留め公開しない。
+abstract class ArticleError extends Error {}
 
 export class ArticleNotFoundError extends ArticleError {
   name = 'ArticleNotFoundError'

--- a/application/packages/domain/src/article/index.ts
+++ b/application/packages/domain/src/article/index.ts
@@ -9,6 +9,6 @@ export function createArticleUseCase(db: RdbClient): UseCase {
   return new UseCase(articleQuery, articleCommand)
 }
 
-export { ArticleError, ArticleNotFoundError, ArticleRepositoryError } from './error'
+export { ArticleNotFoundError, ArticleRepositoryError } from './error'
 export type { Article } from './schema/article-schema'
 export type { QueryParams } from './schema/query-schema'

--- a/application/packages/domain/src/article/infrastructure/command-impl.ts
+++ b/application/packages/domain/src/article/infrastructure/command-impl.ts
@@ -4,7 +4,7 @@ import { fromDbId, toDbId } from '@trend-diary/datastore/rdb/id'
 import { articles, normalizeDateTime, readHistories } from '@trend-diary/datastore/schema'
 import { and, eq, exists, sql } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
-import { type ArticleError, ArticleNotFoundError, ArticleRepositoryError } from '../error'
+import { ArticleNotFoundError, ArticleRepositoryError } from '../error'
 import type { Command } from '../port'
 import type { ReadHistory } from '../schema/read-history-schema'
 import type { SkippedArticle } from '../schema/skipped-article-schema'
@@ -32,7 +32,7 @@ export default class CommandImpl implements Command {
     activeUserId: bigint,
     articleId: bigint,
     readAt: Date,
-  ): Promise<Result<ReadHistory, ArticleError>> {
+  ): Promise<Result<ReadHistory, ArticleNotFoundError | ArticleRepositoryError>> {
     const dbActiveUserId = toDbId(activeUserId)
     const dbArticleId = toDbId(articleId)
 
@@ -70,7 +70,7 @@ export default class CommandImpl implements Command {
   async deleteAllReadHistory(
     activeUserId: bigint,
     articleId: bigint,
-  ): Promise<Result<void, ArticleError>> {
+  ): Promise<Result<void, ArticleNotFoundError | ArticleRepositoryError>> {
     const dbActiveUserId = toDbId(activeUserId)
     const dbArticleId = toDbId(articleId)
 
@@ -113,7 +113,7 @@ export default class CommandImpl implements Command {
   async createSkippedArticle(
     activeUserId: bigint,
     articleId: bigint,
-  ): Promise<Result<SkippedArticle, ArticleError>> {
+  ): Promise<Result<SkippedArticle, ArticleNotFoundError | ArticleRepositoryError>> {
     const dbActiveUserId = toDbId(activeUserId)
     const dbArticleId = toDbId(articleId)
 

--- a/application/packages/domain/src/article/infrastructure/query-impl.test.ts
+++ b/application/packages/domain/src/article/infrastructure/query-impl.test.ts
@@ -605,6 +605,13 @@ describe('QueryImpl', () => {
         `enumerateJstDateRange received an invalid date string: ${invalid}`,
       )
     })
+
+    // from > to は API 境界(validateDiaryDateRange)で 422 検証済みのため、到達は契約違反
+    it('fromDateJstがtoDateJstより大きい場合は契約違反として送出する', () => {
+      expect(() => dateRangeEnumerator.enumerateJstDateRange('2026-03-08', '2026-03-06')).toThrow(
+        'enumerateJstDateRange received fromDateJst (2026-03-08) greater than toDateJst (2026-03-06)',
+      )
+    })
   })
 
   describe('日付範囲SQLビルダの同一性', () => {

--- a/application/packages/domain/src/article/infrastructure/query-impl.test.ts
+++ b/application/packages/domain/src/article/infrastructure/query-impl.test.ts
@@ -1,6 +1,5 @@
 import { type SQL, sql } from 'drizzle-orm'
 import { SQLiteSyncDialect } from 'drizzle-orm/sqlite-core'
-import { type Result } from 'neverthrow'
 import { beforeEach, describe, expect, it } from 'vitest'
 import getRdbClient, { mockRdbExecutor } from '../../test-helper/rdb'
 import QueryImpl from './query-impl'
@@ -18,7 +17,7 @@ interface DateRangeSqlBuilders {
 const dateRangeSqlBuilders = QueryImpl as unknown as DateRangeSqlBuilders
 
 interface DateRangeEnumerator {
-  enumerateJstDateRange(fromDateJst: string, toDateJst: string): Result<string[], Error>
+  enumerateJstDateRange(fromDateJst: string, toDateJst: string): string[]
 }
 // oxlint-disable-next-line typescript/consistent-type-assertions, typescript/no-restricted-types -- privateなstaticメソッドをホワイトボックステストするため、型システムを意図的に迂回する必要があるためです
 const dateRangeEnumerator = QueryImpl as unknown as DateRangeEnumerator
@@ -593,24 +592,18 @@ describe('QueryImpl', () => {
     it('範囲内の日付を列挙できる', () => {
       const result = dateRangeEnumerator.enumerateJstDateRange('2026-03-06', '2026-03-08')
 
-      expect(result.isOk()).toBe(true)
-      if (result.isOk()) {
-        expect(result.value).toEqual(['2026-03-06', '2026-03-07', '2026-03-08'])
-      }
+      expect(result).toEqual(['2026-03-06', '2026-03-07', '2026-03-08'])
     })
 
     it.each([
-      // fromDateJstが不正だと辞書順比較次第で空配列を正常値として返しうるため、検証してエラーにする
+      // fromDateJstが不正だと辞書順比較次第で空配列を正常値として返しうるため、契約違反として送出する
       { name: 'fromDateJstが不正', from: 'invalid', to: '2026-03-08', invalid: 'invalid' },
       // toDateJstが不正だと辞書順比較で常にcurrentより大きく、Date上限まで巨大ループになるのを防ぐ
       { name: 'toDateJstが不正', from: '2026-03-06', to: 'invalid', invalid: 'invalid' },
-    ])('$nameな場合は欠けたリストを返さずエラーを伝播する', ({ from, to, invalid }) => {
-      const result = dateRangeEnumerator.enumerateJstDateRange(from, to)
-
-      expect(result.isErr()).toBe(true)
-      if (result.isErr()) {
-        expect(result.error.message).toBe(`不正な日付文字列です: ${invalid}`)
-      }
+    ])('$nameな場合は契約違反として送出する', ({ from, to, invalid }) => {
+      expect(() => dateRangeEnumerator.enumerateJstDateRange(from, to)).toThrow(
+        `enumerateJstDateRange received an invalid date string: ${invalid}`,
+      )
     })
   })
 

--- a/application/packages/domain/src/article/infrastructure/query-impl.ts
+++ b/application/packages/domain/src/article/infrastructure/query-impl.ts
@@ -9,7 +9,7 @@ import { DEFAULT_LIMIT, DEFAULT_PAGE } from '@trend-diary/std/pagination'
 import type { Nullable } from '@trend-diary/std/types/utility'
 import { eq, type SQL, sql } from 'drizzle-orm'
 import { err, ok, type Result } from 'neverthrow'
-import { type ArticleError, ArticleRepositoryError } from '../error'
+import { ArticleRepositoryError } from '../error'
 import { ARTICLE_MEDIA, type ArticleMedia, assertArticleMedia } from '../media'
 import type { Query } from '../port'
 import type {
@@ -108,7 +108,9 @@ export default class QueryImpl implements Query {
   async searchArticles(
     params: QueryParams,
     activeUserId?: bigint,
-  ): Promise<Result<OffsetPaginationResult<ArticleWithOptionalReadStatus>, ArticleError>> {
+  ): Promise<
+    Result<OffsetPaginationResult<ArticleWithOptionalReadStatus>, ArticleRepositoryError>
+  > {
     const { page = DEFAULT_PAGE, limit = DEFAULT_LIMIT, from, to, ...searchParams } = params
     const dbActiveUserId = activeUserId !== undefined ? toDbId(activeUserId) : undefined
     const whereSql = QueryImpl.buildSqlWhereClause({
@@ -166,7 +168,9 @@ export default class QueryImpl implements Query {
     })
   }
 
-  async findArticleById(articleId: bigint): Promise<Result<Nullable<Article>, ArticleError>> {
+  async findArticleById(
+    articleId: bigint,
+  ): Promise<Result<Nullable<Article>, ArticleRepositoryError>> {
     const dbArticleId = toDbId(articleId)
     const result = await wrapDbCall(() =>
       this.db.select().from(articles).where(eq(articles.articleId, dbArticleId)),
@@ -188,7 +192,7 @@ export default class QueryImpl implements Query {
     activeUserId: bigint,
     targetDateJst: string,
     media?: ArticleMedia[],
-  ): Promise<Result<UnreadDigestionResult, ArticleError>> {
+  ): Promise<Result<UnreadDigestionResult, ArticleRepositoryError>> {
     const dbActiveUserId = toDbId(activeUserId)
     const { fromDate, toDateExclusive } = QueryImpl.buildDateRange(targetDateJst, targetDateJst)
     const createdAtRangeSql = QueryImpl.buildClosedOpenDateRangeSql(
@@ -248,7 +252,7 @@ export default class QueryImpl implements Query {
     targetDateJst: string,
     page: number,
     limit: number,
-  ): Promise<Result<DailyDiary, ArticleError>> {
+  ): Promise<Result<DailyDiary, ArticleRepositoryError>> {
     const dbActiveUserId = toDbId(activeUserId)
     const { fromDate, toDateExclusive } = QueryImpl.buildDateRange(targetDateJst, targetDateJst)
     const readAtRangeSql = QueryImpl.buildClosedOpenDateRangeSql(
@@ -371,7 +375,7 @@ export default class QueryImpl implements Query {
     activeUserId: bigint,
     fromDateJst: string,
     toDateJst: string,
-  ): Promise<Result<DailyDiaryRangeItem[], ArticleError>> {
+  ): Promise<Result<DailyDiaryRangeItem[], ArticleRepositoryError>> {
     const dbActiveUserId = toDbId(activeUserId)
     const { fromDate, toDateExclusive } = QueryImpl.buildDateRange(fromDateJst, toDateJst)
     const readAtRangeSql = QueryImpl.buildClosedOpenDateRangeSql(
@@ -431,13 +435,10 @@ export default class QueryImpl implements Query {
 
     const readByDate = QueryImpl.groupSourcesByDate(readSourceRows)
     const skipByDate = QueryImpl.groupSourcesByDate(skipSourceRows)
-    const datesResult = QueryImpl.enumerateJstDateRange(fromDateJst, toDateJst)
-    if (datesResult.isErr()) {
-      return err(new ArticleRepositoryError(datesResult.error))
-    }
+    const dates = QueryImpl.enumerateJstDateRange(fromDateJst, toDateJst)
 
     return ok(
-      datesResult.value.map((date) => {
+      dates.map((date) => {
         const sources = QueryImpl.mergeDiarySources(
           readByDate.get(date) ?? [],
           skipByDate.get(date) ?? [],
@@ -715,16 +716,14 @@ export default class QueryImpl implements Query {
     }))
   }
 
-  private static enumerateJstDateRange(
-    fromDateJst: string,
-    toDateJst: string,
-  ): Result<string[], Error> {
-    // 不正なtoDateJstは辞書順比較で常にcurrentより大きく評価され、Date上限到達まで巨大ループになる。
-    // 不正なfromDateJstは空配列を正常値として返してしまう。両端を先に検証して両方を防ぐ
+  private static enumerateJstDateRange(fromDateJst: string, toDateJst: string): string[] {
+    // 日付は API 境界(diaryDateSchema)で 422 検証済みのため、ここへの不正日付の到達はサーバ側の契約違反。
+    // 不正な toDateJst は辞書順比較で Date 上限まで巨大ループになり、不正な fromDateJst は空配列を正常値として返すため、両端を先に表明して顕在化させる
     for (const dateJst of [fromDateJst, toDateJst]) {
-      if (Number.isNaN(toJstDate(dateJst).getTime())) {
-        return err(new Error(`不正な日付文字列です: ${dateJst}`))
-      }
+      assert(
+        !Number.isNaN(toJstDate(dateJst).getTime()),
+        `enumerateJstDateRange received an invalid date string: ${dateJst}`,
+      )
     }
 
     const dates: string[] = []
@@ -734,6 +733,6 @@ export default class QueryImpl implements Query {
       // 両端は検証済みのため、途中の加算失敗は契約違反として addJstDays が送出する
       current = addJstDays(current, 1)
     }
-    return ok(dates)
+    return dates
   }
 }

--- a/application/packages/domain/src/article/infrastructure/query-impl.ts
+++ b/application/packages/domain/src/article/infrastructure/query-impl.ts
@@ -717,14 +717,20 @@ export default class QueryImpl implements Query {
   }
 
   private static enumerateJstDateRange(fromDateJst: string, toDateJst: string): string[] {
-    // 日付は API 境界(diaryDateSchema)で 422 検証済みのため、ここへの不正日付の到達はサーバ側の契約違反。
-    // 不正な toDateJst は辞書順比較で Date 上限まで巨大ループになり、不正な fromDateJst は空配列を正常値として返すため、両端を先に表明して顕在化させる
+    // 日付とその前後関係は API 境界(diaryDateSchema / validateDiaryDateRange)で 422 検証済みのため、
+    // ここへの不正日付・逆転範囲の到達はサーバ側の契約違反。
+    // 不正な toDateJst は辞書順比較で Date 上限まで巨大ループになり、不正・逆転した fromDateJst は
+    // 空配列を正常値として返すため、両端の妥当性と前後関係を先に表明して顕在化させる
     for (const dateJst of [fromDateJst, toDateJst]) {
       assert(
         !Number.isNaN(toJstDate(dateJst).getTime()),
         `enumerateJstDateRange received an invalid date string: ${dateJst}`,
       )
     }
+    assert(
+      fromDateJst <= toDateJst,
+      `enumerateJstDateRange received fromDateJst (${fromDateJst}) greater than toDateJst (${toDateJst})`,
+    )
 
     const dates: string[] = []
     let current = fromDateJst

--- a/application/packages/domain/src/article/port.ts
+++ b/application/packages/domain/src/article/port.ts
@@ -1,7 +1,7 @@
 import type { OffsetPaginationResult } from '@trend-diary/std/pagination'
 import type { Nullable } from '@trend-diary/std/types/utility'
 import { type Result } from 'neverthrow'
-import type { ArticleError } from './error'
+import type { ArticleNotFoundError, ArticleRepositoryError } from './error'
 import type { ArticleMedia } from './media'
 import type {
   Article,
@@ -22,28 +22,28 @@ export interface Query {
   searchArticles(
     params: QueryParams,
     activeUserId?: bigint,
-  ): Promise<Result<OffsetPaginationResult<ArticleWithOptionalReadStatus>, ArticleError>>
+  ): Promise<Result<OffsetPaginationResult<ArticleWithOptionalReadStatus>, ArticleRepositoryError>>
 
   getUnreadDigestionArticles(
     activeUserId: bigint,
     targetDateJst: string,
     media?: ArticleMedia[],
-  ): Promise<Result<UnreadDigestionResult, ArticleError>>
+  ): Promise<Result<UnreadDigestionResult, ArticleRepositoryError>>
 
   getDailyDiary(
     activeUserId: bigint,
     targetDateJst: string,
     page: number,
     limit: number,
-  ): Promise<Result<DailyDiary, ArticleError>>
+  ): Promise<Result<DailyDiary, ArticleRepositoryError>>
 
   getDailyDiaryRange(
     activeUserId: bigint,
     fromDateJst: string,
     toDateJst: string,
-  ): Promise<Result<DailyDiaryRangeItem[], ArticleError>>
+  ): Promise<Result<DailyDiaryRangeItem[], ArticleRepositoryError>>
 
-  findArticleById(articleId: bigint): Promise<Result<Nullable<Article>, ArticleError>>
+  findArticleById(articleId: bigint): Promise<Result<Nullable<Article>, ArticleRepositoryError>>
 }
 
 export interface Command {
@@ -54,7 +54,7 @@ export interface Command {
     activeUserId: bigint,
     articleId: bigint,
     readAt: Date,
-  ): Promise<Result<ReadHistory, ArticleError>>
+  ): Promise<Result<ReadHistory, ArticleNotFoundError | ArticleRepositoryError>>
 
   /**
    * 記事をスキップ登録する。記事が存在しない場合は ArticleNotFoundError を返す
@@ -62,10 +62,13 @@ export interface Command {
   createSkippedArticle(
     activeUserId: bigint,
     articleId: bigint,
-  ): Promise<Result<SkippedArticle, ArticleError>>
+  ): Promise<Result<SkippedArticle, ArticleNotFoundError | ArticleRepositoryError>>
 
   /**
    * 記事の既読履歴を全削除する。記事が存在しない場合は ArticleNotFoundError を返す
    */
-  deleteAllReadHistory(activeUserId: bigint, articleId: bigint): Promise<Result<void, ArticleError>>
+  deleteAllReadHistory(
+    activeUserId: bigint,
+    articleId: bigint,
+  ): Promise<Result<void, ArticleNotFoundError | ArticleRepositoryError>>
 }

--- a/application/packages/domain/src/article/use-case.ts
+++ b/application/packages/domain/src/article/use-case.ts
@@ -3,7 +3,7 @@ import type { OffsetPaginationResult } from '@trend-diary/std/pagination'
 import { DEFAULT_LIMIT, DEFAULT_PAGE } from '@trend-diary/std/pagination'
 import extractTrimmed from '@trend-diary/std/sanitization'
 import type { Result } from 'neverthrow'
-import type { ArticleError } from './error'
+import type { ArticleNotFoundError, ArticleRepositoryError } from './error'
 import type { ArticleMedia } from './media'
 import type { Command, Query } from './port'
 import type { ArticleWithOptionalReadStatus, UnreadDigestionResult } from './schema/article-schema'
@@ -26,7 +26,9 @@ export class UseCase {
   async searchArticles(
     params: QueryParams,
     activeUserId?: bigint,
-  ): Promise<Result<OffsetPaginationResult<ArticleWithOptionalReadStatus>, ArticleError>> {
+  ): Promise<
+    Result<OffsetPaginationResult<ArticleWithOptionalReadStatus>, ArticleRepositoryError>
+  > {
     const optimizedParams: QueryParams = {
       title: extractTrimmed(params.title),
       author: extractTrimmed(params.author),
@@ -45,7 +47,7 @@ export class UseCase {
     activeUserId: bigint,
     articleId: bigint,
     readAt: Date,
-  ): Promise<Result<ReadHistory, ArticleError>> {
+  ): Promise<Result<ReadHistory, ArticleNotFoundError | ArticleRepositoryError>> {
     // 記事存在チェックは command 側のSQLに集約済みのため、ここでは委譲のみ行う
     return this.command.createReadHistory(activeUserId, articleId, readAt)
   }
@@ -54,7 +56,7 @@ export class UseCase {
     activeUserId: bigint,
     media?: ArticleMedia[],
     now: Date = new Date(),
-  ): Promise<Result<UnreadDigestionResult, ArticleError>> {
+  ): Promise<Result<UnreadDigestionResult, ArticleRepositoryError>> {
     return this.query.getUnreadDigestionArticles(activeUserId, toJstDateString(now), media)
   }
 
@@ -63,7 +65,7 @@ export class UseCase {
     targetDateJst: string,
     page: number,
     limit: number,
-  ): Promise<Result<DailyDiary, ArticleError>> {
+  ): Promise<Result<DailyDiary, ArticleRepositoryError>> {
     return this.query.getDailyDiary(activeUserId, targetDateJst, page, limit)
   }
 
@@ -71,14 +73,14 @@ export class UseCase {
     activeUserId: bigint,
     fromDateJst: string,
     toDateJst: string,
-  ): Promise<Result<DailyDiaryRangeItem[], ArticleError>> {
+  ): Promise<Result<DailyDiaryRangeItem[], ArticleRepositoryError>> {
     return this.query.getDailyDiaryRange(activeUserId, fromDateJst, toDateJst)
   }
 
   async createSkippedArticle(
     activeUserId: bigint,
     articleId: bigint,
-  ): Promise<Result<SkippedArticle, ArticleError>> {
+  ): Promise<Result<SkippedArticle, ArticleNotFoundError | ArticleRepositoryError>> {
     // 記事存在チェックは command 側のSQLに集約済みのため、ここでは委譲のみ行う
     return this.command.createSkippedArticle(activeUserId, articleId)
   }
@@ -86,7 +88,7 @@ export class UseCase {
   async deleteAllReadHistory(
     activeUserId: bigint,
     articleId: bigint,
-  ): Promise<Result<void, ArticleError>> {
+  ): Promise<Result<void, ArticleNotFoundError | ArticleRepositoryError>> {
     // 記事存在チェックは command 側のSQLに集約済みのため、ここでは委譲のみ行う
     return this.command.deleteAllReadHistory(activeUserId, articleId)
   }


### PR DESCRIPTION
# 概要
## 課題
authentication パッケージと article 集約では、各メソッドの `Result` エラー型を基底の `AuthError` / `ArticleError` でぼかしていました。呼び出し側からは実際にどのエラーが返り得るかが型から読み取れず、ハンドリングの網羅性を型で担保できません。PR #1028 で account 集約は解消済みで、横断調査で残っていたこの2箇所を同様に絞ります。

## 修正内容
- fix: #1030
- 各メソッドの `Result` エラー型を、実際に返し得る具象型で表すようにしました
  - **authentication**: `callSupabase` を `mapError` の戻り型 `TError` でジェネリック化し、`Result<..., UnexpectedAuthError | TError>` を返すようにしました。これを土台に OAuth / Password / Passkey / Session の各メソッドを実際のエラー集合へ絞っています（例: `signIn` → `InvalidCredentialsError | UnexpectedAuthError`、`getClaims` → `NoSessionError | UnexpectedAuthError`）
    - ジェネリックな `TError` を戻す既定値は型として表現できないため、既定 `mapError` は引数のデフォルト関数ではなく未指定時の分岐で `UnexpectedAuthError` を返す形にしています
  - **article**: port / infrastructure / use-case の `Result` を `ArticleRepositoryError`、もしくは記事不在を返す Command 系は `ArticleNotFoundError | ArticleRepositoryError` へ絞りました
- 署名から使われなくなった基底 `AuthError` / `ArticleError` は、パッケージ／集約内の共通土台として残しつつ公開 API（`index.ts`）からは外しました
  - web 側に `instanceof` 依存はなく、`AuthError` を境界型として使っていた passkey / oauth のファクトリは、`start` / `execute` が返す具象型を `TError` で受け取るジェネリックに変更しています
- `enumerateJstDateRange` の素の `Error`: 日付は API 境界（`diaryDateSchema`）で 422 検証済みのため、不正日付の到達はサーバ側の契約違反です。`.claude/rules/contract.md` に従い `err` 縮退をやめ `assert` で送出し、素の `Error` を無くして戻り値を `string[]` にしました


---
_Generated by [Claude Code](https://claude.ai/code/session_01SoLnqvHhkNajhFpsA6BPKF)_