### PR TITLE
chore: catalog の登録対象を「2 パッケージ以上で使う依存」にそろえる

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,7 +30,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "catalog:",
-    "hono": "catalog:",
+    "hono": "^4.12.32",
     "lucide-react": "^1.27.0",
     "neverthrow": "catalog:",
     "next-themes": "^0.4.6",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@supabase/supabase-js": "^2.111.0",
+    "@supabase/supabase-js": "catalog:",
     "@trend-diary/datastore": "workspace:*",
     "@trend-diary/domain": "workspace:*",
     "@trend-diary/std": "workspace:*",

--- a/packages/authentication/package.json
+++ b/packages/authentication/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@supabase/ssr": "^0.12.4",
-    "@supabase/supabase-js": "^2.111.0",
+    "@supabase/supabase-js": "catalog:",
     "@trend-diary/std": "workspace:*",
     "neverthrow": "catalog:"
   },

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -26,6 +26,6 @@
     "@trend-diary/config": "workspace:*",
     "@types/node": "catalog:",
     "vitest": "catalog:",
-    "vitest-mock-extended": "catalog:"
+    "vitest-mock-extended": "^5.0.0"
   }
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -11,7 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "pino": "catalog:"
+    "pino": "^10.3.1"
   },
   "devDependencies": {
     "@trend-diary/config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     '@playwright/test':
       specifier: ^1.62.0
       version: 1.62.0
+    '@supabase/supabase-js':
+      specifier: ^2.111.0
+      version: 2.111.0
     '@types/node':
       specifier: ^26.1.2
       version: 26.1.2
@@ -320,7 +323,7 @@ importers:
   e2e:
     dependencies:
       '@supabase/supabase-js':
-        specifier: ^2.111.0
+        specifier: 'catalog:'
         version: 2.111.0
       '@trend-diary/datastore':
         specifier: workspace:*
@@ -363,7 +366,7 @@ importers:
         specifier: ^0.12.4
         version: 0.12.4(@supabase/supabase-js@2.111.0)
       '@supabase/supabase-js':
-        specifier: ^2.111.0
+        specifier: 'catalog:'
         version: 2.111.0
       '@trend-diary/std':
         specifier: workspace:*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,24 +27,15 @@ catalogs:
     drizzle-orm:
       specifier: 0.45.2
       version: 0.45.2
-    hono:
-      specifier: ^4.12.32
-      version: 4.12.32
     neverthrow:
       specifier: ^8.2.0
       version: 8.2.0
-    pino:
-      specifier: ^10.3.1
-      version: 10.3.1
     playwright:
       specifier: ^1.62.0
       version: 1.62.0
     vitest:
       specifier: ^4.1.10
       version: 4.1.10
-    vitest-mock-extended:
-      specifier: ^5.0.0
-      version: 5.1.0
     wrangler:
       specifier: ^4.115.0
       version: 4.116.0
@@ -193,7 +184,7 @@ importers:
         specifier: 'catalog:'
         version: 0.45.2(@cloudflare/workers-types@5.20260731.1)(@libsql/client@0.17.3)
       hono:
-        specifier: 'catalog:'
+        specifier: ^4.12.32
         version: 4.12.32
       lucide-react:
         specifier: ^1.27.0
@@ -462,13 +453,13 @@ importers:
         specifier: 'catalog:'
         version: 4.1.10(@types/node@26.1.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-istanbul@4.1.10)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.1.5(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       vitest-mock-extended:
-        specifier: 'catalog:'
+        specifier: ^5.0.0
         version: 5.1.0(typescript@7.0.2)(vitest@4.1.10)
 
   packages/logger:
     dependencies:
       pino:
-        specifier: 'catalog:'
+        specifier: ^10.3.1
         version: 10.3.1
     devDependencies:
       '@trend-diary/config':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,12 +13,9 @@ catalog:
   '@supabase/supabase-js': ^2.111.0
   '@types/node': ^26.1.2
   drizzle-orm: 0.45.2
-  hono: ^4.12.32
   neverthrow: ^8.2.0
-  pino: ^10.3.1
   playwright: ^1.62.0
   vitest: ^4.1.10
-  vitest-mock-extended: ^5.0.0
   wrangler: ^4.115.0
   zod: ^4.4.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ catalog:
   '@cloudflare/workers-types': ^5.20260729.1
   '@faker-js/faker': ^10.5.0
   '@playwright/test': ^1.62.0
+  '@supabase/supabase-js': ^2.111.0
   '@types/node': ^26.1.2
   drizzle-orm: 0.45.2
   hono: ^4.12.32


### PR DESCRIPTION
# 概要
## 課題
catalog は「パッケージ間で共有する依存のバージョンを集中管理する」場所（`pnpm-workspace.yaml` のコメント）ですが、実態がその方針から両方向にずれていました。

- `@supabase/supabase-js` は `packages/authentication` と `e2e` の 2 パッケージで使われているのに catalog になく、それぞれが個別にバージョンを宣言していた
- 逆に `hono` / `pino` / `vitest-mock-extended` は 1 パッケージからしか参照されていないのに catalog にあった

前者はバージョンがずれる余地が残り、後者は catalog を見ても共有依存かどうか判断できない状態でした。

## 修正内容
- fix: 特になし（Issue 番号なし）
- catalog の登録基準を「2 パッケージ以上で使う依存」に統一しました
  - `@supabase/supabase-js` を catalog へ移し、`packages/authentication` と `e2e` から `catalog:` で参照します
  - `hono`（apps/web のみ）/ `pino`（packages/logger のみ）/ `vitest-mock-extended`（packages/domain のみ）は各 package.json の直接宣言に戻します
- `@playwright/test` は `e2e` からしか参照されていませんが、catalog に残しています
  - `apps/web` が Storybook の addon-vitest 経由で使う `playwright` とバージョンを揃える必要があり、両者を同じ場所で管理したいためです
- `@supabase/ssr` は `packages/authentication` 単独のままです

バージョンは一切変えていません。`pnpm-lock.yaml` の差分も specifier の表記と catalog 項目の増減だけで、解決される版はすべて据え置きです。

なお Dependabot の npm ecosystem は catalog のバージョンも更新対象にしており（#1059 で `pnpm-workspace.yaml` の `wrangler` 等が引き上げられています）、catalog へ移しても自動更新は従来どおり効きます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7cndMoWdxQ4G5eGf1SiTn