### PR TITLE
import-lint の minimumReleaseAgeExclude（3日隔離の除外）を撤去する

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,11 +28,6 @@ allowBuilds:
 
 minimumReleaseAge: 4320
 
-# import-lint の境界機能(packageDirectory)は 0.1.6 以降でのみ利用でき、
-# 隔離期間(minimumReleaseAge)を満たす旧版では機能しないため、当該パッケージ群のみ隔離対象から除外する。
-minimumReleaseAgeExclude:
-  - '@import-lint/*'
-
 overrides:
   '@esbuild-kit/core-utils>esbuild': ^0.25.0
   '@hono/node-server': ^1.19.13


### PR DESCRIPTION
# 概要
## 課題
PR #1010 で import-lint を導入した際、境界機能（`packageDirectory`）を持つ `@import-lint/cli@0.1.6` が公開直後で `minimumReleaseAge: 4320`（3日隔離）の期間内だったため、暫定措置として `pnpm-workspace.yaml` に `minimumReleaseAgeExclude: ['@import-lint/*']` を追加し、当該パッケージ群のみ隔離対象から除外していた。この除外は supply-chain の安全策を import-lint に限って無効化するものであり、恒久的に残すべきものではない（#1013）。

## 修正内容
- fix: #1013
- `pnpm-workspace.yaml` から `minimumReleaseAgeExclude`（`@import-lint/*`）とその説明コメントを撤去した
  - `@import-lint/cli@0.1.6` は 2026-07-19 公開で、3日隔離期間（2026-07-22 まで）を経過しているため除外なしで解決可能
- 撤去後に `pnpm install --frozen-lockfile` が supply-chain ポリシー検証を通過すること、`pnpm import-lint` が引き続き違反0で通過することを確認した
  - バージョンは exact 固定（`0.1.6`）のため、lockfile 上のバージョンに変更はない


---
_Generated by [Claude Code](https://claude.ai/code/session_01Uk2KEErFZaBz9KF4XhA2o7)_