### PR TITLE
fix(cron): RSS取得の run 内リトライを廃止し毎時実行に再試行を委ねる

### DIFF
--- a/apps/cron/src/feed/fetch-all-articles.test.ts
+++ b/apps/cron/src/feed/fetch-all-articles.test.ts
@@ -100,38 +100,29 @@ describe('fetchAllArticles', () => {
       expect(sendMessageSpy).toHaveBeenCalledWith(expect.stringContaining('body: Rate limited'))
     })
 
-    it('レート制限(429)の場合は次回実行で再試行する旨を通知に含める', async () => {
-      const fetchError = new RssFetchError('https://zenn.dev/feed', {
-        status: 429,
-        headers: { 'retry-after': '281' },
-        bodySnippet: 'error code: 1015',
-      })
-      runScheduledFetchMock.mockImplementation(async (media: ArticleMedia) =>
-        media === 'zenn' ? err(fetchError) : ok(1),
-      )
-      const { discord, sendMessageSpy } = buildDiscord()
+    // レート制限は次回の定期実行で回復する見込みのため、通知の受け手が即時対応の要否を判断できる必要がある
+    const rateLimitNoteCases = [
+      { status: 429, expectsNote: true },
+      { status: 503, expectsNote: false },
+    ]
 
-      await expect(runFetchAllArticles(discord, 5000)).rejects.toThrow()
+    it.each(rateLimitNoteCases)(
+      'status=$status の失敗では通知への再試行注記の有無が $expectsNote になる',
+      async ({ status, expectsNote }) => {
+        const fetchError = new RssFetchError('https://zenn.dev/feed', { status, headers: {} })
+        runScheduledFetchMock.mockImplementation(async (media: ArticleMedia) =>
+          media === 'zenn' ? err(fetchError) : ok(1),
+        )
+        const { discord, sendMessageSpy } = buildDiscord()
 
-      expect(sendMessageSpy).toHaveBeenCalledWith(
-        expect.stringContaining('note: rate limited (retry on next scheduled run)'),
-      )
-    })
+        await expect(runFetchAllArticles(discord, 5000)).rejects.toThrow()
 
-    it('レート制限以外の失敗では再試行の注記を含めない', async () => {
-      const fetchError = new RssFetchError('https://zenn.dev/feed', {
-        status: 503,
-        headers: {},
-      })
-      runScheduledFetchMock.mockImplementation(async (media: ArticleMedia) =>
-        media === 'zenn' ? err(fetchError) : ok(1),
-      )
-      const { discord, sendMessageSpy } = buildDiscord()
-
-      await expect(runFetchAllArticles(discord, 6000)).rejects.toThrow()
-
-      expect(sendMessageSpy).not.toHaveBeenCalledWith(expect.stringContaining('note: rate limited'))
-    })
+        const noted = sendMessageSpy.mock.calls.some(([message]) =>
+          message.includes('note: rate limited (retry on next scheduled run)'),
+        )
+        expect(noted).toBe(expectsNote)
+      },
+    )
   })
 
   describe('異常系', () => {

--- a/apps/cron/src/feed/fetch-all-articles.test.ts
+++ b/apps/cron/src/feed/fetch-all-articles.test.ts
@@ -99,6 +99,39 @@ describe('fetchAllArticles', () => {
       )
       expect(sendMessageSpy).toHaveBeenCalledWith(expect.stringContaining('body: Rate limited'))
     })
+
+    it('レート制限(429)の場合は次回実行で再試行する旨を通知に含める', async () => {
+      const fetchError = new RssFetchError('https://zenn.dev/feed', {
+        status: 429,
+        headers: { 'retry-after': '281' },
+        bodySnippet: 'error code: 1015',
+      })
+      runScheduledFetchMock.mockImplementation(async (media: ArticleMedia) =>
+        media === 'zenn' ? err(fetchError) : ok(1),
+      )
+      const { discord, sendMessageSpy } = buildDiscord()
+
+      await expect(runFetchAllArticles(discord, 5000)).rejects.toThrow()
+
+      expect(sendMessageSpy).toHaveBeenCalledWith(
+        expect.stringContaining('note: rate limited (retry on next scheduled run)'),
+      )
+    })
+
+    it('レート制限以外の失敗では再試行の注記を含めない', async () => {
+      const fetchError = new RssFetchError('https://zenn.dev/feed', {
+        status: 503,
+        headers: {},
+      })
+      runScheduledFetchMock.mockImplementation(async (media: ArticleMedia) =>
+        media === 'zenn' ? err(fetchError) : ok(1),
+      )
+      const { discord, sendMessageSpy } = buildDiscord()
+
+      await expect(runFetchAllArticles(discord, 6000)).rejects.toThrow()
+
+      expect(sendMessageSpy).not.toHaveBeenCalledWith(expect.stringContaining('note: rate limited'))
+    })
   })
 
   describe('異常系', () => {

--- a/apps/cron/src/feed/fetch-all-articles.ts
+++ b/apps/cron/src/feed/fetch-all-articles.ts
@@ -75,14 +75,15 @@ export async function fetchAllArticles({
     if (result.isErr()) {
       failedCount += 1
       const error = result.error
+      const rssError = error instanceof RssFetchError ? error : undefined
       // 429 等は status だけでは原因を追えないため、配信元レスポンスの診断情報を併せて残す
-      const diagnostics = error instanceof RssFetchError ? error.diagnostics : undefined
+      const diagnostics = rssError?.diagnostics
       logger.error(
         { msg: 'cron media fetch failed', media, durationMs, ...(diagnostics && { diagnostics }) },
         error,
       )
       const detail = diagnostics ? formatDiagnostics(diagnostics) : ''
-      const note = error instanceof RssFetchError && error.isRateLimited ? RATE_LIMIT_NOTE : ''
+      const note = rssError?.isRateLimited ? RATE_LIMIT_NOTE : ''
       await discord.sendMessage(
         `[trend-diary cron] fetch failed\ncron: ${cron}\nmedia: ${media}\nerror: ${error.message}${detail}${note}`,
       )

--- a/apps/cron/src/feed/fetch-all-articles.ts
+++ b/apps/cron/src/feed/fetch-all-articles.ts
@@ -15,6 +15,10 @@ export interface FetchAllArticlesParams {
   scheduledTime: number
 }
 
+// レート制限は次回の定期実行（毎時）までに解除される見込みのため、
+// 通知の受け手が即時対応の要否を判断できるよう回復見込みを明示する。
+const RATE_LIMIT_NOTE = '\nnote: rate limited (retry on next scheduled run)'
+
 interface MediaFetchOutcome {
   media: ArticleMedia
   result: Result<number, Error>
@@ -78,8 +82,9 @@ export async function fetchAllArticles({
         error,
       )
       const detail = diagnostics ? formatDiagnostics(diagnostics) : ''
+      const note = error instanceof RssFetchError && error.isRateLimited ? RATE_LIMIT_NOTE : ''
       await discord.sendMessage(
-        `[trend-diary cron] fetch failed\ncron: ${cron}\nmedia: ${media}\nerror: ${error.message}${detail}`,
+        `[trend-diary cron] fetch failed\ncron: ${cron}\nmedia: ${media}\nerror: ${error.message}${detail}${note}`,
       )
       continue
     }

--- a/apps/cron/src/feed/fetch-articles.test.ts
+++ b/apps/cron/src/feed/fetch-articles.test.ts
@@ -8,6 +8,7 @@ import {
   buildQiitaAtom,
   buildZennRss,
   type FeedItem,
+  nonOkResponse,
   rssResponse,
 } from '../test-helper/feed'
 import { countArticles, testRdb as db } from '../test-helper/rdb'
@@ -438,28 +439,20 @@ describe('fetchHatenaArticles', () => {
       expect(options?.signal).toBeInstanceOf(AbortSignal)
     })
 
-    it('取得に失敗した場合はリトライせず err を返し何も保存しない', async () => {
+    it('取得に失敗した場合は err を返し何も保存しない', async () => {
       fetchMock.mockRejectedValue(new Error('network error'))
 
       const result = await fetchHatenaArticles(cronEnv, logger)
 
-      expect(fetchMock).toHaveBeenCalledTimes(1)
       expect(result._unsafeUnwrapErr()).toBeInstanceOf(Error)
       expect(await countArticles()).toBe(0)
     })
 
-    it('レスポンスが ok でない場合もリトライせず err を返し何も保存しない', async () => {
-      // 実 Response の契約（headers・text が必ず存在する）に合わせたモックにする
-      fetchMock.mockResolvedValue({
-        ok: false,
-        status: 500,
-        headers: new Headers(),
-        text: async () => '',
-      })
+    it('レスポンスが ok でない場合も err を返し何も保存しない', async () => {
+      fetchMock.mockResolvedValue(nonOkResponse(500, ''))
 
       const result = await fetchHatenaArticles(cronEnv, logger)
 
-      expect(fetchMock).toHaveBeenCalledTimes(1)
       expect(result._unsafeUnwrapErr().message).toContain('status=500')
       expect(await countArticles()).toBe(0)
     })

--- a/apps/cron/src/feed/fetch-articles.test.ts
+++ b/apps/cron/src/feed/fetch-articles.test.ts
@@ -438,38 +438,17 @@ describe('fetchHatenaArticles', () => {
       expect(options?.signal).toBeInstanceOf(AbortSignal)
     })
 
-    it('一時的な取得失敗はリトライし、回復後は成功する', async () => {
-      vi.useFakeTimers()
-      fetchMock
-        .mockRejectedValueOnce(new Error('network error'))
-        .mockResolvedValueOnce(rssResponse(buildHatenaRdf([])))
-
-      const promise = fetchHatenaArticles(cronEnv, logger)
-      await vi.runAllTimersAsync()
-      const result = await promise
-      vi.useRealTimers()
-
-      expect(fetchMock).toHaveBeenCalledTimes(2)
-      expect(result.isOk()).toBe(true)
-    })
-
-    it('全試行が失敗した場合は最大3回試行し err を返し何も保存しない', async () => {
-      vi.useFakeTimers()
+    it('取得に失敗した場合はリトライせず err を返し何も保存しない', async () => {
       fetchMock.mockRejectedValue(new Error('network error'))
 
-      const promise = fetchHatenaArticles(cronEnv, logger)
-      await vi.runAllTimersAsync()
-      const result = await promise
-      vi.useRealTimers()
+      const result = await fetchHatenaArticles(cronEnv, logger)
 
-      expect(fetchMock).toHaveBeenCalledTimes(3)
-      expect(result.isErr()).toBe(true)
-      if (result.isErr()) expect(result.error).toBeInstanceOf(Error)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(Error)
       expect(await countArticles()).toBe(0)
     })
 
-    it('レスポンスが ok でない場合もリトライ対象とし、最終的に err を返す', async () => {
-      vi.useFakeTimers()
+    it('レスポンスが ok でない場合もリトライせず err を返し何も保存しない', async () => {
       // 実 Response の契約（headers・text が必ず存在する）に合わせたモックにする
       fetchMock.mockResolvedValue({
         ok: false,
@@ -478,14 +457,10 @@ describe('fetchHatenaArticles', () => {
         text: async () => '',
       })
 
-      const promise = fetchHatenaArticles(cronEnv, logger)
-      await vi.runAllTimersAsync()
-      const result = await promise
-      vi.useRealTimers()
+      const result = await fetchHatenaArticles(cronEnv, logger)
 
-      expect(fetchMock).toHaveBeenCalledTimes(3)
-      expect(result.isErr()).toBe(true)
-      if (result.isErr()) expect(result.error.message).toContain('status=500')
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(result._unsafeUnwrapErr().message).toContain('status=500')
       expect(await countArticles()).toBe(0)
     })
   })

--- a/apps/cron/src/feed/rss-client.test.ts
+++ b/apps/cron/src/feed/rss-client.test.ts
@@ -22,6 +22,25 @@ describe('backoffDelayMs', () => {
   })
 })
 
+describe('RssFetchError', () => {
+  describe('正常系', () => {
+    const cases = [
+      { status: 429, expected: true },
+      { status: 403, expected: false },
+      { status: 503, expected: false },
+    ]
+
+    it.each(cases)(
+      'status=$status のとき isRateLimited は $expected を返す',
+      ({ status, expected }) => {
+        const error = new RssFetchError('https://zenn.dev/feed', { status, headers: {} })
+
+        expect(error.isRateLimited).toBe(expected)
+      },
+    )
+  })
+})
+
 describe('fetchRssFeed', () => {
   beforeEach(() => {
     fetchMock.mockReset()
@@ -29,7 +48,6 @@ describe('fetchRssFeed', () => {
 
   describe('異常系', () => {
     it('非ok応答は RssFetchError として status・診断ヘッダ・本文先頭を残す', async () => {
-      vi.useFakeTimers()
       fetchMock.mockResolvedValue({
         ok: false,
         status: 429,
@@ -42,14 +60,12 @@ describe('fetchRssFeed', () => {
         text: async () => 'Rate limited by origin',
       })
 
-      const promise = fetchRssFeed('https://zenn.dev/feed')
-      await vi.runAllTimersAsync()
-      const result = await promise
-      vi.useRealTimers()
+      const result = await fetchRssFeed('https://zenn.dev/feed')
 
-      expect(result.isErr()).toBe(true)
-      if (result.isErr() && result.error instanceof RssFetchError) {
-        expect(result.error.diagnostics).toEqual({
+      const error = result._unsafeUnwrapErr()
+      expect(error).toBeInstanceOf(RssFetchError)
+      expect(error).toMatchObject({
+        diagnostics: {
           status: 429,
           headers: {
             'retry-after': '30',
@@ -58,8 +74,40 @@ describe('fetchRssFeed', () => {
             server: 'cloudflare',
           },
           bodySnippet: 'Rate limited by origin',
-        })
-      }
+        },
+      })
+    })
+
+    it('429応答はリトライせず1回の試行で失敗を返す', async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 429,
+        headers: new Headers({ 'retry-after': '281', server: 'cloudflare' }),
+        text: async () => 'error code: 1015',
+      })
+
+      const result = await fetchRssFeed('https://zenn.dev/feed')
+
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(RssFetchError)
+    })
+
+    it('429以外の非ok応答は上限回数までリトライする', async () => {
+      vi.useFakeTimers()
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 503,
+        headers: new Headers({ server: 'cloudflare' }),
+        text: async () => 'Service Unavailable',
+      })
+
+      const promise = fetchRssFeed('https://zenn.dev/feed')
+      await vi.runAllTimersAsync()
+      const result = await promise
+      vi.useRealTimers()
+
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+      expect(result._unsafeUnwrapErr()).toBeInstanceOf(RssFetchError)
     })
 
     it('本文が上限を超える場合は先頭のみを残す', async () => {
@@ -76,10 +124,9 @@ describe('fetchRssFeed', () => {
       const result = await promise
       vi.useRealTimers()
 
-      expect(result.isErr()).toBe(true)
-      if (result.isErr() && result.error instanceof RssFetchError) {
-        expect(result.error.diagnostics.bodySnippet).toBe(`${'x'.repeat(500)}…`)
-      }
+      const error = result._unsafeUnwrapErr()
+      expect(error).toBeInstanceOf(RssFetchError)
+      expect(error).toMatchObject({ diagnostics: { bodySnippet: `${'x'.repeat(500)}…` } })
     })
   })
 })

--- a/apps/cron/src/feed/rss-client.test.ts
+++ b/apps/cron/src/feed/rss-client.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { backoffDelayMs, fetchRssFeed, RssFetchError } from './rss-client'
+import { fetchRssFeed, RssFetchError } from './rss-client'
 
 const fetchMock = vi.fn()
 vi.stubGlobal('fetch', fetchMock)
@@ -7,34 +7,6 @@ vi.stubGlobal('fetch', fetchMock)
 function nonOkResponse(status: number, body: string, headers: Record<string, string> = {}) {
   return { ok: false, status, headers: new Headers(headers), text: async () => body }
 }
-
-// リトライ間のバックオフを実時間で待たないよう、fake timer 下で全試行を進めてから結果を受け取る
-async function fetchRssFeedWithTimersAdvanced(url: string) {
-  vi.useFakeTimers()
-  const promise = fetchRssFeed(url)
-  await vi.runAllTimersAsync()
-  const result = await promise
-  vi.useRealTimers()
-  return result
-}
-
-describe('backoffDelayMs', () => {
-  describe('正常系', () => {
-    const cases = [
-      { attempt: 0, expectedMs: 1_000 },
-      { attempt: 1, expectedMs: 2_000 },
-      { attempt: 2, expectedMs: 4_000 },
-      { attempt: 4, expectedMs: 16_000 },
-      // attempt=5以降は理論値(2^attempt×base)が上限を超えるため30,000msにクランプされる
-      { attempt: 5, expectedMs: 30_000 },
-      { attempt: 10, expectedMs: 30_000 },
-    ]
-
-    it.each(cases)('attempt=$attempt のとき $expectedMs ms を返す', ({ attempt, expectedMs }) => {
-      expect(backoffDelayMs(attempt)).toBe(expectedMs)
-    })
-  })
-})
 
 describe('RssFetchError', () => {
   describe('正常系', () => {
@@ -89,7 +61,7 @@ describe('fetchRssFeed', () => {
       })
     })
 
-    it('429応答はリトライせず1回の試行で失敗を返す', async () => {
+    it('失敗しても run 内でリトライせず1回の試行で失敗を返す', async () => {
       fetchMock.mockResolvedValue(
         nonOkResponse(429, 'error code: 1015', { 'retry-after': '281', server: 'cloudflare' }),
       )
@@ -100,19 +72,10 @@ describe('fetchRssFeed', () => {
       expect(result._unsafeUnwrapErr()).toBeInstanceOf(RssFetchError)
     })
 
-    it('429以外の非ok応答は上限回数までリトライする', async () => {
-      fetchMock.mockResolvedValue(nonOkResponse(503, 'Service Unavailable'))
-
-      const result = await fetchRssFeedWithTimersAdvanced('https://zenn.dev/feed')
-
-      expect(fetchMock).toHaveBeenCalledTimes(3)
-      expect(result._unsafeUnwrapErr()).toBeInstanceOf(RssFetchError)
-    })
-
     it('本文が上限を超える場合は先頭のみを残す', async () => {
       fetchMock.mockResolvedValue(nonOkResponse(503, 'x'.repeat(600)))
 
-      const result = await fetchRssFeedWithTimersAdvanced('https://zenn.dev/feed')
+      const result = await fetchRssFeed('https://zenn.dev/feed')
 
       const error = result._unsafeUnwrapErr()
       expect(error).toBeInstanceOf(RssFetchError)

--- a/apps/cron/src/feed/rss-client.test.ts
+++ b/apps/cron/src/feed/rss-client.test.ts
@@ -4,6 +4,20 @@ import { backoffDelayMs, fetchRssFeed, RssFetchError } from './rss-client'
 const fetchMock = vi.fn()
 vi.stubGlobal('fetch', fetchMock)
 
+function nonOkResponse(status: number, body: string, headers: Record<string, string> = {}) {
+  return { ok: false, status, headers: new Headers(headers), text: async () => body }
+}
+
+// リトライ間のバックオフを実時間で待たないよう、fake timer 下で全試行を進めてから結果を受け取る
+async function fetchRssFeedWithTimersAdvanced(url: string) {
+  vi.useFakeTimers()
+  const promise = fetchRssFeed(url)
+  await vi.runAllTimersAsync()
+  const result = await promise
+  vi.useRealTimers()
+  return result
+}
+
 describe('backoffDelayMs', () => {
   describe('正常系', () => {
     const cases = [
@@ -48,17 +62,14 @@ describe('fetchRssFeed', () => {
 
   describe('異常系', () => {
     it('非ok応答は RssFetchError として status・診断ヘッダ・本文先頭を残す', async () => {
-      fetchMock.mockResolvedValue({
-        ok: false,
-        status: 429,
-        headers: new Headers({
+      fetchMock.mockResolvedValue(
+        nonOkResponse(429, 'Rate limited by origin', {
           'retry-after': '30',
           'cf-ray': '8abc',
           'cf-mitigated': 'challenge',
           server: 'cloudflare',
         }),
-        text: async () => 'Rate limited by origin',
-      })
+      )
 
       const result = await fetchRssFeed('https://zenn.dev/feed')
 
@@ -79,12 +90,9 @@ describe('fetchRssFeed', () => {
     })
 
     it('429応答はリトライせず1回の試行で失敗を返す', async () => {
-      fetchMock.mockResolvedValue({
-        ok: false,
-        status: 429,
-        headers: new Headers({ 'retry-after': '281', server: 'cloudflare' }),
-        text: async () => 'error code: 1015',
-      })
+      fetchMock.mockResolvedValue(
+        nonOkResponse(429, 'error code: 1015', { 'retry-after': '281', server: 'cloudflare' }),
+      )
 
       const result = await fetchRssFeed('https://zenn.dev/feed')
 
@@ -93,36 +101,18 @@ describe('fetchRssFeed', () => {
     })
 
     it('429以外の非ok応答は上限回数までリトライする', async () => {
-      vi.useFakeTimers()
-      fetchMock.mockResolvedValue({
-        ok: false,
-        status: 503,
-        headers: new Headers({ server: 'cloudflare' }),
-        text: async () => 'Service Unavailable',
-      })
+      fetchMock.mockResolvedValue(nonOkResponse(503, 'Service Unavailable'))
 
-      const promise = fetchRssFeed('https://zenn.dev/feed')
-      await vi.runAllTimersAsync()
-      const result = await promise
-      vi.useRealTimers()
+      const result = await fetchRssFeedWithTimersAdvanced('https://zenn.dev/feed')
 
       expect(fetchMock).toHaveBeenCalledTimes(3)
       expect(result._unsafeUnwrapErr()).toBeInstanceOf(RssFetchError)
     })
 
     it('本文が上限を超える場合は先頭のみを残す', async () => {
-      vi.useFakeTimers()
-      fetchMock.mockResolvedValue({
-        ok: false,
-        status: 503,
-        headers: new Headers({ server: 'cloudflare' }),
-        text: async () => 'x'.repeat(600),
-      })
+      fetchMock.mockResolvedValue(nonOkResponse(503, 'x'.repeat(600)))
 
-      const promise = fetchRssFeed('https://zenn.dev/feed')
-      await vi.runAllTimersAsync()
-      const result = await promise
-      vi.useRealTimers()
+      const result = await fetchRssFeedWithTimersAdvanced('https://zenn.dev/feed')
 
       const error = result._unsafeUnwrapErr()
       expect(error).toBeInstanceOf(RssFetchError)

--- a/apps/cron/src/feed/rss-client.test.ts
+++ b/apps/cron/src/feed/rss-client.test.ts
@@ -1,12 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nonOkResponse } from '../test-helper/feed'
 import { fetchRssFeed, RssFetchError } from './rss-client'
 
 const fetchMock = vi.fn()
 vi.stubGlobal('fetch', fetchMock)
-
-function nonOkResponse(status: number, body: string, headers: Record<string, string> = {}) {
-  return { ok: false, status, headers: new Headers(headers), text: async () => body }
-}
 
 describe('RssFetchError', () => {
   describe('正常系', () => {

--- a/apps/cron/src/feed/rss-client.ts
+++ b/apps/cron/src/feed/rss-client.ts
@@ -3,12 +3,8 @@ import { wrapAsyncCall } from '@trend-diary/std/result'
 import { err, type Result } from 'neverthrow'
 import Parser from 'rss-parser'
 
-// INFO: 外部RSSのハング時に無限待機しないよう1試行あたりのタイムアウトを設ける
+// INFO: 外部RSSのハング時に無限待機しないようタイムアウトを設ける
 const FETCH_TIMEOUT_MS = 30_000
-// INFO: 一時的なネットワークエラーを吸収するためのリトライ回数（初回 + リトライ）
-const MAX_FETCH_ATTEMPTS = 3
-const RETRY_BASE_DELAY_MS = 1_000
-const RETRY_MAX_DELAY_MS = 30_000
 const TOO_MANY_REQUESTS = 429
 
 // 429 等の失敗要因を後から切り分けられるよう、配信元レスポンスから残す診断情報。
@@ -40,7 +36,7 @@ export class RssFetchError extends Error {
     this.diagnostics = diagnostics
   }
 
-  // レート制限は他の失敗と扱いを変える（リトライしない・通知の文面を変える）ため判定を公開する。
+  // レート制限は配信元の障害と違い受け手の対応が不要なため、通知で区別できるよう判定を公開する。
   get isRateLimited(): boolean {
     return this.diagnostics.status === TOO_MANY_REQUESTS
   }
@@ -67,16 +63,9 @@ async function readBodySnippet(response: Response): Promise<string | undefined> 
   return text.length > BODY_SNIPPET_MAX_LENGTH ? `${text.slice(0, BODY_SNIPPET_MAX_LENGTH)}…` : text
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
-}
-
-// 指数バックオフの待機時間(2^attempt × base)を算出し、上限でクランプする。
-export function backoffDelayMs(attempt: number): number {
-  return Math.min(RETRY_BASE_DELAY_MS * 2 ** attempt, RETRY_MAX_DELAY_MS)
-}
-
-async function fetchRssFeedOnce<T>(url: string): Promise<Result<T[], Error>> {
+// 取得失敗は毎時の定期実行が再試行を兼ねるため、run 内でのリトライは行わない。
+// 保存は URL 一意制約で冪等なため、1回分の取得を落としても次回実行で取り込み直せる。
+export async function fetchRssFeed<T>(url: string): Promise<Result<T[], Error>> {
   const responseResult = await wrapAsyncCall(() =>
     fetchWithTimeout(url, { timeoutMs: FETCH_TIMEOUT_MS }),
   )
@@ -94,24 +83,4 @@ async function fetchRssFeedOnce<T>(url: string): Promise<Result<T[], Error>> {
     const feed = await parser.parseString(xml)
     return feed.items
   })
-}
-
-export async function fetchRssFeed<T>(url: string): Promise<Result<T[], Error>> {
-  let lastError: Error = new Error(`Failed to fetch rss feed: ${url}`)
-
-  for (let attempt = 0; attempt < MAX_FETCH_ATTEMPTS; attempt += 1) {
-    const result = await fetchRssFeedOnce<T>(url)
-    if (result.isOk()) return result
-
-    lastError = result.error
-    // レート制限の解除は分単位に及び in-run のバックオフ（最大30秒）では明けないうえ、
-    // 制限中の追加リクエストは制限期間を延ばし得るため、リトライせず次回の定期実行に委ねる
-    if (lastError instanceof RssFetchError && lastError.isRateLimited) return result
-    // INFO: 最終試行後は待機せず失敗を返す
-    if (attempt < MAX_FETCH_ATTEMPTS - 1) {
-      await delay(backoffDelayMs(attempt))
-    }
-  }
-
-  return err(lastError)
 }

--- a/apps/cron/src/feed/rss-client.ts
+++ b/apps/cron/src/feed/rss-client.ts
@@ -64,7 +64,6 @@ async function readBodySnippet(response: Response): Promise<string | undefined> 
 }
 
 // 取得失敗は毎時の定期実行が再試行を兼ねるため、run 内でのリトライは行わない。
-// 保存は URL 一意制約で冪等なため、1回分の取得を落としても次回実行で取り込み直せる。
 export async function fetchRssFeed<T>(url: string): Promise<Result<T[], Error>> {
   const responseResult = await wrapAsyncCall(() =>
     fetchWithTimeout(url, { timeoutMs: FETCH_TIMEOUT_MS }),

--- a/apps/cron/src/feed/rss-client.ts
+++ b/apps/cron/src/feed/rss-client.ts
@@ -9,6 +9,7 @@ const FETCH_TIMEOUT_MS = 30_000
 const MAX_FETCH_ATTEMPTS = 3
 const RETRY_BASE_DELAY_MS = 1_000
 const RETRY_MAX_DELAY_MS = 30_000
+const TOO_MANY_REQUESTS = 429
 
 // 429 等の失敗要因を後から切り分けられるよう、配信元レスポンスから残す診断情報。
 export interface RssFetchDiagnostics {
@@ -37,6 +38,11 @@ export class RssFetchError extends Error {
     super(`Failed to fetch rss feed: ${url}, status=${diagnostics.status}`)
     this.name = 'RssFetchError'
     this.diagnostics = diagnostics
+  }
+
+  // レート制限は他の失敗と扱いを変える（リトライしない・通知の文面を変える）ため判定を公開する。
+  get isRateLimited(): boolean {
+    return this.diagnostics.status === TOO_MANY_REQUESTS
   }
 }
 
@@ -98,6 +104,9 @@ export async function fetchRssFeed<T>(url: string): Promise<Result<T[], Error>> 
     if (result.isOk()) return result
 
     lastError = result.error
+    // レート制限の解除は分単位に及び in-run のバックオフ（最大30秒）では明けないうえ、
+    // 制限中の追加リクエストは制限期間を延ばし得るため、リトライせず次回の定期実行に委ねる
+    if (lastError instanceof RssFetchError && lastError.isRateLimited) return err(lastError)
     // INFO: 最終試行後は待機せず失敗を返す
     if (attempt < MAX_FETCH_ATTEMPTS - 1) {
       await delay(backoffDelayMs(attempt))

--- a/apps/cron/src/feed/rss-client.ts
+++ b/apps/cron/src/feed/rss-client.ts
@@ -106,7 +106,7 @@ export async function fetchRssFeed<T>(url: string): Promise<Result<T[], Error>> 
     lastError = result.error
     // レート制限の解除は分単位に及び in-run のバックオフ（最大30秒）では明けないうえ、
     // 制限中の追加リクエストは制限期間を延ばし得るため、リトライせず次回の定期実行に委ねる
-    if (lastError instanceof RssFetchError && lastError.isRateLimited) return err(lastError)
+    if (lastError instanceof RssFetchError && lastError.isRateLimited) return result
     // INFO: 最終試行後は待機せず失敗を返す
     if (attempt < MAX_FETCH_ATTEMPTS - 1) {
       await delay(backoffDelayMs(attempt))

--- a/apps/cron/src/test-helper/feed.ts
+++ b/apps/cron/src/test-helper/feed.ts
@@ -87,3 +87,8 @@ ${entries}
 export function rssResponse(xml: string) {
   return { ok: true, status: 200, text: async () => xml }
 }
+
+// 失敗時は診断情報のためヘッダと本文を読むため、実 Response の契約に合わせて双方を備えたモックにする
+export function nonOkResponse(status: number, body: string, headers: Record<string, string> = {}) {
+  return { ok: false, status, headers: new Headers(headers), text: async () => body }
+}


### PR DESCRIPTION
# 概要
## 問題のあった領域

- [x] バックエンド
  - [x] ビジネスロジック

### 要因の詳細
定期実行（毎時）の RSS 取得で zenn.dev/feed が 429 を返し、cron ジョブが失敗して Discord へ通知が飛んでいました。先行 PR で仕込んだ診断情報により、原因が以下と判明しました。

- 429 は Cloudflare のレート制限ルールによるもの
  - 本文が `error code: 1015`（Cloudflare のレート制限）で、`cf-mitigated` は付与されていない。bot 判定によるチャレンジではないため、User-Agent 未設定が原因ではない
- 制限解除まで `retry-after=281`（約4.7分）と、in-run のリトライ間隔と桁が合っていない
  - 指数バックオフは 1秒 → 2秒 で、3回の試行がいずれも制限期間内に収まり必ず失敗する
  - 制限中の追加リクエストは Cloudflare 側のカウンタを再度叩き、制限期間自体を延ばし得る

### 再現手順
1. zenn.dev/feed が Cloudflare のレート制限（429 / error code: 1015）を返す状態になる
2. 毎時の cron が起動し RSS を取得する
3. 3回の試行がすべて制限期間内で失敗し、`cron job failed: 1/3 media failed` で終了する

## 修正方針
- run 内のリトライ機構（試行ループ・指数バックオフ・待機）を丸ごと削除し、再試行は毎時の定期実行に委ねます
- 失敗がレート制限だった場合は Discord 通知に注記を添え、受け手が即時対応の要否を判断できるようにします

### その方針を選んだ理由
そもそも毎時の定期実行が再試行を兼ねており、保存も URL 一意制約（`ON CONFLICT DO NOTHING`）で冪等なため、1回分の取得を落としても次回実行で取り込み直せます。対象は人気・トレンド系フィード（Qiita popular-items / Zenn / はてなホットエントリ）で記事はフィード上に数時間残るため、1時間の間隔で取りこぼしは生じません。

そのうえで指数バックオフ（1秒 → 2秒）が拾えるのは「数秒で回復する失敗」という狭い帯域のみです。実際の失敗は即時回復（リトライ不要）か、今回の 429 のように分単位で継続する（リトライ無効）かのどちらかが大半で、機構の維持コストに見合いません。

当初は「429 のみリトライ対象から外す」案でしたが、上記のとおりリトライ全体が冗長と判断し、機構ごと削除する方針に切り替えました。Retry-After を待って in-run でリトライする案は、Worker の実行時間を数分間拘束するため採っていません。User-Agent の付与は、今回の診断情報から bot 判定が原因でないと分かったため見送っています。

## その他、参考情報
- 診断情報の取得は先行 PR（`52b4f72`）で導入したものです。今回はその実データに基づく対応です
- トレードオフとして、数秒で回復する一時的な失敗も1回分は失敗として通知されるため、Discord 通知はやや増える可能性があります。ノイズが問題になる場合は、in-run リトライを戻すのではなく通知側（連続失敗回数での抑制など）で対処するのが筋と考えています
- レート制限が毎時継続する場合は Cloudflare Workers の共有 egress IP 起因が疑われ、こちらのリクエスト量では解消できません。その際は取得経路の見直しが別途必要になります